### PR TITLE
Add support for custom log format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ import { logger } from 'logixlysia'
 
 const app = new Elysia({
   name: 'Logixlysia Example'
-}).use(logger())
+}).use(
+  logger({
+    ip: false,
+    customLogMessage:
+      '🦊 {now} {level} {duration} {method} {pathname} {status} {message} {ip}'
+  })
+)
 
 app.listen(3000)
 ```
@@ -27,9 +33,10 @@ app.listen(3000)
 
 ### Options
 
-| Option | Type      | Description                                                           | Default |
-| ------ | --------- | --------------------------------------------------------------------- | ------- |
-| `ip`   | `boolean` | Display the incoming IP address based on the `X-Forwarded-For` header | `false` |
+| Option             | Type      | Description                                                           | Default                                                                   |
+| ------------------ | --------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `ip`               | `boolean` | Display the incoming IP address based on the `X-Forwarded-For` header | `false`                                                                   |
+| `customLogMessage` | `string`  | Custom log message to display                                         | `🦊 {now} {level} {duration} {method} {pathname} {status} {message} {ip}` |
 
 ## `📄` License
 

--- a/example/basic.ts
+++ b/example/basic.ts
@@ -6,7 +6,9 @@ const app = new Elysia({
 })
   .use(
     logger({
-      ip: true
+      ip: true,
+      customLogFormat:
+        '🦊 {now} {level} {duration} {method} {pathname} {status} {message} {ip}' // default format
     })
   )
   .get('/', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ interface Logger {
     data: LogData,
     store: StoreData
   ): void
+  customLogFormat?: string
 }
 
 interface StoreData {
@@ -45,6 +46,7 @@ class HttpError extends Error {
 
 interface Options {
   ip?: boolean
+  customLogFormat?: string
 }
 
 export {

--- a/test/logixlysia.test.ts
+++ b/test/logixlysia.test.ts
@@ -10,7 +10,13 @@ describe('Logixlysia with IP logging enabled', () => {
 
   beforeAll(() => {
     server = new Elysia()
-      .use(logger({ ip: true }))
+      .use(
+        logger({
+          ip: true,
+          customLogFormat:
+            '🦊 {now} {duration} {level} {method} {pathname} {status} {message} {ip}'
+        })
+      )
       .get('/', ctx => {
         const ipAddress = ctx.request.headers.get('x-forwarded-for') || 'null'
         return '🦊 Logixlysia Getting'
@@ -35,7 +41,9 @@ describe('Logixlysia with IP logging enabled', () => {
     }
 
     logs.forEach(log => {
-      expect(log).toMatch(/^IP: \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)
+      expect(log).toMatch(
+        /^🦊 .+ INFO .+ .+ GET \/ .+ IP: \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
+      )
     })
   })
 
@@ -47,7 +55,7 @@ describe('Logixlysia with IP logging enabled', () => {
     }
 
     logs.forEach(log => {
-      expect(log).toBe('IP: null')
+      expect(log).toMatch(/^🦊 .+ INFO .+ .+ GET \/ .+ IP: null$/)
     })
   })
 })
@@ -59,7 +67,13 @@ describe('Logixlysia with IP logging disabled', () => {
 
   beforeAll(() => {
     server = new Elysia()
-      .use(logger({ ip: false }))
+      .use(
+        logger({
+          ip: false,
+          customLogFormat:
+            '🦊 {now} {duration} {level} {method} {pathname} {status} {message} {ip}'
+        })
+      )
       .get('/', () => '🦊 Logixlysia Getting')
       .post('logixlysia', () => '🦊 Logixlysia Posting')
       .listen(3000)


### PR DESCRIPTION
## `🫀` Pull Request

### `💔` Breaking change
- Added support for custom log format in the logger
- Enhanced flexibility for define thier preferred log message structure

### `🧑‍🏫` Description

This commit introduces a new feature to logger, allowing to specify a custom log format

### `📝` Checklist

- [x] I have tested the changes locally.
- [x] I have updated the documentation accordingly.
