### PR TITLE
Add optional startup message config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,14 @@ app.listen(3000)
 
 ### Options
 
-| Option             | Type      | Description                                                           | Default                                                                   |
-| ------------------ | --------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `showBanner`       | `boolean` | Display the banner on the console                                     | `true`                                                                    |
-| `ip`               | `boolean` | Display the incoming IP address based on the `X-Forwarded-For` header | `false`                                                                   |
-| `customLogMessage` | `string`  | Custom log message to display                                         | `🦊 {now} {level} {duration} {method} {pathname} {status} {message} {ip}` |
-| `logFilter`        | `object`  | Filter the logs based on the level, method, and status                | `null`                                                                    |
-| `logFilePath`      | `string`  | Path to the log file                                                  | `./logs/elysia.log`                                                       |
+| Option                 | Type                     | Description                                                           | Default                                                                   |
+| ---------------------- | ------------------------ | --------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `showStartupMessage`   | `boolean`                | Display the startup message                                           | `true`                                                                    |
+| `startupMessageFormat` | `"banner"` \| `"simple"` | Choose the startup message format                                     | `"banner"`                                                                  |
+| `ip`                   | `boolean`                | Display the incoming IP address based on the `X-Forwarded-For` header | `false`                                                                   |
+| `customLogMessage`     | `string`                 | Custom log message to display                                         | `🦊 {now} {level} {duration} {method} {pathname} {status} {message} {ip}` |
+| `logFilter`            | `object`                 | Filter the logs based on the level, method, and status                | `null`                                                                    |
+| `logFilePath`          | `string`                 | Path to the log file                                                  | `./logs/elysia.log`                                                       |
 
 ### Custom Log Message
 

--- a/example/basic.ts
+++ b/example/basic.ts
@@ -8,7 +8,8 @@ const app = new Elysia({
   .use(
     logixlysia({
       config: {
-        showBanner: false,
+        showStartupMessage: true,
+        startupMessageFormat: 'simple',
         logFilePath: './logs/example.log',
         ip: true,
         customLogFormat:

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,10 @@ export default function logixlysia(options?: Options): Elysia {
   return new Elysia({
     name: 'Logixlysia'
   })
-    .onStart(ctx => startServer(ctx.server as Server, options))
+    .onStart(ctx => {
+        const showStartupMessage = options?.config?.showStartupMessage ?? true
+        if (showStartupMessage) startServer(ctx.server as Server, options)}
+    )
     .onRequest(ctx => {
       ctx.store = { beforeTime: process.hrtime.bigint() }
     })
@@ -26,6 +29,6 @@ export default function logixlysia(options?: Options): Elysia {
     })
 }
 
-export { createLogger } from './core'
-export { handleHttpError } from './core'
+export { createLogger, handleHttpError } from './core'
 export { logToTransports } from './transports'
+

--- a/src/plugins/startServer.ts
+++ b/src/plugins/startServer.ts
@@ -8,7 +8,7 @@ const createBoxText = (text: string, width: number): string => {
 
 export default function startServer(config: Server, options?: Options): void {
   const { hostname, port, protocol } = config
-  const showBanner = options?.config?.showBanner ?? true
+  const showBanner = options?.config?.startupMessageFormat !== 'simple'
 
   if (showBanner) {
     const ELYSIA_VERSION = import.meta.require('elysia/package.json').version

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,7 +88,8 @@ export interface Options {
     } | null
     ip?: boolean
     useColors?: boolean
-    showBanner?: boolean
+    showStartupMessage?: boolean
+    startupMessageFormat?: 'banner' | 'simple'
     transports?: Transport[]
   }
 }


### PR DESCRIPTION
## `🫀` Add optional startup message config

### `🧑‍🏫` Description

Some users want to disable the default startup message to add their own. I added the `showStartupMessage` config and changed the `showBanner` config to `startupMessageFormat`, which now accepts two literal arguments (banner | simple) 

```diff
export interface Options {
  config?: {
    customLogFormat?: string
    logFilePath?: string
    logFilter?: {
      level?: LogLevel | LogLevel[]
      method?: string | string[]
      status?: number | number[]
    } | null
    ip?: boolean
    useColors?: boolean
-   showBanner?: boolean
+   showStartupMessage?: boolean
+   startupMessageFormat?: 'banner' | 'simple'
    transports?: Transport[]
  }
}
```

### `📝` Checklist

- [x] I have tested the changes locally.
- [ ] I have added tests for the changes.
- [x] I have updated the documentation accordingly.
