### PR TITLE
Move `elysia` to peerDependencies

### DIFF
--- a/.changeset/move-elysia-to-peer-deps.md
+++ b/.changeset/move-elysia-to-peer-deps.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": minor
+---
+
+Move `elysia` from dependencies to peerDependencies to follow best practices for Elysia plugins and avoid duplicate dependency installations.

--- a/bun.lock
+++ b/bun.lock
@@ -86,20 +86,21 @@
         "typescript": "^5.9.3",
       },
     },
-    "packages/cli": {
+    "packages/logixlysia": {
       "name": "logixlysia",
       "version": "6.0.1",
       "dependencies": {
         "chalk": "^5.6.2",
-        "elysia": "^1.4.19",
         "pino": "^10.1.0",
         "pino-pretty": "^13.1.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.5",
         "bunup": "^0.16.17",
+        "elysia": "^1.4.19",
       },
       "peerDependencies": {
+        "elysia": "^1.4.19",
         "typescript": "^5.9.3",
       },
     },
@@ -1057,7 +1058,7 @@
 
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
 
-    "logixlysia": ["logixlysia@workspace:packages/cli"],
+    "logixlysia": ["logixlysia@workspace:packages/logixlysia"],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -38,15 +38,16 @@
   },
   "dependencies": {
     "chalk": "^5.6.2",
-    "elysia": "^1.4.19",
     "pino": "^10.1.0",
     "pino-pretty": "^13.1.3"
   },
   "devDependencies": {
     "@types/bun": "^1.3.5",
-    "bunup": "^0.16.17"
+    "bunup": "^0.16.17",
+    "elysia": "^1.4.19"
   },
   "peerDependencies": {
+    "elysia": "^1.4.19",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
## Description

Move elysia from dependencies to peerDependencies to follow best practices for Elysia plugins and avoid duplicate dependency installations.

Thanks to @eastgold15 for PR #197 which highlighted this need, though the implementation should be in the plugin package rather than the test app.

## Checklist

- [x] I've reviewed my code
- ~~[ ] I've written tests~~
- [x] I've generated a change set file
- ~~[ ] I've updated the docs, if necessary~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured package dependency configuration by moving a core framework library from standard dependencies to peer dependencies and development dependencies. This approach reduces installation overhead and package footprints, aligns with plugin architecture best practices, and prevents redundant installations in downstream projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->