### PR TITLE
fix(logixlysia): ensure message is a string in response headers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export default function logixlysia(options?: Options): Elysia {
         request,
         {
           status,
-          message: set.headers?.['x-message'] || ''
+          message: String(set.headers?.['x-message'] || '')
         },
         store as { beforeTime: bigint }
       )


### PR DESCRIPTION
This pull request includes a small change to the `src/index.ts` file. The change ensures that the `message` property is always a string by wrapping the value in the `String` constructor.

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L28-R28): Modified the `message` property to ensure it is always a string by using `String(set.headers?.['x-message'] || '')`.