### PR TITLE
New Feature to add option to toggle server start banner display

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ const app = new Elysia({
 }).use(
   logixlysia({
     config: {
+      showBanner: true,
       ip: true,
       logFilePath: './logs/example.log',
       customLogFormat:
@@ -43,6 +44,7 @@ app.listen(3000)
 
 | Option             | Type      | Description                                                           | Default                                                                   |
 | ------------------ | --------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `showBanner`       | `boolean` | Display the banner on the console                                     | `true`                                                                    |
 | `ip`               | `boolean` | Display the incoming IP address based on the `X-Forwarded-For` header | `false`                                                                   |
 | `customLogMessage` | `string`  | Custom log message to display                                         | `🦊 {now} {level} {duration} {method} {pathname} {status} {message} {ip}` |
 | `logFilter`        | `object`  | Filter the logs based on the level, method, and status                | `null`                                                                    |

--- a/example/basic.ts
+++ b/example/basic.ts
@@ -8,6 +8,7 @@ const app = new Elysia({
   .use(
     logixlysia({
       config: {
+        showBanner: false,
         logFilePath: './logs/example.log',
         ip: true,
         customLogFormat:

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export default function logixlysia(options?: Options): Elysia {
   return new Elysia({
     name: 'Logixlysia'
   })
-    .onStart(ctx => startServer(ctx.server as Server))
+    .onStart(ctx => startServer(ctx.server as Server, options))
     .onRequest(ctx => {
       ctx.store = { beforeTime: process.hrtime.bigint() }
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,7 @@ interface Options {
       method?: string | string[]
       status?: number | number[]
     } | null
+    showBanner?: boolean
   }
 }
 

--- a/src/utils/start.ts
+++ b/src/utils/start.ts
@@ -1,4 +1,4 @@
-import { Server } from '~/types'
+import { Options, Server } from '~/types'
 
 /**
  * Creates a box text.
@@ -19,15 +19,18 @@ function createBoxText(text: string, width: number): string {
  * @param {Server} config The server configuration.
  * @returns {void} The server string.
  */
-function startServer(config: Server): void {
+function startServer(config: Server, options?: Options): void {
   const { hostname, port, protocol } = config
-  const ELYSIA_VERSION = import.meta.require('elysia/package.json').version
-  const title = `Elysia v${ELYSIA_VERSION}`
-  const message = `🦊 Elysia is running at ${protocol}://${hostname}:${port}`
-  const boxWidth = Math.max(title.length, message.length) + 4
-  const border = '─'.repeat(boxWidth)
+  const showBanner = options?.config?.showBanner ?? true
 
-  console.log(`
+  if (showBanner) {
+    const ELYSIA_VERSION = import.meta.require('elysia/package.json').version
+    const title = `Elysia v${ELYSIA_VERSION}`
+    const message = `🦊 Elysia is running at ${protocol}://${hostname}:${port}`
+    const boxWidth = Math.max(title.length, message.length) + 4
+    const border = '─'.repeat(boxWidth)
+
+    console.log(`
       ┌${border}┐
       │${createBoxText('', boxWidth)}│
       │${createBoxText(title, boxWidth)}│
@@ -36,6 +39,9 @@ function startServer(config: Server): void {
       │${createBoxText('', boxWidth)}│
       └${border}┘
     `)
+  } else {
+    console.log(`🦊 Elysia is running at ${protocol}://${hostname}:${port}`)
+  }
 }
 
 export default startServer


### PR DESCRIPTION
## `🫀` Pull Request Template

### `🧑‍🏫` Description

This change allows users to control the visibility of the server start banner, providing more flexible logging.

### `🔗` Related Issues

fix #52

### `📝` Checklist

- [x] I have tested the changes locally.
- [ ] I have added tests for the changes.
- [x] I have updated the documentation accordingly.
