### PR TITLE
Add option for disable internal log

### DIFF
--- a/__tests__/logger/disable-internal-logger.test.ts
+++ b/__tests__/logger/disable-internal-logger.test.ts
@@ -1,0 +1,182 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test
+} from 'bun:test'
+import type {
+  HttpError,
+  Options,
+  RequestInfo,
+  StoreData
+} from '../../src/interfaces'
+import { createLogger } from '../../src/logger/create-logger'
+
+describe('disableInternalLogger', () => {
+  let consoleSpy: ReturnType<typeof spyOn>
+  let mockRequest: RequestInfo
+  let mockStore: StoreData
+
+  beforeEach(() => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {
+      // Mock implementation - intentionally empty
+    })
+    mockRequest = {
+      headers: { get: () => 'application/json' },
+      method: 'GET',
+      url: 'http://localhost:3000/test'
+    }
+    mockStore = {
+      beforeTime: process.hrtime.bigint()
+    }
+  })
+
+  afterEach(() => {
+    consoleSpy.mockRestore()
+  })
+
+  test('should log to console when disableInternalLogger is false', () => {
+    const options: Options = {
+      config: {
+        disableInternalLogger: false
+      }
+    }
+
+    const logger = createLogger(options)
+    logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+    expect(consoleSpy).toHaveBeenCalled()
+  })
+
+  test('should log to console when disableInternalLogger is not specified (default behavior)', () => {
+    const options: Options = {
+      config: {}
+    }
+
+    const logger = createLogger(options)
+    logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+    expect(consoleSpy).toHaveBeenCalled()
+  })
+
+  test('should not log to console when disableInternalLogger is true', () => {
+    const options: Options = {
+      config: {
+        disableInternalLogger: true
+      }
+    }
+
+    const logger = createLogger(options)
+    logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+  })
+
+  test('should still call transports when disableInternalLogger is true', () => {
+    const transportMock = mock(() => Promise.resolve())
+    const options: Options = {
+      config: {
+        disableInternalLogger: true,
+        transports: [
+          {
+            log: transportMock
+          }
+        ]
+      }
+    }
+
+    const logger = createLogger(options)
+    logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+    expect(transportMock).toHaveBeenCalled()
+  })
+
+  test('should work with custom logger methods when disableInternalLogger is true', () => {
+    const transportMock = mock(() => Promise.resolve())
+    const options: Options = {
+      config: {
+        disableInternalLogger: true,
+        transports: [
+          {
+            log: transportMock
+          }
+        ]
+      }
+    }
+
+    const logger = createLogger(options)
+    logger.info(mockRequest, 'Info message')
+    logger.error(mockRequest, 'Error message')
+    logger.warn(mockRequest, 'Warning message')
+    logger.debug(mockRequest, 'Debug message')
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+    expect(transportMock).toHaveBeenCalledTimes(4)
+  })
+
+  test('should handle both console and transports when disableInternalLogger is false', () => {
+    const transportMock = mock(() => Promise.resolve())
+    const options: Options = {
+      config: {
+        disableInternalLogger: false,
+        transports: [
+          {
+            log: transportMock
+          }
+        ]
+      }
+    }
+
+    const logger = createLogger(options)
+    logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+    expect(consoleSpy).toHaveBeenCalled()
+    expect(transportMock).toHaveBeenCalled()
+  })
+
+  test('should handle file logging when disableInternalLogger is true', () => {
+    const options: Options = {
+      config: {
+        disableInternalLogger: true,
+        logFilePath: '/tmp/test.log'
+      }
+    }
+
+    const logger = createLogger(options)
+
+    // We don't test actual file writing here, but ensure console is not called
+    logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+  })
+
+  test('should handle error logging correctly when disableInternalLogger is true', () => {
+    const transportMock = mock(() => Promise.resolve())
+    const options: Options = {
+      config: {
+        disableInternalLogger: true,
+        transports: [
+          {
+            log: transportMock
+          }
+        ]
+      }
+    }
+
+    const logger = createLogger(options)
+    const error = { status: 500, message: 'Internal Server Error' } as const
+
+    logger.handleHttpError(
+      mockRequest,
+      error as unknown as HttpError,
+      mockStore
+    )
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+    expect(transportMock).toHaveBeenCalled()
+  })
+})

--- a/__tests__/logger/logging-output-control.test.ts
+++ b/__tests__/logger/logging-output-control.test.ts
@@ -1,0 +1,274 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test
+} from 'bun:test'
+import type { Options, RequestInfo, StoreData } from '../../src/interfaces'
+import { HttpError } from '../../src/interfaces'
+import { createLogger } from '../../src/logger/create-logger'
+import { handleHttpError } from '../../src/logger/handle-http-error'
+
+// Mock fs module
+mock.module('node:fs/promises', () => ({
+  appendFile: mock(() => Promise.resolve())
+}))
+
+describe('Logging Output Control', () => {
+  let consoleSpy: ReturnType<typeof spyOn>
+  let consoleErrorSpy: ReturnType<typeof spyOn>
+  let mockRequest: RequestInfo
+  let mockStore: StoreData
+
+  beforeEach(() => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {
+      // Mock implementation - intentionally empty
+    })
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {
+      // Mock implementation - intentionally empty
+    })
+    mockRequest = {
+      headers: { get: () => 'application/json' },
+      method: 'GET',
+      url: 'http://localhost:3000/test'
+    }
+    mockStore = {
+      beforeTime: process.hrtime.bigint()
+    }
+  })
+
+  afterEach(() => {
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  describe('useTransportsOnly option', () => {
+    test('should only use transports when useTransportsOnly is true', () => {
+      const transportMock = mock(() => Promise.resolve())
+      const options: Options = {
+        config: {
+          useTransportsOnly: true,
+          transports: [
+            {
+              log: transportMock
+            }
+          ]
+        }
+      }
+
+      const logger = createLogger(options)
+      logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+      expect(consoleSpy).not.toHaveBeenCalled()
+      expect(transportMock).toHaveBeenCalled()
+    })
+
+    test('should disable file logging when useTransportsOnly is true', () => {
+      const transportMock = mock(() => Promise.resolve())
+      const options: Options = {
+        config: {
+          useTransportsOnly: true,
+          logFilePath: '/tmp/test.log',
+          transports: [
+            {
+              log: transportMock
+            }
+          ]
+        }
+      }
+
+      const logger = createLogger(options)
+      logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+      expect(consoleSpy).not.toHaveBeenCalled()
+      expect(transportMock).toHaveBeenCalled()
+      // File logging should be disabled, so fs.appendFile should not be called
+      // This is implicit since we're mocking fs.appendFile and it shouldn't be called
+    })
+
+    test('should handle HTTP errors with useTransportsOnly', () => {
+      const transportMock = mock(() => Promise.resolve())
+      const options: Options = {
+        config: {
+          useTransportsOnly: true,
+          transports: [
+            {
+              log: transportMock
+            }
+          ]
+        }
+      }
+
+      const error = new HttpError(500, 'Internal Server Error')
+      handleHttpError(mockRequest, error, mockStore, options)
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+      expect(transportMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('disableFileLogging option', () => {
+    test('should disable file logging when disableFileLogging is true', () => {
+      const options: Options = {
+        config: {
+          logFilePath: '/tmp/test.log',
+          disableFileLogging: true
+        }
+      }
+
+      const logger = createLogger(options)
+      logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+      expect(consoleSpy).toHaveBeenCalled()
+      // File logging should be disabled
+    })
+
+    test('should still log to console when disableFileLogging is true', () => {
+      const options: Options = {
+        config: {
+          disableFileLogging: true
+        }
+      }
+
+      const logger = createLogger(options)
+      logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+      expect(consoleSpy).toHaveBeenCalled()
+    })
+
+    test('should still use transports when disableFileLogging is true', () => {
+      const transportMock = mock(() => Promise.resolve())
+      const options: Options = {
+        config: {
+          logFilePath: '/tmp/test.log',
+          disableFileLogging: true,
+          transports: [
+            {
+              log: transportMock
+            }
+          ]
+        }
+      }
+
+      const logger = createLogger(options)
+      logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+      expect(consoleSpy).toHaveBeenCalled()
+      expect(transportMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('Combined options', () => {
+    test('should work with both disableInternalLogger and disableFileLogging', () => {
+      const transportMock = mock(() => Promise.resolve())
+      const options: Options = {
+        config: {
+          logFilePath: '/tmp/test.log',
+          disableInternalLogger: true,
+          disableFileLogging: true,
+          transports: [
+            {
+              log: transportMock
+            }
+          ]
+        }
+      }
+
+      const logger = createLogger(options)
+      logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+      expect(consoleSpy).not.toHaveBeenCalled()
+      expect(transportMock).toHaveBeenCalled()
+      // File logging should be disabled
+    })
+
+    test('should use only transports when useTransportsOnly is true regardless of other options', () => {
+      const transportMock = mock(() => Promise.resolve())
+      const options: Options = {
+        config: {
+          logFilePath: '/tmp/test.log',
+          useTransportsOnly: true,
+          disableInternalLogger: false, // This should be ignored
+          disableFileLogging: false, // This should be ignored
+          transports: [
+            {
+              log: transportMock
+            }
+          ]
+        }
+      }
+
+      const logger = createLogger(options)
+      logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+      expect(consoleSpy).not.toHaveBeenCalled()
+      expect(transportMock).toHaveBeenCalled()
+      // File logging should be disabled
+    })
+
+    test('should handle all outputs disabled scenario', () => {
+      const options: Options = {
+        config: {
+          useTransportsOnly: true
+          // No transports defined
+        }
+      }
+
+      const logger = createLogger(options)
+      logger.log('INFO', mockRequest, { message: 'Test message' }, mockStore)
+
+      expect(consoleSpy).not.toHaveBeenCalled()
+      // No transports, no file logging, no console - should complete without errors
+    })
+  })
+
+  describe('Custom logger methods', () => {
+    test('should respect useTransportsOnly in custom methods', () => {
+      const transportMock = mock(() => Promise.resolve())
+      const options: Options = {
+        config: {
+          useTransportsOnly: true,
+          transports: [
+            {
+              log: transportMock
+            }
+          ]
+        }
+      }
+
+      const logger = createLogger(options)
+      logger.info(mockRequest, 'Info message')
+      logger.error(mockRequest, 'Error message')
+      logger.warn(mockRequest, 'Warning message')
+      logger.debug(mockRequest, 'Debug message')
+
+      expect(consoleSpy).not.toHaveBeenCalled()
+      expect(transportMock).toHaveBeenCalledTimes(4)
+    })
+
+    test('should respect disableFileLogging in custom methods', () => {
+      const transportMock = mock(() => Promise.resolve())
+      const options: Options = {
+        config: {
+          logFilePath: '/tmp/test.log',
+          disableFileLogging: true,
+          transports: [
+            {
+              log: transportMock
+            }
+          ]
+        }
+      }
+
+      const logger = createLogger(options)
+      logger.info(mockRequest, 'Info message')
+      logger.error(mockRequest, 'Error message')
+
+      expect(consoleSpy).toHaveBeenCalledTimes(2)
+      expect(transportMock).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,9 +43,9 @@ export default function logixlysia(options?: Options): Elysia {
         )
       }
     })
-    .onError({ as: 'global' }, ({ request, error, set, store }) => {
+    .onError({ as: 'global' }, async ({ request, error, set, store }) => {
       const status = getStatusCode(set.status || 500)
-      log.handleHttpError(
+      await log.handleHttpError(
         request,
         { ...error, status } as HttpError,
         store as StoreData

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -144,5 +144,7 @@ export interface Options {
     transports?: Transport[]
     timestamp?: TimestampConfig // Add this new option
     disableInternalLogger?: boolean // Add option to disable internal console logging
+    disableFileLogging?: boolean // Add option to disable file logging
+    useTransportsOnly?: boolean // Add option to use only transports (disable console and file)
   }
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -40,7 +40,7 @@ export interface Logger {
     request: RequestInfo,
     error: HttpError,
     store: StoreData
-  ): void
+  ): Promise<void>
   customLogFormat?: string
   info(
     request: RequestInfo,
@@ -143,5 +143,6 @@ export interface Options {
     startupMessageFormat?: 'banner' | 'simple'
     transports?: Transport[]
     timestamp?: TimestampConfig // Add this new option
+    disableInternalLogger?: boolean // Add option to disable internal console logging
   }
 }

--- a/src/logger/create-logger.ts
+++ b/src/logger/create-logger.ts
@@ -43,7 +43,11 @@ async function log(
   }
 
   const logMessage = buildLogMessage(level, request, data, store, options, true)
-  console.log(logMessage)
+
+  // Only log to console if internal logger is not disabled
+  if (!options?.config?.disableInternalLogger) {
+    console.log(logMessage)
+  }
 
   const promises: Promise<void>[] = []
 
@@ -72,8 +76,8 @@ export function createLogger(options?: Options): Logger {
     store: undefined,
     log: (level, request, data, store) =>
       log(level, request, data, store, options),
-    handleHttpError: (request, error, store) =>
-      handleHttpError(request, error, store, options),
+    handleHttpError: async (request, error, store) =>
+      await handleHttpError(request, error, store, options),
     customLogFormat: options?.config?.customLogFormat,
     info: (request, message, context, store) => {
       const storeData = store ||

--- a/src/logger/create-logger.ts
+++ b/src/logger/create-logger.ts
@@ -44,14 +44,24 @@ async function log(
 
   const logMessage = buildLogMessage(level, request, data, store, options, true)
 
-  // Only log to console if internal logger is not disabled
-  if (!options?.config?.disableInternalLogger) {
+  const promises: Promise<void>[] = []
+
+  // Handle console logging
+  if (
+    !(
+      options?.config?.useTransportsOnly ||
+      options?.config?.disableInternalLogger
+    )
+  ) {
     console.log(logMessage)
   }
 
-  const promises: Promise<void>[] = []
-
-  if (options?.config?.logFilePath) {
+  // Handle file logging
+  if (
+    !options?.config?.useTransportsOnly &&
+    options?.config?.logFilePath &&
+    !options?.config?.disableFileLogging
+  ) {
     promises.push(
       logToFile(
         options.config.logFilePath,
@@ -64,6 +74,7 @@ async function log(
     )
   }
 
+  // Handle transport logging
   if (options?.config?.transports?.length) {
     promises.push(logToTransports(level, request, data, store, options))
   }

--- a/src/logger/handle-http-error.ts
+++ b/src/logger/handle-http-error.ts
@@ -15,14 +15,24 @@ export async function handleHttpError(
     stack: error.stack
   }
 
-  // Only log to console if internal logger is not disabled
-  if (!options?.config?.disableInternalLogger) {
+  const promises: Promise<void>[] = []
+
+  // Handle console logging
+  if (
+    !(
+      options?.config?.useTransportsOnly ||
+      options?.config?.disableInternalLogger
+    )
+  ) {
     console.error(buildLogMessage('ERROR', request, logData, store, options))
   }
 
-  const promises: Promise<void>[] = []
-
-  if (options?.config?.logFilePath) {
+  // Handle file logging
+  if (
+    !options?.config?.useTransportsOnly &&
+    options?.config?.logFilePath &&
+    !options?.config?.disableFileLogging
+  ) {
     promises.push(
       logToFile(
         options.config.logFilePath,
@@ -35,6 +45,7 @@ export async function handleHttpError(
     )
   }
 
+  // Handle transport logging
   if (options?.config?.transports?.length) {
     promises.push(logToTransports('ERROR', request, logData, store, options))
   }

--- a/website/content/docs/(general)/usage.mdx
+++ b/website/content/docs/(general)/usage.mdx
@@ -142,6 +142,39 @@ app.get('/error', () => {
 
 This will automatically log the error with stack trace and request details.
 
+### Output Control
+
+Logixlysia supports multiple logging outputs that can be controlled independently:
+
+```ts
+logixlysia({
+  config: {
+    // Control console output
+    disableInternalLogger: false, // Default: false (console enabled)
+    
+    // Control file output
+    logFilePath: '/var/log/app.log',
+    disableFileLogging: false, // Default: false (file enabled if logFilePath is set)
+    
+    // Control transport output
+    transports: [
+      // Custom transports are always additive
+      elasticsearchTransport,
+      slackTransport
+    ],
+    
+    // Use only transports (disable console and file)
+    useTransportsOnly: false // Default: false
+  }
+})
+```
+
+**Output Behavior:**
+- **Default**: Console + File (if `logFilePath` is set) + Transports
+- **`disableInternalLogger: true`**: Disables console logging only
+- **`disableFileLogging: true`**: Disables file logging only  
+- **`useTransportsOnly: true`**: Disables both console and file logging, uses only transports
+
 ## Best Practices
 
 1. **Log Levels**

--- a/website/content/docs/features/transports.mdx
+++ b/website/content/docs/features/transports.mdx
@@ -3,7 +3,22 @@ title: Custom Transports
 description: Send logs to external services with custom transports.
 ---
 
-Logixlysia allows you to send logs to external services using custom transports.
+Logixlysia allows you to send logs to external services using custom transports. By default, transports work alongside the built-in console and file logging outputs.
+
+## Output Behavior
+
+Logixlysia supports three types of logging outputs:
+
+1. **Console Logging** - Built-in console output (can be disabled with `disableInternalLogger`)
+2. **File Logging** - Built-in file output (can be disabled with `disableFileLogging`)
+3. **Transport Logging** - Custom external services (always additive)
+
+### Controlling Outputs
+
+- **Default behavior**: Console + File (if `logFilePath` is set) + Transports
+- **`disableInternalLogger: true`**: Disables console logging only
+- **`disableFileLogging: true`**: Disables file logging only
+- **`useTransportsOnly: true`**: Disables both console and file logging, uses only transports
 
 ## Basic Transport
 
@@ -97,6 +112,46 @@ app.use(logixlysia({
 }))
 ```
 
+## Advanced Configuration
+
+### Transport-Only Logging
+
+To use only transports (disable console and file logging):
+
+```ts
+app.use(logixlysia({
+  config: {
+    useTransportsOnly: true,
+    transports: [
+      elasticsearchTransport,
+      slackTransport
+    ]
+  }
+}))
+```
+
+### Selective Output Control
+
+```ts
+// Disable console but keep file logging
+app.use(logixlysia({
+  config: {
+    logFilePath: '/var/log/app.log',
+    disableInternalLogger: true,
+    transports: [elasticsearchTransport]
+  }
+}))
+
+// Disable file logging but keep console
+app.use(logixlysia({
+  config: {
+    logFilePath: '/var/log/app.log',
+    disableFileLogging: true,
+    transports: [elasticsearchTransport]
+  }
+}))
+```
+
 ## Best Practices
 
 1. **Error Handling**
@@ -112,6 +167,11 @@ app.use(logixlysia({
 3. **Security**
    - Secure transport credentials
    - Validate log data
+
+4. **Output Management**
+   - Use `useTransportsOnly` for production environments where you only want external logging
+   - Use `disableFileLogging` when you want console output but not file output
+   - Use `disableInternalLogger` when you want file/transport output but not console output
    - Implement access control
 
 ## Example Configurations

--- a/website/content/docs/features/transports.mdx
+++ b/website/content/docs/features/transports.mdx
@@ -25,7 +25,13 @@ Logixlysia supports three types of logging outputs:
 Create a basic transport:
 
 ```ts
-const consoleTransport = {
+// TypeScript type definitions for transport interface
+type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+type Transport = {
+  log: (level: LogLevel, message: string, meta?: Record<string, unknown>) => void | Promise<void>
+}
+
+const consoleTransport: Transport = {
   log: (level, message, meta) => {
     console.log(`[${level}] ${message}`, meta)
   }
@@ -45,18 +51,25 @@ app.use(logixlysia({
 ```ts
 const elasticsearchTransport = {
   log: async (level, message, meta) => {
-    await fetch('http://elasticsearch:9200/logs/_doc', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        level,
-        message,
-        ...meta,
-        timestamp: new Date().toISOString()
+    try {
+      const res = await fetch('http://elasticsearch:9200/logs/_doc', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          level,
+          message,
+          ...meta,
+          timestamp: new Date().toISOString()
+        })
       })
-    })
+      if (!res.ok) {
+        console.error('Elasticsearch transport failed', { status: res.status, statusText: res.statusText })
+      }
+    } catch (err) {
+      console.error('Elasticsearch transport error', err)
+    }
   }
 }
 ```
@@ -66,12 +79,16 @@ const elasticsearchTransport = {
 ```ts
 const mongodbTransport = {
   log: async (level, message, meta) => {
-    await db.collection('logs').insertOne({
-      level,
-      message,
-      ...meta,
-      timestamp: new Date()
-    })
+    try {
+      await db.collection('logs').insertOne({
+        level,
+        message,
+        ...meta,
+        timestamp: new Date()
+      })
+    } catch (err) {
+      console.error('MongoDB transport error', err)
+    }
   }
 }
 ```
@@ -81,16 +98,23 @@ const mongodbTransport = {
 ```ts
 const slackTransport = {
   log: async (level, message, meta) => {
-    if (level === 'ERROR') {
-      await fetch('https://hooks.slack.com/services/...', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          text: `[${level}] ${message}\n${JSON.stringify(meta, null, 2)}`
+    if (level.toLowerCase() === 'error') {
+      const webhook = process.env.SLACK_WEBHOOK_URL
+      if (!webhook) return
+      
+      try {
+        await fetch(webhook, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            text: `[${level}] ${message}\n${JSON.stringify(meta, null, 2)}`
+          })
         })
-      })
+      } catch (err) {
+        console.error('Slack transport error', err)
+      }
     }
   }
 }
@@ -130,6 +154,8 @@ app.use(logixlysia({
 }))
 ```
 
+**Note:** In `useTransportsOnly` mode, `logFilePath` and console output are ignored.
+
 ### Selective Output Control
 
 ```ts
@@ -145,7 +171,7 @@ app.use(logixlysia({
 // Disable file logging but keep console
 app.use(logixlysia({
   config: {
-    logFilePath: '/var/log/app.log',
+    // logFilePath is ignored when disableFileLogging is true
     disableFileLogging: true,
     transports: [elasticsearchTransport]
   }
@@ -172,6 +198,7 @@ app.use(logixlysia({
    - Use `useTransportsOnly` for production environments where you only want external logging
    - Use `disableFileLogging` when you want console output but not file output
    - Use `disableInternalLogger` when you want file/transport output but not console output
+   - Avoid logging secrets or PII; redact sensitive fields where unavoidable
    - Implement access control
 
 ## Example Configurations
@@ -181,6 +208,7 @@ app.use(logixlysia({
 ```ts
 app.use(logixlysia({
   config: {
+    useTransportsOnly: true,
     transports: [
       elasticsearchTransport,
       slackTransport
@@ -194,6 +222,7 @@ app.use(logixlysia({
 ```ts
 app.use(logixlysia({
   config: {
+    disableInternalLogger: true,
     transports: [
       consoleTransport,
       mongodbTransport


### PR DESCRIPTION
### `🧑‍🏫` Description

- Updated error handling functions to return promises for better async support.
- Added an option to disable internal console logging via `disableInternalLogger`.
- Improved logging behavior by conditionally logging errors based on the new option.
- Ensured compatibility with existing logging mechanisms while enhancing flexibility.

### `🔗` Related Issues

closes #125

### `📝` Checklist

- [x] I have tested the changes locally.
- [x] I have added tests for the changes.
- [x] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added options to disable internal console logging, disable file logging, and to use transports-only; transports can be used alongside or instead of built-in outputs.

- Refactor
  - Logging and HTTP error handling are now asynchronous, coordinate parallel outputs (console, file, transports), and produce richer log payloads; console/file output honor the new flags.

- Tests
  - Added comprehensive tests for output-control flags, file/transports interactions, and HTTP error routing.

- Documentation
  - Added Output Control and enhanced transports docs with examples and best practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->