### PR TITLE
feat(logixlysia): add dev, prod, and json presets

### DIFF
--- a/.changeset/presets.md
+++ b/.changeset/presets.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": minor
+---
+
+Add `preset` option (`dev`, `prod`, `json`) with `resolveOptions` for opinionated environment defaults.

--- a/apps/docs/content/(docs)/configuration.mdx
+++ b/apps/docs/content/(docs)/configuration.mdx
@@ -11,11 +11,14 @@ All configuration options are passed through the `config` property:
 
 ```ts
 logixlysia({
+  preset: 'prod', // optional: 'dev' | 'prod' | 'json'
   config: {
-    // ... configuration options
+    // ... configuration options (override preset)
   }
 })
 ```
+
+See [Presets](/features/presets) for defaults per environment.
 
 ## Startup Options
 

--- a/apps/docs/content/(docs)/usage.mdx
+++ b/apps/docs/content/(docs)/usage.mdx
@@ -34,6 +34,16 @@ Accumulate fields during a request; they are merged into the automatic access lo
 
 See [Request context](/features/request-context) for details.
 
+## Presets
+
+```ts
+logixlysia({ preset: 'dev' })   // pretty console + banner
+logixlysia({ preset: 'prod' })  // JSON logs + autoRedact
+logixlysia({ preset: 'json' })  // minimal JSON console
+```
+
+Explicit `config` overrides preset defaults. Details: [Presets](/features/presets).
+
 ## Configuration
 
 ### Basic Options

--- a/apps/docs/content/features/meta.json
+++ b/apps/docs/content/features/meta.json
@@ -4,6 +4,7 @@
   "pages": [
     "---Configuration---",
     "startup",
+    "presets",
     "request-context",
     "formatting",
     "filtering",

--- a/apps/docs/content/features/presets.mdx
+++ b/apps/docs/content/features/presets.mdx
@@ -1,0 +1,49 @@
+---
+title: Presets
+description: Opinionated dev, prod, and json logging defaults
+---
+
+Use `preset` for one-line environment defaults. Explicit `config` fields always override the preset.
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+
+const app = new Elysia().use(
+  logixlysia({
+    preset: 'prod',
+    config: {
+      service: 'api',
+      logFilePath: './logs/app.log'
+    }
+  })
+)
+```
+
+## Available presets
+
+| Preset | Startup banner | Pretty print | Context tree | `autoRedact` |
+| ------ | -------------- | ------------ | ------------ | ------------ |
+| `dev` | Yes (banner) | Yes | Yes | No |
+| `prod` | No | No | No | Yes |
+| `json` | No | No | No | No |
+
+## Override example
+
+```ts
+logixlysia({
+  preset: 'prod',
+  config: {
+    autoRedact: false,
+    showStartupMessage: true
+  }
+})
+```
+
+You can also resolve options programmatically:
+
+```ts
+import { resolveOptions } from 'logixlysia'
+
+const options = resolveOptions({ preset: 'dev', config: { service: 'api' } })
+```

--- a/packages/logixlysia/__tests__/config/resolve-options.test.ts
+++ b/packages/logixlysia/__tests__/config/resolve-options.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test'
+
+import { resolveOptions } from '../../src/config/resolve-options'
+
+describe('resolveOptions', () => {
+  test('prod preset enables autoRedact and disables banner', () => {
+    const resolved = resolveOptions({ preset: 'prod' })
+
+    expect(resolved.config?.autoRedact).toBe(true)
+    expect(resolved.config?.showStartupMessage).toBe(false)
+    expect(resolved.config?.showContextTree).toBe(false)
+  })
+
+  test('explicit config overrides preset', () => {
+    const resolved = resolveOptions({
+      preset: 'prod',
+      config: {
+        autoRedact: false,
+        showStartupMessage: true
+      }
+    })
+
+    expect(resolved.config?.autoRedact).toBe(false)
+    expect(resolved.config?.showStartupMessage).toBe(true)
+  })
+
+  test('dev preset enables pretty print', () => {
+    const resolved = resolveOptions({ preset: 'dev' })
+
+    expect(resolved.config?.pino?.prettyPrint).toBe(true)
+    expect(resolved.config?.showStartupMessage).toBe(true)
+  })
+})

--- a/packages/logixlysia/src/config/resolve-options.ts
+++ b/packages/logixlysia/src/config/resolve-options.ts
@@ -1,0 +1,93 @@
+import type { Options } from '../interfaces'
+
+export type LogPreset = 'dev' | 'prod' | 'json'
+
+const PRESET_DEFAULTS: Record<LogPreset, NonNullable<Options['config']>> = {
+  dev: {
+    showStartupMessage: true,
+    startupMessageFormat: 'banner',
+    useColors: true,
+    showContextTree: true,
+    pino: {
+      prettyPrint: true
+    }
+  },
+  prod: {
+    showStartupMessage: false,
+    useColors: false,
+    showContextTree: false,
+    autoRedact: true,
+    pino: {
+      prettyPrint: false
+    }
+  },
+  json: {
+    showStartupMessage: false,
+    useColors: false,
+    showContextTree: false,
+    pino: {
+      prettyPrint: false
+    }
+  }
+}
+
+const mergeConfig = (
+  base: NonNullable<Options['config']>,
+  override?: Options['config']
+): NonNullable<Options['config']> => {
+  if (!override) {
+    return base
+  }
+
+  const merged: NonNullable<Options['config']> = { ...base, ...override }
+
+  if (base.pino || override.pino) {
+    merged.pino = {
+      ...base.pino,
+      ...override.pino,
+      ...(base.pino?.prettyPrint !== undefined ||
+      override.pino?.prettyPrint !== undefined
+        ? {
+            prettyPrint: override.pino?.prettyPrint ?? base.pino?.prettyPrint
+          }
+        : {})
+    }
+  }
+
+  if (base.logFilter || override.logFilter) {
+    merged.logFilter = {
+      ...base.logFilter,
+      ...override.logFilter
+    }
+  }
+
+  if (base.logRotation || override.logRotation) {
+    merged.logRotation = {
+      ...base.logRotation,
+      ...override.logRotation
+    }
+  }
+
+  if (base.timestamp || override.timestamp) {
+    merged.timestamp = {
+      ...base.timestamp,
+      ...override.timestamp
+    }
+  }
+
+  return merged
+}
+
+/** Applies preset defaults; explicit `config` keys override preset values. */
+export const resolveOptions = (options: Options = {}): Options => {
+  const preset = options.preset
+  if (!preset) {
+    return options
+  }
+
+  const presetConfig = PRESET_DEFAULTS[preset]
+  return {
+    ...options,
+    config: mergeConfig(presetConfig, options.config)
+  }
+}

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -1,4 +1,5 @@
 import { Elysia } from 'elysia'
+import { resolveOptions } from './config/resolve-options'
 import { createRequestContextStore } from './context/request-context'
 import { startServer } from './extensions'
 import type { LogixlysiaStore, Options } from './interfaces'
@@ -27,7 +28,8 @@ export interface LogixlysiaSingleton {
 // @ts-expect-error — closed store is correct at runtime and for merged `ws.data` inference.
 export type Logixlysia = Elysia<'', LogixlysiaSingleton>
 
-export const logixlysia = (options: Options = {}): Logixlysia => {
+export const logixlysia = (rawOptions: Options = {}): Logixlysia => {
+  const options = resolveOptions(rawOptions)
   const didCustomLog = new WeakSet<Request>()
   const contextStore = createRequestContextStore()
   const baseLogger = createPluginLogger(options, contextStore)
@@ -127,11 +129,14 @@ export const logixlysia = (options: Options = {}): Logixlysia => {
     .as('scoped') as Logixlysia
 }
 
+// biome-ignore lint/performance/noBarrelFile: public package entry re-exports
+export { resolveOptions } from './config/resolve-options'
 export type {
   Logger,
   LogixlysiaContext,
   LogixlysiaStore,
   LogLevel,
+  LogPreset,
   Options,
   Pino,
   StoreData,

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -63,6 +63,8 @@ export interface LogFilter {
  */
 export type PrettyPrintConfig = boolean | Record<string, unknown>
 
+export type LogPreset = 'dev' | 'prod' | 'json'
+
 export interface Options {
   config?: {
     showStartupMessage?: boolean
@@ -108,6 +110,11 @@ export interface Options {
     // Pino
     pino?: (PinoLoggerOptions & { prettyPrint?: PrettyPrintConfig }) | undefined
   }
+  /**
+   * Opinionated defaults for common environments.
+   * Explicit `config` fields override preset values.
+   */
+  preset?: LogPreset
 }
 
 export class HttpError extends Error {


### PR DESCRIPTION
## Description

Introduces `config.preset` (`dev` | `prod` | `json`) and `resolveOptions()` so common environments need fewer manual options. Explicit `config` fields override preset defaults.

### Problem

New users had to copy large configuration blocks for local dev vs production JSON logging. There was no opinionated starting point comparable to evlog-style environment presets.

### Result

- `resolveOptions()` applied inside `logixlysia()` before logger creation
- Exported `resolveOptions` and `LogPreset` from the main entry
- Docs: `features/presets.mdx`, configuration + usage updates
- Changeset: minor bump for `logixlysia`

## Related Issues

N/A

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Additional Notes

**Stack:** PR 2 of 8 — base: `feat/request-context`. Merge after #310.

Made with [Cursor](https://cursor.com)