### PR TITLE
OnStart server undefined test

### DIFF
--- a/packages/logixlysia/__tests__/plugin/logixlysia.test.ts
+++ b/packages/logixlysia/__tests__/plugin/logixlysia.test.ts
@@ -1,10 +1,48 @@
 import { describe, expect, mock, test } from 'bun:test'
 import { Elysia } from 'elysia'
 
-import { logixlysia } from '../../src'
+import { createOnStartHandler, logixlysia } from '../../src'
 import type { Options } from '../../src/interfaces'
+import { spyConsole } from '../_helpers/console'
 
 describe('logixlysia plugin', () => {
+  test('onStart when server is undefined uses process.env.HOST and process.env.PORT and emits startup banner', () => {
+    const originalHost = process.env.HOST
+    const originalPort = process.env.PORT
+
+    const testHost = 'testhost.example.com'
+    const testPort = '9999'
+    process.env.HOST = testHost
+    process.env.PORT = testPort
+
+    const { spies, restore: restoreConsole } = spyConsole(['log'])
+
+    try {
+      const options: Options = {}
+      const onStartHandler = createOnStartHandler(options)
+
+      // Simulate the onStart path when server is undefined (e.g. Node adapter)
+      onStartHandler({ server: undefined })
+
+      // startServer is called with { hostname, port, protocol: 'http' } and emits the banner
+      expect(spies.log).toHaveBeenCalled()
+      const output = String(spies.log.mock.calls[0]?.[0] ?? '')
+      expect(output).toContain('🦊 Elysia is running at')
+      expect(output).toContain(`http://${testHost}:${testPort}`)
+    } finally {
+      if (originalHost !== undefined) {
+        process.env.HOST = originalHost
+      } else {
+        delete process.env.HOST
+      }
+      if (originalPort !== undefined) {
+        process.env.PORT = originalPort
+      } else {
+        delete process.env.PORT
+      }
+      restoreConsole()
+    }
+  })
   test('auto-logs once when no custom log was emitted', async () => {
     const transport = mock<
       (lvl: unknown, msg: unknown, meta?: unknown) => void

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -8,6 +8,23 @@ export type Logixlysia = Elysia<
   SingletonBase & { store: LogixlysiaStore }
 >
 
+export type OnStartContext = {
+  server?: { port?: number; hostname?: string; protocol?: string | null }
+}
+
+export function createOnStartHandler(options: Options) {
+  return ({ server }: OnStartContext) => {
+    if (server) {
+      startServer(server, options)
+    } else {
+      // Node adapter fallback
+      const port = Number(process.env.PORT) || 3000
+      const hostname = process.env.HOST || 'localhost'
+      startServer({ port, hostname, protocol: 'http' }, options)
+    }
+  }
+}
+
 export const logixlysia = (options: Options = {}): Logixlysia => {
   const didCustomLog = new WeakSet<Request>()
   const baseLogger = createLogger(options)
@@ -61,16 +78,7 @@ export const logixlysia = (options: Options = {}): Logixlysia => {
       .state('logger', logger)
       .state('pino', logger.pino)
       .state('beforeTime', BigInt(0))
-      .onStart(({ server }) => {
-        if (server) {
-          startServer(server, options)
-        } else {
-          // Node adapter fallback
-          const port = Number(process.env.PORT) || 3000
-          const hostname = process.env.HOST || 'localhost'
-          startServer({ port, hostname, protocol: 'http' }, options)
-        }
-      })
+      .onStart(createOnStartHandler(options))
       .onRequest(({ store }) => {
         store.beforeTime = process.hrtime.bigint()
       })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a regression test to verify the `onStart` handler correctly initializes the server using `process.env.HOST` and `process.env.PORT` when the `server` object is undefined. This required extracting the `onStart` logic into a testable function.

## Related Issues

Closes #<issue_number>

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [ ] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

The test asserts that the startup banner is emitted with the correct URL, confirming `startServer` was invoked with the expected hostname and port from environment variables.

<div><a href="https://cursor.com/agents/bc-1756ed42-8c4b-468f-bbde-d3142a32c187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1756ed42-8c4b-468f-bbde-d3142a32c187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->