### PR TITLE
perf(logixlysia): optimize log formatting and add early bailout

### DIFF
--- a/.changeset/smooth-mice-dance.md
+++ b/.changeset/smooth-mice-dance.md
@@ -1,0 +1,8 @@
+---
+"logixlysia": patch
+---
+
+- Optimized log formatting performance by replacing multiple `.replaceAll()` calls with a single-pass regex replacement in `formatLogOutput` and `formatTimestamp`.
+- Optimized `getIp` string slicing to reduce array allocations.
+- Fixed a bug where padded HTTP methods (e.g., `GET    `) lost their color formatting.
+- Added early bailout logic to bypass allocations and system calls when logging is effectively disabled, significantly improving disabled-state benchmark performance.

--- a/.changeset/smooth-mice-dance.md
+++ b/.changeset/smooth-mice-dance.md
@@ -4,5 +4,5 @@
 
 - Optimized log formatting performance by replacing multiple `.replaceAll()` calls with a single-pass regex replacement in `formatLogOutput` and `formatTimestamp`.
 - Optimized `getIp` string slicing to reduce array allocations.
-- Fixed a bug where padded HTTP methods (e.g., `GET    `) lost their color formatting.
+- Fixed a bug where padded HTTP methods (e.g., `GET`) lost their color formatting.
 - Added early bailout logic to bypass allocations and system calls when logging is effectively disabled, significantly improving disabled-state benchmark performance.

--- a/packages/logixlysia/src/logger/create-logger.ts
+++ b/packages/logixlysia/src/logger/create-logger.ts
@@ -20,6 +20,9 @@ const METHOD_PAD = 7
 const DEFAULT_LOG_FORMAT =
   '{now} {service}{icon} {method} {pathname} {status} {duration} {message}{speed}'
 
+const LOG_FORMAT_REGEX =
+  /\{(now|epoch|level|icon|duration|method|pathname|path|status|statusText|message|ip|context|service|speed)\}/g
+
 export interface FormattedLogOutput {
   contextLines: string[]
   main: string
@@ -451,9 +454,6 @@ export const formatLogOutput = ({
   const icon = getLevelIcon(level, useColors)
   const statusText = getStatusText(statusCode)
   const serviceToken = getServiceToken(options, useColors)
-
-  const LOG_FORMAT_REGEX =
-    /\{(now|epoch|level|icon|duration|method|pathname|path|status|statusText|message|ip|context|service|speed)\}/g
 
   const tokenMap: Record<string, string> = {
     '{now}': timestamp,

--- a/packages/logixlysia/src/logger/create-logger.ts
+++ b/packages/logixlysia/src/logger/create-logger.ts
@@ -452,22 +452,28 @@ export const formatLogOutput = ({
   const statusText = getStatusText(statusCode)
   const serviceToken = getServiceToken(options, useColors)
 
-  const main = format
-    .replaceAll('{now}', timestamp)
-    .replaceAll('{epoch}', epoch)
-    .replaceAll('{level}', coloredLevel)
-    .replaceAll('{icon}', icon)
-    .replaceAll('{duration}', coloredDuration)
-    .replaceAll('{method}', coloredMethod)
-    .replaceAll('{pathname}', coloredPathname)
-    .replaceAll('{path}', coloredPathname)
-    .replaceAll('{status}', coloredStatus)
-    .replaceAll('{statusText}', statusText)
-    .replaceAll('{message}', message)
-    .replaceAll('{ip}', ip)
-    .replaceAll('{context}', ctxString)
-    .replaceAll('{service}', serviceToken)
-    .replaceAll('{speed}', speedToken)
+  const LOG_FORMAT_REGEX =
+    /\{(now|epoch|level|icon|duration|method|pathname|path|status|statusText|message|ip|context|service|speed)\}/g
+
+  const tokenMap: Record<string, string> = {
+    '{now}': timestamp,
+    '{epoch}': epoch,
+    '{level}': coloredLevel,
+    '{icon}': icon,
+    '{duration}': coloredDuration,
+    '{method}': coloredMethod,
+    '{pathname}': coloredPathname,
+    '{path}': coloredPathname,
+    '{status}': coloredStatus,
+    '{statusText}': statusText,
+    '{message}': message,
+    '{ip}': ip,
+    '{context}': ctxString,
+    '{service}': serviceToken,
+    '{speed}': speedToken
+  }
+
+  const main = format.replace(LOG_FORMAT_REGEX, match => tokenMap[match] ?? match)
 
   const contextLines = buildContextTreeLines(level, data, options)
 

--- a/packages/logixlysia/src/logger/index.ts
+++ b/packages/logixlysia/src/logger/index.ts
@@ -68,14 +68,22 @@ export const createLogger = (
     return logFilter.level.includes(level)
   }
 
+  const useTransportsOnly = config?.useTransportsOnly === true
+  const disableInternalLogger = config?.disableInternalLogger === true
+  const disableFileLogging = config?.disableFileLogging === true
+
+  const hasTransports = (config?.transports?.length ?? 0) > 0
+  const hasFileLogging = !useTransportsOnly && !disableFileLogging && !!config?.logFilePath
+  const hasInternalLogger = !useTransportsOnly && !disableInternalLogger
+  const isEffectivelyDisabled = !hasTransports && !hasFileLogging && !hasInternalLogger
+
   const log = (
     level: LogLevel,
     request: RequestInfo,
     data: Record<string, unknown>,
     store: StoreData
   ): void => {
-    // Check if this log level should be filtered
-    if (!shouldLog(level, config?.logFilter)) {
+    if (isEffectivelyDisabled || !shouldLog(level, config?.logFilter)) {
       return
     }
 
@@ -83,19 +91,17 @@ export const createLogger = (
     const logRequest =
       config?.autoRedact === true ? redactRequest(request) : request
 
-    logToTransports({
-      level,
-      request: logRequest,
-      data: logData,
-      store,
-      options
-    })
+    if (hasTransports) {
+      logToTransports({
+        level,
+        request: logRequest,
+        data: logData,
+        store,
+        options
+      })
+    }
 
-    const useTransportsOnly = config?.useTransportsOnly === true
-    const disableInternalLogger = config?.disableInternalLogger === true
-    const disableFileLogging = config?.disableFileLogging === true
-
-    if (!(useTransportsOnly || disableFileLogging)) {
+    if (hasFileLogging) {
       const filePath = config?.logFilePath
       if (filePath) {
         logToFile({
@@ -111,7 +117,7 @@ export const createLogger = (
       }
     }
 
-    if (useTransportsOnly || disableInternalLogger) {
+    if (!hasInternalLogger) {
       return
     }
 
@@ -155,6 +161,9 @@ export const createLogger = (
     message: string,
     context?: Record<string, unknown>
   ): void => {
+    if (isEffectivelyDisabled || !shouldLog(level, config?.logFilter)) {
+      return
+    }
     const store: StoreData = { beforeTime: process.hrtime.bigint() }
     log(level, request, { message, context }, store)
   }


### PR DESCRIPTION
## Description

This PR introduces several performance optimizations and bug fixes to the core logging hot-path. 

**Problem:**
- Inefficient log formatting using chained `.replaceAll()` calls, leading to multiple string allocations per request.
- Padded HTTP methods (e.g., `GET    `) failing to match color cases.
- High disabled-state overhead in benchmarks due to unconditional system calls and allocations.

**Solution:**
- **Single-Pass Formatting:** Replaced chained replacements with a single-pass regex and `tokenMap` in `formatLogOutput` and `formatTimestamp`.
- **Early Bailout:** Added an `isEffectivelyDisabled` check to immediately return from logging methods when no output is configured, bypassing `process.hrtime.bigint()`.
- **Method Coloring Fix:** Updated `getColoredMethod` to trim strings before case matching while preserving padding in the output.
- **IP Parsing:** Optimized header parsing to use string slicing instead of array splitting.

**Result:**
Significant performance improvement. Benchmark results show `logixlysia` is now the fastest logger across all string and object logging tests, matching or beating the competition's disabled-state overhead.

## Related Issues

None.

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

N/A

## Additional Notes

These changes maintain full backward compatibility while drastically reducing the per-request CPU and memory overhead of the plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed color formatting for padded HTTP methods in logs.

* **Performance**
  * Faster log formatting via optimized token substitution.
  * Reduced memory allocations when obtaining IP addresses.
  * Added early-exit logic to skip logging work when logging is disabled.

* **Refactor**
  * Logging flow reworked to avoid unnecessary processing when features are disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PunGrumpy/logixlysia/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->