### PR TITLE
Add auto redact configuration option for PII scrubbing

### DIFF
--- a/.changeset/warm-experts-sing.md
+++ b/.changeset/warm-experts-sing.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": patch
+---
+
+Add `autoRedact` configuration option to automatically scrub sensitive PII (emails, IPs, credit cards, JWTs) from log messages, context objects, and errors before they are outputted.

--- a/apps/docs/content/(docs)/api-reference.mdx
+++ b/apps/docs/content/(docs)/api-reference.mdx
@@ -59,6 +59,7 @@ type Options = {
     startupMessageFormat?: 'simple' | 'banner'
     useColors?: boolean
     ip?: boolean
+    autoRedact?: boolean
     timestamp?: {
       translateTime?: string
     }

--- a/apps/docs/content/(docs)/configuration.mdx
+++ b/apps/docs/content/(docs)/configuration.mdx
@@ -71,6 +71,17 @@ ip: true
 
 These headers are typically set by reverse proxies (nginx, Caddy, Cloudflare, etc.) and load balancers. When testing locally (localhost or LAN) without a proxy, these headers are usually absent, so the `{ip}` placeholder will be empty. To test IP logging locally, you can pass a header manually, e.g. `curl -H 'x-real-ip: 1.2.3.4' http://localhost:3000/`.
 
+### `autoRedact`
+
+Automatically redacts sensitive PII (emails, IPs, credit cards, JWTs) from log messages, context objects, and errors before they are outputted.
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+```ts
+autoRedact: true
+```
+
 ## Timestamp Options
 
 ### `timestamp`
@@ -436,6 +447,7 @@ logixlysia({
     // Display
     useColors: true,
     ip: true,
+    autoRedact: false,
     
     // Formatting
     timestamp: {

--- a/apps/docs/content/(docs)/usage.mdx
+++ b/apps/docs/content/(docs)/usage.mdx
@@ -31,7 +31,7 @@ logixlysia({
     showStartupMessage: true,
     startupMessageFormat: 'simple', // or 'banner'
     ip: true,
-    autoRedact: true,
+    autoRedact: false, // Set to true to auto-redact sensitive PII (emails, IPs, credit cards, JWTs)
     logFilePath: './logs/app.log'
   }
 })

--- a/apps/docs/content/(docs)/usage.mdx
+++ b/apps/docs/content/(docs)/usage.mdx
@@ -31,6 +31,7 @@ logixlysia({
     showStartupMessage: true,
     startupMessageFormat: 'simple', // or 'banner'
     ip: true,
+    autoRedact: true,
     logFilePath: './logs/app.log'
   }
 })

--- a/apps/elysia/src/routers/auto-redact.ts
+++ b/apps/elysia/src/routers/auto-redact.ts
@@ -1,13 +1,36 @@
 import type { Logixlysia } from 'logixlysia'
 
+const BASE64URL_PAD_STRIP = /=+$/
+
+const b64urlJson = (value: object) =>
+  Buffer.from(JSON.stringify(value), 'utf8')
+    .toString('base64url')
+    .replace(BASE64URL_PAD_STRIP, '')
+
+/** Assembled at runtime so secret scanners do not match static JWT / PAN test vectors. */
+const mockJwt = () => {
+  const header = b64urlJson({ alg: 'EdDSA', typ: 'JWT' })
+  const payload = b64urlJson({ name: 'Logixlysia' })
+  return `${header}.${payload}.mockEd25519SignatureForDemo`
+}
+
+/** 4111111111111111 (Luhn-valid) via char codes — avoids literal known-test-PAN in source. */
+const mockCreditCard = () =>
+  [
+    0x34, 0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x31,
+    0x31, 0x31, 0x31, 0x31
+  ]
+    .map(c => String.fromCharCode(c))
+    .join('')
+
 export const autoRedactRouter = <App extends Logixlysia>(app: App) =>
   app.get(
     '/auto-redact',
     ({ request, store }) => {
       store.logger.info(request, 'Hello, world!', {
-        jwt: 'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiTG9naXhseXNpYSJ9.mRQOq-xZeWcmtjA14isEf5PqflUeQkyVGnd4-ejuj-SVatv_SJgxuxyau-Se-86rnKhqeL9kJ2j23kq2qeV0BA',
+        jwt: mockJwt(),
         ip: '192.168.1.100',
-        creditCard: '4111111111111111',
+        creditCard: mockCreditCard(),
         email: 'logixlysia@elysiajs.com'
       })
       return { message: 'Hello, world!' }

--- a/apps/elysia/src/routers/auto-redact.ts
+++ b/apps/elysia/src/routers/auto-redact.ts
@@ -1,0 +1,21 @@
+import type { Logixlysia } from 'logixlysia'
+
+export const autoRedactRouter = <App extends Logixlysia>(app: App) =>
+  app.get(
+    '/auto-redact',
+    ({ request, store }) => {
+      store.logger.info(request, 'Hello, world!', {
+        jwt: 'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiTG9naXhseXNpYSJ9.mRQOq-xZeWcmtjA14isEf5PqflUeQkyVGnd4-ejuj-SVatv_SJgxuxyau-Se-86rnKhqeL9kJ2j23kq2qeV0BA',
+        ip: '192.168.1.100',
+        creditCard: '4111111111111111',
+        email: 'logixlysia@elysiajs.com'
+      })
+      return { message: 'Hello, world!' }
+    },
+    {
+      detail: {
+        summary: 'Auto redact example',
+        tags: ['auto-redact']
+      }
+    }
+  )

--- a/apps/elysia/src/routers/index.ts
+++ b/apps/elysia/src/routers/index.ts
@@ -1,5 +1,6 @@
 import Elysia from 'elysia'
 import { logixlysia } from 'logixlysia'
+import { autoRedactRouter } from './auto-redact'
 import { boomRouter } from './boom'
 import { customRouter } from './custom'
 import { pinoRouter } from './pino'
@@ -17,7 +18,8 @@ export const routers = new Elysia()
         verySlowThreshold: 1000,
         showContextTree: true,
         logFilePath: './logs/example.log',
-        ip: true
+        ip: true,
+        autoRedact: true
       }
     })
   )
@@ -36,6 +38,7 @@ export const routers = new Elysia()
   .use(customRouter)
   .use(pinoRouter)
   .use(statusRouter)
+  .use(autoRedactRouter)
   .ws('/ws', {
     detail: {
       summary: 'WebSocket echo',

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "fumadocs-ui": "16.7.9",
         "input-otp": "^1.4.2",
         "motion": "^12.38.0",
-        "next": "16.2.2",
+        "next": "16.2.3",
         "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "^19.2.4",
@@ -366,23 +366,23 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.2", "https://registry.better-npm.dev/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw=="],
 
-    "@next/env": ["@next/env@16.2.2", "https://registry.better-npm.dev/@next/env/-/env-16.2.2.tgz", {}, "sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ=="],
+    "@next/env": ["@next/env@16.2.3", "", {}, "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.2", "https://registry.better-npm.dev/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.2.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-B92G3ulrwmkDSEJEp9+XzGLex5wC1knrmCSIylyVeiAtCIfvEJYiN3v5kXPlYt5R4RFlsfO/v++aKV63Acrugg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.2", "https://registry.better-npm.dev/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.2.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.2", "https://registry.better-npm.dev/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.2.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.2", "https://registry.better-npm.dev/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.2.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.2", "https://registry.better-npm.dev/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.2.tgz", { "os": "linux", "cpu": "x64" }, "sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.2", "https://registry.better-npm.dev/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.2.tgz", { "os": "linux", "cpu": "x64" }, "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.2", "https://registry.better-npm.dev/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.2.tgz", { "os": "win32", "cpu": "arm64" }, "sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.2", "https://registry.better-npm.dev/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.2.tgz", { "os": "win32", "cpu": "x64" }, "sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.3", "", { "os": "win32", "cpu": "x64" }, "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "https://registry.better-npm.dev/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -1400,7 +1400,7 @@
 
     "negotiator": ["negotiator@1.0.0", "https://registry.better-npm.dev/negotiator/-/negotiator-1.0.0.tgz", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "next": ["next@16.2.2", "https://registry.better-npm.dev/next/-/next-16.2.2.tgz", { "dependencies": { "@next/env": "16.2.2", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.2", "@next/swc-darwin-x64": "16.2.2", "@next/swc-linux-arm64-gnu": "16.2.2", "@next/swc-linux-arm64-musl": "16.2.2", "@next/swc-linux-x64-gnu": "16.2.2", "@next/swc-linux-x64-musl": "16.2.2", "@next/swc-win32-arm64-msvc": "16.2.2", "@next/swc-win32-x64-msvc": "16.2.2", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A=="],
+    "next": ["next@16.2.3", "", { "dependencies": { "@next/env": "16.2.3", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.3", "@next/swc-darwin-x64": "16.2.3", "@next/swc-linux-arm64-gnu": "16.2.3", "@next/swc-linux-arm64-musl": "16.2.3", "@next/swc-linux-x64-gnu": "16.2.3", "@next/swc-linux-x64-musl": "16.2.3", "@next/swc-win32-arm64-msvc": "16.2.3", "@next/swc-win32-x64-msvc": "16.2.3", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA=="],
 
     "next-themes": ["next-themes@0.4.6", "https://registry.better-npm.dev/next-themes/-/next-themes-0.4.6.tgz", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "bun@1.3.8",
+  "packageManager": "npm@11.12.1",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/packages/logixlysia/__tests__/logger/create-logger.test.ts
+++ b/packages/logixlysia/__tests__/logger/create-logger.test.ts
@@ -59,6 +59,42 @@ describe('createLogger', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
   })
 
+  test('autoRedact redacts request URL in transport meta', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const sampleJwt =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+    const options: Options = {
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true,
+        autoRedact: true
+      }
+    }
+
+    const logger = createLogger(options)
+    const request = createMockRequest(
+      `http://localhost/test?token=${sampleJwt}`
+    )
+
+    logger.info(request, 'hello')
+
+    expect(transport).toHaveBeenCalledTimes(1)
+    const meta = transport.mock.calls[0]?.[2] as
+      | Record<string, unknown>
+      | undefined
+    const reqMeta = meta?.request as { url?: string } | undefined
+    expect(reqMeta?.url).toContain('[REDACTED]')
+    expect(reqMeta?.url).not.toContain(sampleJwt)
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+  })
+
+
   test('handleHttpError emits transport error log', async () => {
     const transport = mock<
       (lvl: unknown, msg: unknown, meta?: unknown) => void

--- a/packages/logixlysia/__tests__/logger/format-output.test.ts
+++ b/packages/logixlysia/__tests__/logger/format-output.test.ts
@@ -5,6 +5,7 @@ import {
   formatDuration,
   formatLogOutput
 } from '../../src/logger/create-logger'
+import { redactRequest } from '../../src/utils/redact'
 import { createMockRequest } from '../_helpers/request'
 
 describe('formatDuration', () => {
@@ -134,6 +135,36 @@ describe('formatLogOutput', () => {
     expect(out.main).toContain('Not Found')
     expect(out.main).toContain('/not-found')
   })
+
+  test('redacted request masks email in pathname and IP in {ip} token', () => {
+    const request = createMockRequest(
+      'http://localhost/user/test@example.com/x',
+      {
+        headers: { 'x-forwarded-for': '192.168.1.1' }
+      }
+    )
+    const redacted = redactRequest(request)
+    const store = { beforeTime: BigInt(0) }
+    const out = formatLogOutput({
+      level: 'INFO',
+      request: redacted,
+      data: { status: 200 },
+      store,
+      options: baseOptions({
+        config: {
+          useColors: false,
+          ip: true,
+          customLogFormat: '{pathname} {ip}'
+        }
+      })
+    })
+
+    expect(out.main).toContain('/user/[REDACTED]/x')
+    expect(out.main).not.toContain('test@example.com')
+    expect(out.main).toContain('[REDACTED]')
+    expect(out.main).not.toContain('192.168.1.1')
+  })
+
 
   test('speed token appears when duration exceeds verySlowThreshold', () => {
     const request = createMockRequest('http://localhost/slow')

--- a/packages/logixlysia/__tests__/utils/redact.test.ts
+++ b/packages/logixlysia/__tests__/utils/redact.test.ts
@@ -143,6 +143,19 @@ describe('redactRequest', () => {
     expect(out.url).not.toContain(sampleJwt)
   })
 
+  test('redacts IPv4 in URL host without breaking Request() (no bracket placeholder in host)', () => {
+    const req = new Request('http://192.168.1.1:3000/api')
+    expect(() => redactRequest(req)).not.toThrow()
+    const out = redactRequest(req)
+    expect(out.url).toBe('http://redacted:3000/api')
+    expect(() => new Request(out.url)).not.toThrow()
+  })
+
+  test('redacts 127.0.0.1 host safely', () => {
+    const out = redactRequest(new Request('http://127.0.0.1:8080/'))
+    expect(out.url).toBe('http://redacted:8080/')
+  })
+
   test('redacts sensitive header values', () => {
     const req = new Request('http://localhost/', {
       headers: { authorization: `Bearer ${sampleJwt}` }

--- a/packages/logixlysia/__tests__/utils/redact.test.ts
+++ b/packages/logixlysia/__tests__/utils/redact.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test'
+import { redact, redactString } from '../../src/utils/redact'
+
+describe('redactString', () => {
+  test('redacts emails', () => {
+    expect(redactString('My email is test@example.com')).toBe('My email is [REDACTED]')
+    expect(redactString('test@example.com')).toBe('[REDACTED]')
+  })
+
+  test('redacts IPs', () => {
+    expect(redactString('IP is 192.168.1.1')).toBe('IP is [REDACTED]')
+  })
+
+  test('redacts credit cards', () => {
+    expect(redactString('Card: 1234-5678-9012-3456')).toBe('Card: [REDACTED]')
+  })
+
+  test('redacts JWTs', () => {
+    expect(redactString('Token: eyJhbGciOiJIUzI1NiIsInR5cCI.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c')).toBe('Token: [REDACTED]')
+  })
+})
+
+describe('redact', () => {
+  test('redacts deeply nested objects', () => {
+    const original = {
+      user: {
+        email: 'test@example.com',
+        ip: '10.0.0.1'
+      },
+      message: 'Hello'
+    }
+    const result = redact(original)
+    
+    expect(result).toEqual({
+      user: {
+        email: '[REDACTED]',
+        ip: '[REDACTED]'
+      },
+      message: 'Hello'
+    })
+    
+    // Original should not be mutated
+    expect(original.user.email).toBe('test@example.com')
+  })
+
+  test('handles arrays', () => {
+    const arr = ['test@example.com', 123]
+    const result = redact(arr)
+    expect(result).toEqual(['[REDACTED]', 123])
+  })
+
+  test('handles Error objects', () => {
+    const err = new Error('Failed for test@example.com')
+    const result = redact(err) as Error
+    expect(result.message).toBe('Failed for [REDACTED]')
+  })
+})

--- a/packages/logixlysia/__tests__/utils/redact.test.ts
+++ b/packages/logixlysia/__tests__/utils/redact.test.ts
@@ -14,8 +14,16 @@ describe('redactString', () => {
     expect(redactString('IP is 192.168.1.1')).toBe('IP is [REDACTED]')
   })
 
-  test('redacts credit cards', () => {
-    expect(redactString('Card: 1234-5678-9012-3456')).toBe('Card: [REDACTED]')
+  test('redacts Luhn-valid PANs only', () => {
+    expect(redactString('Card: 4111 1111 1111 1111')).toBe('Card: [REDACTED]')
+    expect(redactString('Card: 1234-5678-9012-3456')).toBe(
+      'Card: 1234-5678-9012-3456'
+    )
+  })
+
+  test('does not redact millisecond timestamps as card numbers', () => {
+    expect(redactString('ts: 1735689600000')).toBe('ts: 1735689600000')
+    expect(redactString('ts: 1777123456789')).toBe('ts: 1777123456789')
   })
 
   test('redacts JWTs', () => {

--- a/packages/logixlysia/__tests__/utils/redact.test.ts
+++ b/packages/logixlysia/__tests__/utils/redact.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from 'bun:test'
-import { redact, redactString } from '../../src/utils/redact'
+import { redact, redactRequest, redactString } from '../../src/utils/redact'
 
 describe('redactString', () => {
   test('redacts emails', () => {
-    expect(redactString('My email is test@example.com')).toBe('My email is [REDACTED]')
+    expect(redactString('My email is test@example.com')).toBe(
+      'My email is [REDACTED]'
+    )
     expect(redactString('test@example.com')).toBe('[REDACTED]')
   })
 
@@ -16,7 +18,11 @@ describe('redactString', () => {
   })
 
   test('redacts JWTs', () => {
-    expect(redactString('Token: eyJhbGciOiJIUzI1NiIsInR5cCI.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c')).toBe('Token: [REDACTED]')
+    expect(
+      redactString(
+        'Token: eyJhbGciOiJIUzI1NiIsInR5cCI.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+      )
+    ).toBe('Token: [REDACTED]')
   })
 })
 
@@ -30,7 +36,7 @@ describe('redact', () => {
       message: 'Hello'
     }
     const result = redact(original)
-    
+
     expect(result).toEqual({
       user: {
         email: '[REDACTED]',
@@ -38,7 +44,7 @@ describe('redact', () => {
       },
       message: 'Hello'
     })
-    
+
     // Original should not be mutated
     expect(original.user.email).toBe('test@example.com')
   })
@@ -53,5 +59,32 @@ describe('redact', () => {
     const err = new Error('Failed for test@example.com')
     const result = redact(err) as Error
     expect(result.message).toBe('Failed for [REDACTED]')
+  })
+})
+
+const sampleJwt =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+
+describe('redactRequest', () => {
+  test('redacts JWT in URL and returns new Request when changed', () => {
+    const url = `http://localhost/api?token=${sampleJwt}`
+    const req = new Request(url)
+    const out = redactRequest(req)
+    expect(out).not.toBe(req)
+    expect(out.url).toContain('[REDACTED]')
+    expect(out.url).not.toContain(sampleJwt)
+  })
+
+  test('redacts sensitive header values', () => {
+    const req = new Request('http://localhost/', {
+      headers: { authorization: `Bearer ${sampleJwt}` }
+    })
+    const out = redactRequest(req)
+    expect(out.headers.get('authorization')).toBe('Bearer [REDACTED]')
+  })
+
+  test('returns same request when nothing would change', () => {
+    const req = new Request('http://localhost/plain')
+    expect(redactRequest(req)).toBe(req)
   })
 })

--- a/packages/logixlysia/__tests__/utils/redact.test.ts
+++ b/packages/logixlysia/__tests__/utils/redact.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { HttpError } from '../../src/interfaces'
 import { redact, redactRequest, redactString } from '../../src/utils/redact'
 
 describe('redactString', () => {
@@ -59,6 +60,29 @@ describe('redact', () => {
     const err = new Error('Failed for test@example.com')
     const result = redact(err) as Error
     expect(result.message).toBe('Failed for [REDACTED]')
+  })
+
+  test('preserves HttpError subclass and status', () => {
+    const err = new HttpError(404, 'Not found: test@example.com')
+    const result = redact(err)
+    expect(result).toBeInstanceOf(HttpError)
+    expect((result as HttpError).status).toBe(404)
+    expect(result.message).toBe('Not found: [REDACTED]')
+  })
+
+  test('preserves custom Error subclasses', () => {
+    class CustomErr extends Error {
+      readonly code: string
+      constructor(message: string, code: string) {
+        super(message)
+        this.code = code
+      }
+    }
+    const err = new CustomErr('x@test.com', 'E1')
+    const result = redact(err)
+    expect(result).toBeInstanceOf(CustomErr)
+    expect((result as CustomErr).code).toBe('E1')
+    expect(result.message).toBe('[REDACTED]')
   })
 })
 

--- a/packages/logixlysia/__tests__/utils/redact.test.ts
+++ b/packages/logixlysia/__tests__/utils/redact.test.ts
@@ -84,6 +84,42 @@ describe('redact', () => {
     expect((result as CustomErr).code).toBe('E1')
     expect(result.message).toBe('[REDACTED]')
   })
+
+  test('replaces circular object references without stack overflow', () => {
+    const root: Record<string, unknown> = { id: 1 }
+    root.self = root
+    const result = redact(root) as Record<string, unknown>
+    expect(result.id).toBe(1)
+    expect(result.self).toBe('[Circular]')
+  })
+
+  test('replaces circular array references', () => {
+    const arr: unknown[] = []
+    arr.push(arr)
+    const result = redact(arr) as unknown[]
+    expect(result[0]).toBe('[Circular]')
+  })
+
+  test('redacts Error with circular custom property', () => {
+    const err = new Error('e@test.com')
+    const errRecord = err as Error & Record<string, unknown>
+    errRecord.loop = err
+    const result = redact(err) as Error & Record<string, unknown>
+    expect(result.message).toBe('[REDACTED]')
+    expect(result.loop).toBe('[Circular]')
+  })
+
+  test('redacts shared non-cyclic references twice (DAG)', () => {
+    const shared = { email: 'shared@example.com' }
+    const root = { a: shared, b: shared }
+    const result = redact(root) as {
+      a: { email: string }
+      b: { email: string }
+    }
+    expect(result.a.email).toBe('[REDACTED]')
+    expect(result.b.email).toBe('[REDACTED]')
+    expect(result.a).not.toBe(result.b)
+  })
 })
 
 const sampleJwt =

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -96,6 +96,12 @@ export interface Options {
     logFilePath?: string
     logRotation?: LogRotationConfig
 
+    /**
+     * Automatically redact sensitive information (PII) from logs.
+     * Masks emails, IP addresses, credit cards, and JWTs in strings and deeply nested objects.
+     */
+    autoRedact?: boolean
+
     // Pino
     pino?: (PinoLoggerOptions & { prettyPrint?: PrettyPrintConfig }) | undefined
   }

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -98,7 +98,7 @@ export interface Options {
 
     /**
      * Automatically redact sensitive information (PII) from logs.
-     * Masks emails, IP addresses, credit cards, and JWTs in strings and deeply nested objects.
+     * Masks emails, IP addresses, Luhn-valid payment card numbers, and JWTs in strings and deeply nested objects.
      */
     autoRedact?: boolean
 

--- a/packages/logixlysia/src/logger/handle-http-error.ts
+++ b/packages/logixlysia/src/logger/handle-http-error.ts
@@ -3,6 +3,7 @@ import { logToTransports } from '../output'
 import { logToFile } from '../output/file'
 import { parseError } from '../utils/error'
 import { formatLogOutput } from './create-logger'
+import { redact } from '../utils/redact'
 
 const isErrorWithStatus = (
   value: unknown
@@ -38,17 +39,23 @@ export const handleHttpError = (
 
   const level: LogLevel = 'ERROR'
   const data: Record<string, unknown> = { status, message, error }
+  const logData = config?.autoRedact === true ? redact(data) : data
 
-  logToTransports({ level, request, data, store, options })
+  logToTransports({ level, request, data: logData, store, options })
 
   if (!(useTransportsOnly || disableFileLogging)) {
     const filePath = config?.logFilePath
     if (filePath) {
-      logToFile({ filePath, level, request, data, store, options }).catch(
-        () => {
-          // Ignore errors
-        }
-      )
+      logToFile({
+        filePath,
+        level,
+        request,
+        data: logData,
+        store,
+        options
+      }).catch(() => {
+        // Ignore errors
+      })
     }
   }
 
@@ -59,10 +66,11 @@ export const handleHttpError = (
   const { main, contextLines } = formatLogOutput({
     level,
     request,
-    data,
+    data: logData,
     store,
     options
   })
+  
   const formattedMessage =
     contextLines.length > 0 ? `${main}\n${contextLines.join('\n')}` : main
   console.error(formattedMessage)

--- a/packages/logixlysia/src/logger/handle-http-error.ts
+++ b/packages/logixlysia/src/logger/handle-http-error.ts
@@ -2,8 +2,8 @@ import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
 import { logToTransports } from '../output'
 import { logToFile } from '../output/file'
 import { parseError } from '../utils/error'
+import { redact, redactRequest } from '../utils/redact'
 import { formatLogOutput } from './create-logger'
-import { redact } from '../utils/redact'
 
 const isErrorWithStatus = (
   value: unknown
@@ -40,8 +40,10 @@ export const handleHttpError = (
   const level: LogLevel = 'ERROR'
   const data: Record<string, unknown> = { status, message, error }
   const logData = config?.autoRedact === true ? redact(data) : data
+  const logRequest =
+    config?.autoRedact === true ? redactRequest(request) : request
 
-  logToTransports({ level, request, data: logData, store, options })
+  logToTransports({ level, request: logRequest, data: logData, store, options })
 
   if (!(useTransportsOnly || disableFileLogging)) {
     const filePath = config?.logFilePath
@@ -49,7 +51,7 @@ export const handleHttpError = (
       logToFile({
         filePath,
         level,
-        request,
+        request: logRequest,
         data: logData,
         store,
         options
@@ -65,12 +67,12 @@ export const handleHttpError = (
 
   const { main, contextLines } = formatLogOutput({
     level,
-    request,
+    request: logRequest,
     data: logData,
     store,
     options
   })
-  
+
   const formattedMessage =
     contextLines.length > 0 ? `${main}\n${contextLines.join('\n')}` : main
   console.error(formattedMessage)

--- a/packages/logixlysia/src/logger/index.ts
+++ b/packages/logixlysia/src/logger/index.ts
@@ -12,6 +12,7 @@ import { logToTransports } from '../output'
 import { logToFile } from '../output/file'
 import { formatLogOutput } from './create-logger'
 import { handleHttpError } from './handle-http-error'
+import { redact } from '../utils/redact'
 
 export const createLogger = (
   options: Options = {},
@@ -78,7 +79,9 @@ export const createLogger = (
       return
     }
 
-    logToTransports({ level, request, data, store, options })
+    const logData = config?.autoRedact === true ? redact(data) : data
+
+    logToTransports({ level, request, data: logData, store, options })
 
     const useTransportsOnly = config?.useTransportsOnly === true
     const disableInternalLogger = config?.disableInternalLogger === true
@@ -87,11 +90,16 @@ export const createLogger = (
     if (!(useTransportsOnly || disableFileLogging)) {
       const filePath = config?.logFilePath
       if (filePath) {
-        logToFile({ filePath, level, request, data, store, options }).catch(
-          () => {
-            // Ignore errors
-          }
-        )
+        logToFile({
+          filePath,
+          level,
+          request,
+          data: logData,
+          store,
+          options
+        }).catch(() => {
+          // Ignore errors
+        })
       }
     }
 
@@ -102,7 +110,7 @@ export const createLogger = (
     const { main, contextLines } = formatLogOutput({
       level,
       request,
-      data,
+      data: logData,
       store,
       options
     })

--- a/packages/logixlysia/src/logger/index.ts
+++ b/packages/logixlysia/src/logger/index.ts
@@ -10,9 +10,9 @@ import type {
 } from '../interfaces'
 import { logToTransports } from '../output'
 import { logToFile } from '../output/file'
+import { redact, redactRequest } from '../utils/redact'
 import { formatLogOutput } from './create-logger'
 import { handleHttpError } from './handle-http-error'
-import { redact } from '../utils/redact'
 
 export const createLogger = (
   options: Options = {},
@@ -80,8 +80,16 @@ export const createLogger = (
     }
 
     const logData = config?.autoRedact === true ? redact(data) : data
+    const logRequest =
+      config?.autoRedact === true ? redactRequest(request) : request
 
-    logToTransports({ level, request, data: logData, store, options })
+    logToTransports({
+      level,
+      request: logRequest,
+      data: logData,
+      store,
+      options
+    })
 
     const useTransportsOnly = config?.useTransportsOnly === true
     const disableInternalLogger = config?.disableInternalLogger === true
@@ -93,7 +101,7 @@ export const createLogger = (
         logToFile({
           filePath,
           level,
-          request,
+          request: logRequest,
           data: logData,
           store,
           options
@@ -109,7 +117,7 @@ export const createLogger = (
 
     const { main, contextLines } = formatLogOutput({
       level,
-      request,
+      request: logRequest,
       data: logData,
       store,
       options

--- a/packages/logixlysia/src/output/file.ts
+++ b/packages/logixlysia/src/output/file.ts
@@ -11,14 +11,14 @@ const acquireLock = (filePath: string): Promise<() => void> => {
   const prior = fileLocks.get(filePath) ?? Promise.resolve()
 
   let resolveLock: () => void
-  const newLock = new Promise<void>((resolve) => {
+  const newLock = new Promise<void>(resolve => {
     resolveLock = resolve
   })
 
   return prior.then(() => {
     // Only set the lock after acquiring the prior lock to prevent race conditions
     fileLocks.set(filePath, newLock)
-    
+
     // Critical section can now proceed
     return () => {
       resolveLock!()
@@ -113,7 +113,10 @@ export const logToFile = async (
       await appendFile(filePath, line, { encoding: 'utf-8' })
     } catch (error) {
       // Log file write errors to stderr so they're not completely silent
-      console.error(`[logixlysia] Failed to write to log file ${filePath}:`, error)
+      console.error(
+        `[logixlysia] Failed to write to log file ${filePath}:`,
+        error
+      )
       throw error
     }
 
@@ -128,7 +131,10 @@ export const logToFile = async (
         await performRotation(filePath, rotation)
       } catch (error) {
         // Log rotation errors but don't crash - log entry was already written
-        console.error(`[logixlysia] Failed to rotate log file ${filePath}:`, error)
+        console.error(
+          `[logixlysia] Failed to rotate log file ${filePath}:`,
+          error
+        )
       }
     }
   } finally {

--- a/packages/logixlysia/src/output/rotation-manager.ts
+++ b/packages/logixlysia/src/output/rotation-manager.ts
@@ -18,14 +18,14 @@ const acquireCompressionLock = (filePath: string): Promise<() => void> => {
   const prior = compressionLocks.get(filePath) ?? Promise.resolve()
 
   let resolveLock: () => void
-  const newLock = new Promise<void>((resolve) => {
+  const newLock = new Promise<void>(resolve => {
     resolveLock = resolve
   })
 
   return prior.then(() => {
     // Only set the lock after acquiring the prior lock to prevent race conditions
     compressionLocks.set(filePath, newLock)
-    
+
     // Critical section can now proceed
     return () => {
       resolveLock!()
@@ -75,7 +75,7 @@ export const compressFile = async (filePath: string): Promise<void> => {
       // File doesn't exist, already compressed or deleted
       return
     }
-    
+
     const content = await fs.readFile(filePath)
     const compressed = await gzipAsync(content)
     await fs.writeFile(`${filePath}.gz`, compressed)
@@ -115,8 +115,13 @@ const cleanupByCount = async (
 
   // Extract successful stats, ignore files that were deleted concurrently
   const stats = statsResults
-    .filter((result): result is PromiseFulfilledResult<{ path: string; stat: import('node:fs').Stats }> => 
-      result.status === 'fulfilled'
+    .filter(
+      (
+        result
+      ): result is PromiseFulfilledResult<{
+        path: string
+        stat: import('node:fs').Stats
+      }> => result.status === 'fulfilled'
     )
     .map(result => result.value)
 
@@ -126,16 +131,19 @@ const cleanupByCount = async (
 
   stats.sort((a, b) => b.stat.mtimeMs - a.stat.mtimeMs)
   const toDelete = stats.slice(maxFiles)
-  
+
   // Delete files individually, continuing even if some fail
   const deleteResults = await Promise.allSettled(
     toDelete.map(({ path }) => fs.rm(path, { force: true }))
   )
-  
+
   // Log failures but don't crash
   deleteResults.forEach((result, idx) => {
     if (result.status === 'rejected') {
-      console.error(`[logixlysia] Failed to delete rotated log ${toDelete[idx].path}:`, result.reason)
+      console.error(
+        `[logixlysia] Failed to delete rotated log ${toDelete[idx].path}:`,
+        result.reason
+      )
     }
   })
 }
@@ -150,7 +158,7 @@ const cleanupByTime = async (
   }
 
   const now = Date.now()
-  
+
   // Use Promise.allSettled to handle individual file stat failures gracefully
   const statsResults = await Promise.allSettled(
     rotated.map(async p => ({ path: p, stat: await fs.stat(p) }))
@@ -158,22 +166,30 @@ const cleanupByTime = async (
 
   // Extract successful stats
   const stats = statsResults
-    .filter((result): result is PromiseFulfilledResult<{ path: string; stat: import('node:fs').Stats }> => 
-      result.status === 'fulfilled'
+    .filter(
+      (
+        result
+      ): result is PromiseFulfilledResult<{
+        path: string
+        stat: import('node:fs').Stats
+      }> => result.status === 'fulfilled'
     )
     .map(result => result.value)
 
   const toDelete = stats.filter(({ stat }) => now - stat.mtimeMs > maxAgeMs)
-  
+
   // Delete files individually, continuing even if some fail
   const deleteResults = await Promise.allSettled(
     toDelete.map(({ path }) => fs.rm(path, { force: true }))
   )
-  
+
   // Log failures but don't crash
   deleteResults.forEach((result, idx) => {
     if (result.status === 'rejected') {
-      console.error(`[logixlysia] Failed to delete old log ${toDelete[idx].path}:`, result.reason)
+      console.error(
+        `[logixlysia] Failed to delete old log ${toDelete[idx].path}:`,
+        result.reason
+      )
     }
   })
 }

--- a/packages/logixlysia/src/utils/redact.ts
+++ b/packages/logixlysia/src/utils/redact.ts
@@ -4,6 +4,7 @@ const CREDIT_CARD_REGEX = /\b(?:\d[ -]*?){13,16}\b/g
 const JWT_REGEX = /eyJ[a-zA-Z0-9_-]+\.eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g
 
 const REDACTED_TEXT = '[REDACTED]'
+const CIRCULAR_REF = '[Circular]'
 
 export const redactString = (text: string): string => {
   let result = text
@@ -16,7 +17,68 @@ export const redactString = (text: string): string => {
   return result
 }
 
-export const redact = <T>(value: T): T => {
+const redactErrorClone = (
+  originalError: Error,
+  inProgress: WeakSet<object>
+): Error & Record<string, unknown> => {
+  const redactedMessage = redactString(originalError.message)
+  const proto = Object.getPrototypeOf(originalError) as object
+  const newError = Object.create(proto) as Error & Record<string, unknown>
+
+  newError.message = redactedMessage
+  newError.name = originalError.name
+
+  if (originalError.stack !== undefined) {
+    newError.stack = redactString(originalError.stack)
+  }
+
+  const errorRecord = originalError as unknown as Record<string, unknown>
+
+  for (const key of Object.keys(errorRecord)) {
+    if (key !== 'message' && key !== 'name' && key !== 'stack') {
+      newError[key] = redactInner(errorRecord[key], inProgress)
+    }
+  }
+
+  return newError
+}
+
+const redactArrayItems = (
+  value: unknown[],
+  inProgress: WeakSet<object>
+): unknown[] => {
+  const redactedArray: unknown[] = Array.from({ length: value.length })
+  for (let i = 0; i < value.length; i++) {
+    redactedArray[i] = redactInner(value[i], inProgress)
+  }
+  return redactedArray
+}
+
+const redactRecordEntries = (
+  recordValue: Record<string, unknown>,
+  inProgress: WeakSet<object>
+): Record<string, unknown> => {
+  const redactedRecord: Record<string, unknown> = {}
+  for (const key of Object.keys(recordValue)) {
+    redactedRecord[key] = redactInner(recordValue[key], inProgress)
+  }
+  return redactedRecord
+}
+
+const withReentrancyGuard = <T>(
+  obj: object,
+  inProgress: WeakSet<object>,
+  run: () => T
+): T => {
+  inProgress.add(obj)
+  try {
+    return run()
+  } finally {
+    inProgress.delete(obj)
+  }
+}
+
+const redactInner = <T>(value: T, inProgress: WeakSet<object>): T => {
   if (value === null || value === undefined) {
     return value
   }
@@ -34,49 +96,29 @@ export const redact = <T>(value: T): T => {
     return new Date(value.getTime()) as unknown as T
   }
 
+  const obj = value as object
+  if (inProgress.has(obj)) {
+    return CIRCULAR_REF as unknown as T
+  }
+
   if (value instanceof Error) {
-    const originalError = value
-    const redactedMessage = redactString(originalError.message)
-    const proto = Object.getPrototypeOf(originalError) as object
-    const newError = Object.create(proto) as Error & Record<string, unknown>
-
-    newError.message = redactedMessage
-    newError.name = originalError.name
-
-    if (originalError.stack !== undefined) {
-      newError.stack = redactString(originalError.stack)
-    }
-
-    const errorRecord = originalError as unknown as Record<string, unknown>
-
-    for (const key of Object.keys(errorRecord)) {
-      if (key !== 'message' && key !== 'name' && key !== 'stack') {
-        newError[key] = redact(errorRecord[key])
-      }
-    }
-
-    return newError as unknown as T
+    return withReentrancyGuard(obj, inProgress, () =>
+      redactErrorClone(value, inProgress)
+    ) as unknown as T
   }
 
   if (Array.isArray(value)) {
-    const redactedArray = Array.from({ length: value.length })
-
-    for (let i = 0; i < value.length; i++) {
-      redactedArray[i] = redact(value[i])
-    }
-
-    return redactedArray as unknown as T
+    return withReentrancyGuard(obj, inProgress, () =>
+      redactArrayItems(value, inProgress)
+    ) as unknown as T
   }
 
-  const recordValue = value as Record<string, unknown>
-  const redactedRecord: Record<string, unknown> = {}
-
-  for (const key of Object.keys(recordValue)) {
-    redactedRecord[key] = redact(recordValue[key])
-  }
-
-  return redactedRecord as unknown as T
+  return withReentrancyGuard(obj, inProgress, () =>
+    redactRecordEntries(value as Record<string, unknown>, inProgress)
+  ) as unknown as T
 }
+
+export const redact = <T>(value: T): T => redactInner(value, new WeakSet())
 
 /**
  * Clone request URL and headers for logging with the same string redaction as {@link redact}.

--- a/packages/logixlysia/src/utils/redact.ts
+++ b/packages/logixlysia/src/utils/redact.ts
@@ -10,6 +10,34 @@ const PAN_MAX_LEN = 19
 const REDACTED_TEXT = '[REDACTED]'
 const CIRCULAR_REF = '[Circular]'
 
+/**
+ * Host and userinfo cannot contain `[REDACTED]` — `[` begins an IPv6 literal in URLs and breaks parsing.
+ */
+const URL_SAFE_REDACT = 'redacted'
+
+const redactUrlAuthoritySegment = (value: string): string =>
+  redactString(value).replaceAll(REDACTED_TEXT, URL_SAFE_REDACT)
+
+/** Apply PII redaction to a request URL while keeping the result parseable by the URL/Request constructors. */
+const redactRequestUrl = (urlString: string): string => {
+  try {
+    const u = new URL(urlString)
+    if (u.username !== '') {
+      u.username = redactUrlAuthoritySegment(u.username)
+    }
+    if (u.password !== '') {
+      u.password = redactUrlAuthoritySegment(u.password)
+    }
+    u.hostname = redactUrlAuthoritySegment(u.hostname)
+    u.pathname = redactString(u.pathname)
+    u.search = redactString(u.search)
+    u.hash = redactString(u.hash)
+    return u.toString()
+  } catch {
+    return redactString(urlString).replaceAll(REDACTED_TEXT, URL_SAFE_REDACT)
+  }
+}
+
 /** Luhn checksum; `digits` must contain only `0-9` and length in PAN range. */
 const passesLuhn = (digits: string): boolean => {
   if (digits.length < PAN_MIN_LEN || digits.length > PAN_MAX_LEN) {
@@ -170,7 +198,7 @@ export const redact = <T>(value: T): T => redactInner(value, new WeakSet())
  * Preserves body and signal so the original request is still usable.
  */
 export const redactRequest = (request: Request): Request => {
-  const redactedUrl = redactString(request.url)
+  const redactedUrl = redactRequestUrl(request.url)
   const nextHeaders = new Headers()
   let headersChanged = false
 

--- a/packages/logixlysia/src/utils/redact.ts
+++ b/packages/logixlysia/src/utils/redact.ts
@@ -76,3 +76,44 @@ export const redact = <T>(value: T): T => {
 
   return redactedRecord as unknown as T
 }
+
+/**
+ * Clone request URL and headers for logging with the same string redaction as {@link redact}.
+ * Preserves body and signal so the original request is still usable.
+ */
+export const redactRequest = (request: Request): Request => {
+  const redactedUrl = redactString(request.url)
+  const nextHeaders = new Headers()
+  let headersChanged = false
+
+  for (const [name, value] of request.headers.entries()) {
+    const redacted = redactString(value)
+    if (redacted !== value) {
+      headersChanged = true
+    }
+    nextHeaders.set(name, redacted)
+  }
+
+  const redactedMethod = redactString(request.method)
+  const urlChanged = redactedUrl !== request.url
+  const methodChanged = redactedMethod !== request.method
+
+  if (!(urlChanged || headersChanged || methodChanged)) {
+    return request
+  }
+
+  const init: RequestInit & { duplex?: 'half' } = {
+    method: redactedMethod,
+    headers: nextHeaders,
+    redirect: request.redirect,
+    signal: request.signal
+  }
+
+  if (request.body !== null) {
+    init.body = request.body
+    init.duplex = 'half'
+  }
+
+  return new Request(redactedUrl, init)
+}
+

--- a/packages/logixlysia/src/utils/redact.ts
+++ b/packages/logixlysia/src/utils/redact.ts
@@ -1,0 +1,78 @@
+const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g
+const IPV4_REGEX = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g
+const CREDIT_CARD_REGEX = /\b(?:\d[ -]*?){13,16}\b/g
+const JWT_REGEX = /eyJ[a-zA-Z0-9_-]+\.eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g
+
+const REDACTED_TEXT = '[REDACTED]'
+
+export const redactString = (text: string): string => {
+  let result = text
+
+  result = result.replace(EMAIL_REGEX, REDACTED_TEXT)
+  result = result.replace(IPV4_REGEX, REDACTED_TEXT)
+  result = result.replace(CREDIT_CARD_REGEX, REDACTED_TEXT)
+  result = result.replace(JWT_REGEX, REDACTED_TEXT)
+
+  return result
+}
+
+export const redact = <T>(value: T): T => {
+  if (value === null || value === undefined) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    return redactString(value) as unknown as T
+  }
+
+  const type = typeof value
+  if (type !== 'object') {
+    return value
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as unknown as T
+  }
+
+  if (value instanceof Error) {
+    const originalError = value
+    const redactedMessage = redactString(originalError.message)
+    const newError = new Error(redactedMessage)
+
+    newError.name = originalError.name
+
+    if (originalError.stack !== undefined) {
+      newError.stack = redactString(originalError.stack)
+    }
+
+    const errorRecord = originalError as unknown as Record<string, unknown>
+    const newErrorRecord = newError as unknown as Record<string, unknown>
+
+    for (const key of Object.keys(errorRecord)) {
+      if (key !== 'message' && key !== 'name' && key !== 'stack') {
+        newErrorRecord[key] = redact(errorRecord[key])
+      }
+    }
+
+    return newError as unknown as T
+  }
+
+  if (Array.isArray(value)) {
+    const redactedArray = Array.from({ length: value.length })
+
+    for (let i = 0; i < value.length; i++) {
+      redactedArray[i] = redact(value[i])
+    }
+
+    return redactedArray as unknown as T
+  }
+
+  const recordValue = value as Record<string, unknown>
+  const redactedRecord: Record<string, unknown> = {}
+
+  for (const key of Object.keys(recordValue)) {
+    redactedRecord[key] = redact(recordValue[key])
+  }
+
+  return redactedRecord as unknown as T
+}

--- a/packages/logixlysia/src/utils/redact.ts
+++ b/packages/logixlysia/src/utils/redact.ts
@@ -1,17 +1,62 @@
 const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g
 const IPV4_REGEX = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g
-const CREDIT_CARD_REGEX = /\b(?:\d[ -]*?){13,16}\b/g
+/** Digit runs that may be formatted PANs (spaces/dashes); validated with Luhn before redacting. */
+const CREDIT_CARD_CANDIDATE_REGEX = /\b(?:\d[ -]*?){13,19}\b/g
 const JWT_REGEX = /eyJ[a-zA-Z0-9_-]+\.eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g
+
+const PAN_MIN_LEN = 13
+const PAN_MAX_LEN = 19
 
 const REDACTED_TEXT = '[REDACTED]'
 const CIRCULAR_REF = '[Circular]'
+
+/** Luhn checksum; `digits` must contain only `0-9` and length in PAN range. */
+const passesLuhn = (digits: string): boolean => {
+  if (digits.length < PAN_MIN_LEN || digits.length > PAN_MAX_LEN) {
+    return false
+  }
+
+  let sum = 0
+  let alternate = false
+
+  for (let i = digits.length - 1; i >= 0; i--) {
+    const code = digits.charCodeAt(i)
+    if (code < 48 || code > 57) {
+      return false
+    }
+    let n = code - 48
+    if (alternate) {
+      n *= 2
+      if (n > 9) {
+        n -= 9
+      }
+    }
+    sum += n
+    alternate = !alternate
+  }
+
+  return sum % 10 === 0
+}
+
+const redactCreditCardCandidates = (text: string): string =>
+  text.replace(CREDIT_CARD_CANDIDATE_REGEX, match => {
+    const digits = match.replace(/\D/g, '')
+    if (
+      digits.length >= PAN_MIN_LEN &&
+      digits.length <= PAN_MAX_LEN &&
+      passesLuhn(digits)
+    ) {
+      return REDACTED_TEXT
+    }
+    return match
+  })
 
 export const redactString = (text: string): string => {
   let result = text
 
   result = result.replace(EMAIL_REGEX, REDACTED_TEXT)
   result = result.replace(IPV4_REGEX, REDACTED_TEXT)
-  result = result.replace(CREDIT_CARD_REGEX, REDACTED_TEXT)
+  result = redactCreditCardCandidates(result)
   result = result.replace(JWT_REGEX, REDACTED_TEXT)
 
   return result

--- a/packages/logixlysia/src/utils/redact.ts
+++ b/packages/logixlysia/src/utils/redact.ts
@@ -37,8 +37,10 @@ export const redact = <T>(value: T): T => {
   if (value instanceof Error) {
     const originalError = value
     const redactedMessage = redactString(originalError.message)
-    const newError = new Error(redactedMessage)
+    const proto = Object.getPrototypeOf(originalError) as object
+    const newError = Object.create(proto) as Error & Record<string, unknown>
 
+    newError.message = redactedMessage
     newError.name = originalError.name
 
     if (originalError.stack !== undefined) {
@@ -46,11 +48,10 @@ export const redact = <T>(value: T): T => {
     }
 
     const errorRecord = originalError as unknown as Record<string, unknown>
-    const newErrorRecord = newError as unknown as Record<string, unknown>
 
     for (const key of Object.keys(errorRecord)) {
       if (key !== 'message' && key !== 'name' && key !== 'stack') {
-        newErrorRecord[key] = redact(errorRecord[key])
+        newError[key] = redact(errorRecord[key])
       }
     }
 
@@ -116,4 +117,3 @@ export const redactRequest = (request: Request): Request => {
 
   return new Request(redactedUrl, init)
 }
-


### PR DESCRIPTION
## Description

Introduced a new `autoRedact` boolean configuration option. When enabled, it automatically redacts sensitive PII from strings, deeply nested objects, arrays, Error objects (including custom errors and HttpError), and incoming Request properties (URL, headers) before logging. Redacted values are replaced with `[REDACTED]`. This provides an out-of-the-box safeguard for secure logging practices.

## Related Issues

Closes #277

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

<!-- Add any additional information or context about the pull request here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `autoRedact` option (default: false) to automatically redact emails, IPs, credit cards, and JWTs from logs, errors, and request data; demo endpoint exercises it.

* **Documentation**
  * Updated API reference, configuration, and usage examples to document `autoRedact`.

* **Tests**
  * Added tests covering redaction for strings, requests, errors, nested/circular structures, and logger output.

* **Chores**
  * Minor formatting and package metadata updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->