### PR TITLE
Fix preserve existing state when initializing logixlysia store

### DIFF
--- a/__tests__/state-overwrite.test.ts
+++ b/__tests__/state-overwrite.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test'
+import { Elysia } from 'elysia'
+import logixlysia from '../src/index'
+
+describe('Elysia with state', () => {
+  it('Should return state with logixlysia', () => {
+    const app = new Elysia()
+      .state('state', { a: 1 } as const)
+      .use(logixlysia())
+      .get('/test', ({ store }) => {
+        console.log({ store })
+        return store.state
+      })
+    expect(
+      app.handle(new Request('http://localhost/test')).then(x => x.json())
+    ).resolves.toMatchObject({
+      a: 1
+    })
+  })
+  it('Should return state without logixlysia', () => {
+    const app = new Elysia()
+      .state('state', { a: 1 } as const)
+      .get('/test', ({ store }) => {
+        console.log({ store })
+        return store.state
+      })
+    expect(
+      app.handle(new Request('http://localhost/test')).then(x => x.json())
+    ).resolves.toMatchObject({
+      a: 1
+    })
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export default function logixlysia(options?: Options): Elysia {
     })
     .onRequest(ctx => {
       const store = {
+        ...ctx.store,
         beforeTime: process.hrtime.bigint(),
         logger: log,
         hasCustomLog: false


### PR DESCRIPTION
### `🧑‍🏫` Description

- Use spread operator to merge existing ctx.store with logixlysia properties
- Add test cases to verify state preservation with and without logixlysia
- Ensure backward compatibility with existing Elysia applications

### `📸` Screenshots

<img width="1919" height="1030" alt="Screenshot" src="https://github.com/user-attachments/assets/ff94307b-5cd0-4086-a474-bdb81a8bddad" />

### `🔗` Related Issues

Closes #108
