### PR TITLE
Update IP logging from x-forwarded-for and x-real-ip

### DIFF
--- a/apps/docs/content/(docs)/configuration.mdx
+++ b/apps/docs/content/(docs)/configuration.mdx
@@ -65,6 +65,12 @@ Include client IP address in logs.
 ip: true
 ```
 
+**How IP is resolved:** The client IP is read from HTTP headers in this order:
+1. `x-forwarded-for` — uses the first (leftmost) IP in the comma-separated list (the original client when behind proxies)
+2. `x-real-ip` — fallback when `x-forwarded-for` is not present
+
+These headers are typically set by reverse proxies (nginx, Caddy, Cloudflare, etc.) and load balancers. When testing locally (localhost or LAN) without a proxy, these headers are usually absent, so the `{ip}` placeholder will be empty. To test IP logging locally, you can pass a header manually, e.g. `curl -H 'x-real-ip: 1.2.3.4' http://localhost:3000/`.
+
 ## Timestamp Options
 
 ### `timestamp`
@@ -101,7 +107,7 @@ Available placeholders:
 - `{pathname}` - Request path
 - `{status}` - Response status
 - `{message}` - Custom message
-- `{ip}` - Client IP
+- `{ip}` - Client IP (from `x-forwarded-for` or `x-real-ip`; see `ip` option)
 - `{epoch}` - Unix timestamp
 
 ## Output Options

--- a/apps/docs/content/(docs)/faq.mdx
+++ b/apps/docs/content/(docs)/faq.mdx
@@ -261,6 +261,17 @@ File logging is recommended for production environments. Use log rotation to man
 
 ## Troubleshooting
 
+### IP logging shows empty or IP is not appearing
+
+The `{ip}` placeholder reads from `x-forwarded-for` (first IP in the list) or `x-real-ip` headers. These are set by reverse proxies and load balancers. When testing on localhost or over a LAN without a proxy, these headers are not set, so the IP field will be empty.
+
+**To test IP logging locally:**
+```bash
+curl -H 'x-real-ip: 1.2.3.4' http://localhost:3000/
+```
+
+In production behind nginx, Caddy, Cloudflare, or similar, the proxy typically sets these headers and IP logging works as expected.
+
 ### Logs are not appearing
 
 Check:

--- a/apps/docs/content/features/formatting.mdx
+++ b/apps/docs/content/features/formatting.mdx
@@ -26,7 +26,7 @@ logixlysia({
 | `{pathname}` | Request path |
 | `{status}` | Response status code |
 | `{message}` | Custom message |
-| `{ip}` | Client IP address |
+| `{ip}` | Client IP address (from `x-forwarded-for` or `x-real-ip`; empty when testing locally without these headers) |
 | `{epoch}` | Unix timestamp |
 
 ## Examples

--- a/packages/logixlysia/src/logger/create-logger.ts
+++ b/packages/logixlysia/src/logger/create-logger.ts
@@ -43,6 +43,7 @@ const formatTimestamp = (date: Date, pattern?: string): string => {
     .replaceAll('SSS', SSS)
 }
 
+/** Resolves client IP from x-forwarded-for (first IP) or x-real-ip. Empty when neither header is set (e.g. localhost). */
 const getIp = (request: RequestInfo): string => {
   const forwarded = request.headers.get('x-forwarded-for')
   if (forwarded) {


### PR DESCRIPTION
## Description

Clarify that client IP is read from x-forwarded-for (first IP) or x-real-ip headers. Add troubleshooting for empty IP when testing locally and a curl example for local testing.

## Related Issues

Closes #218

## Checklist

- [ ] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

<!-- Add any additional information or context about the pull request here. -->