### PR TITLE
fix(pino-integration): improve store typing inference for pino logger

### DIFF
--- a/__tests__/logger/route-logger.test.ts
+++ b/__tests__/logger/route-logger.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { Elysia } from 'elysia'
 import type { Logger as PinoLogger } from 'pino'
-import type { LogixlysiaContext } from '../../src'
 import logixlysia from '../../src'
 
 describe('Route Logger', () => {
@@ -22,7 +21,7 @@ describe('Route Logger', () => {
       logs.push(args.join(' '))
     }
 
-    app.get('/test', ({ store, request }: LogixlysiaContext) => {
+    app.get('/test', ({ store, request }) => {
       const { logger, pino } = store
       logger.info(request, 'Test message', { test: 'value' })
       // Test direct Pino access
@@ -57,7 +56,7 @@ describe('Route Logger', () => {
       logs.push(args.join(' '))
     }
 
-    app.get('/test', ({ store, request }: LogixlysiaContext) => {
+    app.get('/test', ({ store, request }) => {
       const { logger } = store
       logger.info(request, 'Custom log message')
       return { success: true }
@@ -90,7 +89,7 @@ describe('Route Logger', () => {
       logs.push(args.join(' '))
     }
 
-    app.get('/test', ({ store, request }: LogixlysiaContext) => {
+    app.get('/test', ({ store, request }) => {
       const { logger } = store
       logger.debug(request, 'Debug message')
       logger.info(request, 'Info message')
@@ -128,7 +127,7 @@ describe('Route Logger', () => {
       logs.push(args.join(' '))
     }
 
-    app.get('/test', ({ store, request }: LogixlysiaContext) => {
+    app.get('/test', ({ store, request }) => {
       const { logger } = store
       logger.info(request, 'Test message', {
         userId: 123,
@@ -161,7 +160,7 @@ describe('Route Logger', () => {
 
     let pinoLogger: PinoLogger | undefined
 
-    app.get('/test', ({ store }: LogixlysiaContext) => {
+    app.get('/test', ({ store }) => {
       const { pino } = store
       pinoLogger = pino
       return { success: true }


### PR DESCRIPTION
### `🧑‍🏫` Description

Improved store typing inference for Pino logger integration by using Elysia's `.state()` method to initialize store properties.

**Changes made:**
- Refactored `src/index.ts` to use `.state()` for declaring `beforeTime`, `logger`, `pino`, and `hasCustomLog` properties, allowing TypeScript to properly infer the store types
- Updated `onRequest` hook to assign values directly to the already-typed store instead of reassigning the entire store object
- Removed redundant `LogixlysiaContext` type annotations from route handlers in tests, as TypeScript can now infer the types automatically

This fix improves the developer experience when accessing `store.pino` or `store.logger` in route handlers without needing explicit type annotations.

### `📸` Screenshots

N/A - No UI changes.

### `🔗` Related Issues

- [Issue 167](https://github.com/PunGrumpy/logixlysia/issues/167)

### `📝` Checklist

- [x] I have tested the changes locally.
- [x] I have added tests for the changes.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal request handling and store initialization for improved efficiency.
  * Simplified type annotations in test cases to reduce redundancy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->