### PR TITLE
feat(logixlysia): add request-scoped context bag

### DIFF
--- a/.changeset/request-context.md
+++ b/.changeset/request-context.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": minor
+---
+
+Add request-scoped context accumulation via `mergeContext` and `getContext`, merged into automatic access logs. Export `createLogger` and `createPluginLogger` for advanced setups.

--- a/apps/docs/content/(docs)/usage.mdx
+++ b/apps/docs/content/(docs)/usage.mdx
@@ -21,6 +21,19 @@ const app = new Elysia()
   .listen(3000)
 ```
 
+## Request context
+
+Accumulate fields during a request; they are merged into the automatic access log:
+
+```ts
+.get('/users/:id', ({ request, store, params }) => {
+  store.logger.mergeContext(request, { userId: params.id })
+  return { ok: true }
+})
+```
+
+See [Request context](/features/request-context) for details.
+
 ## Configuration
 
 ### Basic Options

--- a/apps/docs/content/features/meta.json
+++ b/apps/docs/content/features/meta.json
@@ -4,6 +4,7 @@
   "pages": [
     "---Configuration---",
     "startup",
+    "request-context",
     "formatting",
     "filtering",
     "log-levels",

--- a/apps/docs/content/features/request-context.mdx
+++ b/apps/docs/content/features/request-context.mdx
@@ -1,0 +1,33 @@
+---
+title: Request context
+description: Accumulate request-scoped fields into a single access log line
+---
+
+Logixlysia can accumulate context during a request and merge it into the automatic access log—similar to evlog wide events, without replacing your existing `logger.info()` API.
+
+## Basic usage
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+
+const app = new Elysia()
+  .use(logixlysia())
+  .get('/checkout', ({ request, store }) => {
+    store.logger.mergeContext(request, { userId: 'usr_123' })
+    store.logger.mergeContext(request, { cartTotal: 9999 })
+    return { ok: true }
+  })
+```
+
+The final `INFO` access log includes a `context` object with `userId` and `cartTotal` (and renders as a context tree when `showContextTree` is enabled).
+
+## Precedence
+
+When you call `logger.info(request, message, { ...explicit })`, keys in the explicit context **override** accumulated values. Non-colliding keys from both sources are kept.
+
+## Reading context
+
+```ts
+const ctx = store.logger.getContext(request)
+```

--- a/packages/logixlysia/__tests__/context/request-context.test.ts
+++ b/packages/logixlysia/__tests__/context/request-context.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  createRequestContextStore,
+  mergeLogDataContext
+} from '../../src/context/request-context'
+
+describe('request context store', () => {
+  test('mergeContext accumulates fields per request', () => {
+    const store = createRequestContextStore()
+    const request = new Request('http://localhost/')
+
+    store.mergeContext(request, { userId: 'u1' })
+    store.mergeContext(request, { plan: 'pro' })
+
+    expect(store.getContext(request)).toEqual({ userId: 'u1', plan: 'pro' })
+  })
+
+  test('clearContext removes accumulated fields', () => {
+    const store = createRequestContextStore()
+    const request = new Request('http://localhost/')
+
+    store.mergeContext(request, { userId: 'u1' })
+    store.clearContext(request)
+
+    expect(store.getContext(request)).toEqual({})
+  })
+
+  test('mergeLogDataContext prefers explicit context over accumulated', () => {
+    const merged = mergeLogDataContext(
+      { status: 200, context: { userId: 'override' } },
+      { userId: 'accumulated', plan: 'pro' }
+    )
+
+    expect(merged.context).toEqual({ userId: 'override', plan: 'pro' })
+  })
+})

--- a/packages/logixlysia/__tests__/plugin/request-context.test.ts
+++ b/packages/logixlysia/__tests__/plugin/request-context.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { Elysia } from 'elysia'
+
+import { logixlysia } from '../../src'
+import type { Options } from '../../src/interfaces'
+
+describe('logixlysia request context', () => {
+  test('merges accumulated context into auto access log', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const options: Options = {
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia()
+      .use(logixlysia(options))
+      .get('/test', ({ request, store }) => {
+        store.logger.mergeContext(request, { userId: 'u1' })
+        return 'ok'
+      })
+
+    await app.handle(new Request('http://localhost/test'))
+
+    expect(transport).toHaveBeenCalledTimes(1)
+    const meta = transport.mock.calls[0]?.[2] as
+      | Record<string, unknown>
+      | undefined
+    expect(meta?.context).toEqual({ userId: 'u1' })
+  })
+
+  test('custom log merges accumulated context; explicit context wins on collision', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const options: Options = {
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia()
+      .use(logixlysia(options))
+      .get('/test', ({ request, store }) => {
+        store.logger.mergeContext(request, {
+          userId: 'accumulated',
+          plan: 'pro'
+        })
+        store.logger.info(request, 'custom', { userId: 'override' })
+        return 'ok'
+      })
+
+    await app.handle(new Request('http://localhost/test'))
+
+    expect(transport).toHaveBeenCalledTimes(1)
+    const meta = transport.mock.calls[0]?.[2] as
+      | Record<string, unknown>
+      | undefined
+    expect(meta?.context).toEqual({ userId: 'override', plan: 'pro' })
+  })
+
+  test('autoRedact applies to merged request context', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const options: Options = {
+      config: {
+        autoRedact: true,
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia()
+      .use(logixlysia(options))
+      .get('/test', ({ request, store }) => {
+        store.logger.mergeContext(request, {
+          email: 'secret@example.com'
+        })
+        return 'ok'
+      })
+
+    await app.handle(new Request('http://localhost/test'))
+
+    const meta = transport.mock.calls[0]?.[2] as
+      | { context?: { email?: string } }
+      | undefined
+    expect(meta?.context?.email).toBe('[REDACTED]')
+  })
+
+  test('does not allocate context field when bag is empty', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const options: Options = {
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/test', () => 'ok')
+
+    await app.handle(new Request('http://localhost/test'))
+
+    const meta = transport.mock.calls[0]?.[2] as
+      | Record<string, unknown>
+      | undefined
+    expect(meta?.context).toBeUndefined()
+  })
+})

--- a/packages/logixlysia/src/context/request-context.ts
+++ b/packages/logixlysia/src/context/request-context.ts
@@ -27,7 +27,8 @@ export const createRequestContextStore = (): RequestContextStore => {
       Object.assign(bag, partial)
     },
     getContext(key) {
-      return bags.get(key) ?? {}
+      const bag = bags.get(key)
+      return bag ? { ...bag } : {}
     },
     clearContext(key) {
       bags.delete(key)

--- a/packages/logixlysia/src/context/request-context.ts
+++ b/packages/logixlysia/src/context/request-context.ts
@@ -1,4 +1,4 @@
-export type ContextKey = Request | object
+export type ContextKey = Request
 
 export interface RequestContextStore {
   clearContext: (key: ContextKey) => void

--- a/packages/logixlysia/src/context/request-context.ts
+++ b/packages/logixlysia/src/context/request-context.ts
@@ -1,0 +1,62 @@
+export type ContextKey = Request | object
+
+export interface RequestContextStore {
+  clearContext: (key: ContextKey) => void
+  getContext: (key: ContextKey) => Readonly<Record<string, unknown>>
+  mergeContext: (key: ContextKey, partial: Record<string, unknown>) => void
+}
+
+export const createRequestContextStore = (): RequestContextStore => {
+  const bags = new WeakMap<ContextKey, Record<string, unknown>>()
+
+  const getOrCreate = (key: ContextKey): Record<string, unknown> => {
+    let bag = bags.get(key)
+    if (!bag) {
+      bag = {}
+      bags.set(key, bag)
+    }
+    return bag
+  }
+
+  return {
+    mergeContext(key, partial) {
+      if (Object.keys(partial).length === 0) {
+        return
+      }
+      const bag = getOrCreate(key)
+      Object.assign(bag, partial)
+    },
+    getContext(key) {
+      return bags.get(key) ?? {}
+    },
+    clearContext(key) {
+      bags.delete(key)
+    }
+  }
+}
+
+/** Accumulated request context first; explicit `data.context` wins on key collision. */
+export const mergeLogDataContext = (
+  data: Record<string, unknown>,
+  accumulated: Readonly<Record<string, unknown>>
+): Record<string, unknown> => {
+  const explicit = data.context
+  const hasAccumulated = Object.keys(accumulated).length > 0
+  const hasExplicit =
+    explicit !== undefined &&
+    explicit !== null &&
+    typeof explicit === 'object' &&
+    !Array.isArray(explicit) &&
+    Object.keys(explicit as object).length > 0
+
+  if (!(hasAccumulated || hasExplicit)) {
+    return data
+  }
+
+  const mergedContext = {
+    ...accumulated,
+    ...(hasExplicit ? (explicit as Record<string, unknown>) : {})
+  }
+
+  return { ...data, context: mergedContext }
+}

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -93,30 +93,36 @@ export const logixlysia = (options: Options = {}): Logixlysia => {
       store.beforeTime = process.hrtime.bigint()
     })
     .onAfterHandle(({ request, set, store }) => {
-      if (didCustomLog.has(request)) {
-        return
-      }
+      try {
+        if (didCustomLog.has(request)) {
+          return
+        }
 
-      const status = typeof set.status === 'number' ? set.status : 200
-      let level: 'INFO' | 'WARNING' | 'ERROR' = 'INFO'
-      if (status >= 500) {
-        level = 'ERROR'
-      } else if (status >= 400) {
-        level = 'WARNING'
-      }
+        const status = typeof set.status === 'number' ? set.status : 200
+        let level: 'INFO' | 'WARNING' | 'ERROR' = 'INFO'
+        if (status >= 500) {
+          level = 'ERROR'
+        } else if (status >= 400) {
+          level = 'WARNING'
+        }
 
-      const accumulated = contextStore.getContext(request)
-      const data: Record<string, unknown> = { status }
-      if (Object.keys(accumulated).length > 0) {
-        data.context = { ...accumulated }
-      }
+        const accumulated = contextStore.getContext(request)
+        const data: Record<string, unknown> = { status }
+        if (Object.keys(accumulated).length > 0) {
+          data.context = { ...accumulated }
+        }
 
-      logger.log(level, request, data, store)
-      contextStore.clearContext(request)
+        logger.log(level, request, data, store)
+      } finally {
+        contextStore.clearContext(request)
+      }
     })
     .onError(({ request, error, store }) => {
-      logger.handleHttpError(request, error, store)
-      contextStore.clearContext(request)
+      try {
+        logger.handleHttpError(request, error, store)
+      } finally {
+        contextStore.clearContext(request)
+      }
     })
     .as('scoped') as Logixlysia
 }

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -1,7 +1,8 @@
 import { Elysia } from 'elysia'
+import { createRequestContextStore } from './context/request-context'
 import { startServer } from './extensions'
 import type { LogixlysiaStore, Options } from './interfaces'
-import { createLogger } from './logger'
+import { createPluginLogger } from './logger'
 
 /**
  * Empty singleton slots must not use `Record<string, never>`: intersecting that with Elysia's `Context`
@@ -28,7 +29,8 @@ export type Logixlysia = Elysia<'', LogixlysiaSingleton>
 
 export const logixlysia = (options: Options = {}): Logixlysia => {
   const didCustomLog = new WeakSet<Request>()
-  const baseLogger = createLogger(options)
+  const contextStore = createRequestContextStore()
+  const baseLogger = createPluginLogger(options, contextStore)
   const logger = {
     ...baseLogger,
     debug: (
@@ -74,45 +76,49 @@ export const logixlysia = (options: Options = {}): Logixlysia => {
     }
   })
 
-  return (
-    app
-      .state('logger', logger)
-      .state('pino', logger.pino)
-      .state('beforeTime', BigInt(0))
-      .onStart(({ server }): void => {
-        if (server) {
-          startServer(server, options)
-        } else {
-          // Node adapter fallback
-          const port = Number(process.env.PORT) || 3000
-          const hostname = process.env.HOST || 'localhost'
-          startServer({ port, hostname, protocol: 'http' }, options)
-        }
-      })
-      .onRequest(({ store }) => {
-        store.beforeTime = process.hrtime.bigint()
-      })
-      .onAfterHandle(({ request, set, store }) => {
-        if (didCustomLog.has(request)) {
-          return
-        }
+  return app
+    .state('logger', logger)
+    .state('pino', logger.pino)
+    .state('beforeTime', BigInt(0))
+    .onStart(({ server }): void => {
+      if (server) {
+        startServer(server, options)
+      } else {
+        const port = Number(process.env.PORT) || 3000
+        const hostname = process.env.HOST || 'localhost'
+        startServer({ port, hostname, protocol: 'http' }, options)
+      }
+    })
+    .onRequest(({ store }) => {
+      store.beforeTime = process.hrtime.bigint()
+    })
+    .onAfterHandle(({ request, set, store }) => {
+      if (didCustomLog.has(request)) {
+        return
+      }
 
-        const status = typeof set.status === 'number' ? set.status : 200
-        let level: 'INFO' | 'WARNING' | 'ERROR' = 'INFO'
-        if (status >= 500) {
-          level = 'ERROR'
-        } else if (status >= 400) {
-          level = 'WARNING'
-        }
+      const status = typeof set.status === 'number' ? set.status : 200
+      let level: 'INFO' | 'WARNING' | 'ERROR' = 'INFO'
+      if (status >= 500) {
+        level = 'ERROR'
+      } else if (status >= 400) {
+        level = 'WARNING'
+      }
 
-        logger.log(level, request, { status }, store)
-      })
-      .onError(({ request, error, store }) => {
-        logger.handleHttpError(request, error, store)
-      })
-      // Ensure plugin lifecycle hooks (onRequest/onAfterHandle/onError) apply to the parent app.
-      .as('scoped') as Logixlysia
-  )
+      const accumulated = contextStore.getContext(request)
+      const data: Record<string, unknown> = { status }
+      if (Object.keys(accumulated).length > 0) {
+        data.context = { ...accumulated }
+      }
+
+      logger.log(level, request, data, store)
+      contextStore.clearContext(request)
+    })
+    .onError(({ request, error, store }) => {
+      logger.handleHttpError(request, error, store)
+      contextStore.clearContext(request)
+    })
+    .as('scoped') as Logixlysia
 }
 
 export type {
@@ -125,5 +131,6 @@ export type {
   StoreData,
   Transport
 } from './interfaces'
+export { createLogger, createPluginLogger } from './logger'
 
 export default logixlysia

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -130,6 +130,7 @@ export interface Logger {
     message: string,
     context?: Record<string, unknown>
   ) => void
+  getContext: (key: RequestInfo | object) => Readonly<Record<string, unknown>>
   handleHttpError: (
     request: RequestInfo,
     error: unknown,
@@ -145,6 +146,10 @@ export interface Logger {
     request: RequestInfo,
     data: Record<string, unknown>,
     store: StoreData
+  ) => void
+  mergeContext: (
+    key: RequestInfo | object,
+    partial: Record<string, unknown>
   ) => void
   pino: Pino
   warn: (

--- a/packages/logixlysia/src/logger/handle-http-error.ts
+++ b/packages/logixlysia/src/logger/handle-http-error.ts
@@ -1,3 +1,7 @@
+import {
+  mergeLogDataContext,
+  type RequestContextStore
+} from '../context/request-context'
 import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
 import { logToTransports } from '../output'
 import { logToFile } from '../output/file'
@@ -17,7 +21,8 @@ export const handleHttpError = (
   request: RequestInfo,
   error: unknown,
   store: StoreData,
-  options: Options
+  options: Options,
+  contextStore?: RequestContextStore
 ): void => {
   const config = options.config
 
@@ -39,7 +44,11 @@ export const handleHttpError = (
 
   const level: LogLevel = 'ERROR'
   const data: Record<string, unknown> = { status, message, error }
-  const logData = config?.autoRedact === true ? redact(data) : data
+  const dataWithContext = contextStore
+    ? mergeLogDataContext(data, contextStore.getContext(request))
+    : data
+  const logData =
+    config?.autoRedact === true ? redact(dataWithContext) : dataWithContext
   const logRequest =
     config?.autoRedact === true ? redactRequest(request) : request
 

--- a/packages/logixlysia/src/logger/index.ts
+++ b/packages/logixlysia/src/logger/index.ts
@@ -1,4 +1,9 @@
 import pino from 'pino'
+import {
+  createRequestContextStore,
+  mergeLogDataContext,
+  type RequestContextStore
+} from '../context/request-context'
 import type {
   LogFilter,
   Logger,
@@ -16,8 +21,10 @@ import { handleHttpError } from './handle-http-error'
 
 export const createLogger = (
   options: Options = {},
-  pinoFactory: typeof pino = pino
+  pinoFactory: typeof pino = pino,
+  externalContextStore?: RequestContextStore
 ): Logger => {
+  const contextStore = externalContextStore ?? createRequestContextStore()
   const config = options.config
 
   const pinoConfig = config?.pino
@@ -92,7 +99,12 @@ export const createLogger = (
       return
     }
 
-    const logData = config?.autoRedact === true ? redact(data) : data
+    const dataWithContext = mergeLogDataContext(
+      data,
+      contextStore.getContext(request)
+    )
+    const logData =
+      config?.autoRedact === true ? redact(dataWithContext) : dataWithContext
     const logRequest =
       config?.autoRedact === true ? redactRequest(request) : request
 
@@ -117,7 +129,7 @@ export const createLogger = (
           store,
           options
         }).catch(() => {
-          // Ignore errors
+          /* Ignore errors */
         })
       }
     }
@@ -175,9 +187,13 @@ export const createLogger = (
 
   return {
     pino: pinoLogger,
+    mergeContext: (request, partial) => {
+      contextStore.mergeContext(request, partial)
+    },
+    getContext: request => contextStore.getContext(request),
     log,
     handleHttpError: (request, error, store) => {
-      handleHttpError(request, error, store, options)
+      handleHttpError(request, error, store, options, contextStore)
     },
     debug: (request, message, context) => {
       logWithContext('DEBUG', request, message, context)
@@ -193,3 +209,9 @@ export const createLogger = (
     }
   }
 }
+
+/** Plugin entry: shares one request-context store across the Elysia lifecycle. */
+export const createPluginLogger = (
+  options: Options,
+  contextStore: RequestContextStore
+): Logger => createLogger(options, pino, contextStore)


### PR DESCRIPTION
## Description

Adds a request-scoped context bag so handlers can accumulate fields during a request and have them merged into the automatic access log—similar to evlog wide events, without replacing the existing `logger.info()` API.

### Problem

Logixlysia lacked a first-class way to attach structured context across middleware and handlers that lands on the final access line. Teams either duplicated fields in manual logs or lost correlation data on auto-logged responses.

### Result

- `Logger.mergeContext` / `getContext` on the plugin store logger
- `WeakMap`-backed bag cleared after each HTTP request and WebSocket close
- Merged context on auto access logs; explicit custom logs still win on key collision
- `autoRedact` applies to merged context
- Docs: `features/request-context.mdx`, usage section
- Changeset: minor bump for `logixlysia`

## Related Issues

N/A — competitive parity / DX improvement (no linked issue).

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Additional Notes

**Stack:** PR 1 of 8. Merge before `feat/presets`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request-scoped context accumulation: use mergeContext() to add fields during a request and getContext() to read them.
  * Accumulated context is merged into automatic access logs (preserves existing logging calls).
  * New named logger exports for advanced setups: createLogger and createPluginLogger.

* **Documentation**
  * Added detailed request-context docs with usage examples and behavior notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PunGrumpy/logixlysia/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->