### PR TITLE
feat(logixlysia): add WebSocket lifecycle logging via wrapWs

### DIFF
--- a/.changeset/websocket-logging.md
+++ b/.changeset/websocket-logging.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": minor
+---
+
+Add `wrapWs` for WebSocket open, message, and close lifecycle logging with request context support.

--- a/apps/docs/content/features/meta.json
+++ b/apps/docs/content/features/meta.json
@@ -6,6 +6,7 @@
     "startup",
     "presets",
     "request-context",
+    "websocket",
     "formatting",
     "filtering",
     "log-levels",

--- a/apps/docs/content/features/websocket.mdx
+++ b/apps/docs/content/features/websocket.mdx
@@ -1,0 +1,61 @@
+---
+title: WebSocket logging
+description: Log WebSocket open, message, and close events
+---
+
+Use `wrapWs` on the plugin instance to add lifecycle logs for WebSocket routes:
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+
+const plugin = logixlysia({
+  config: {
+    service: 'chat'
+  }
+})
+
+const app = new Elysia()
+  .use(plugin)
+  .ws(
+    '/chat',
+    plugin.wrapWs({
+      open(ws) {
+        ws.send('connected')
+      },
+      message(ws, message) {
+        ws.send(message)
+      },
+      close(ws) {
+        console.log('bye', ws.id)
+      }
+    })
+  )
+```
+
+Each lifecycle event logs with HTTP method `WS`, the route path, duration, and optional `wsId` in context.
+
+## Request context on WebSockets
+
+Accumulate context with the WebSocket instance as the key:
+
+```ts
+.ws(
+  '/chat',
+  plugin.wrapWs({
+    message(ws, payload) {
+      ws.data.store.logger.mergeContext(ws, { lastPayloadType: typeof payload })
+    }
+  })
+)
+```
+
+## Disable WebSocket logs
+
+```ts
+logixlysia({
+  config: {
+    disableWebSocketLogging: true
+  }
+})
+```

--- a/packages/logixlysia/__tests__/websocket/wrap-ws.test.ts
+++ b/packages/logixlysia/__tests__/websocket/wrap-ws.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+import { createRequestContextStore } from '../../src/context/request-context'
+import { createLogger } from '../../src/logger'
+import { createWsHandlerWrapper } from '../../src/websocket/wrap-ws'
+
+describe('wrapWs', () => {
+  test('logs WebSocket open and close through transports', () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const contextStore = createRequestContextStore()
+    const logger = createLogger(
+      {
+        config: {
+          transports: [{ log: transport }],
+          disableInternalLogger: true,
+          disableFileLogging: true
+        }
+      },
+      undefined,
+      contextStore
+    )
+    const wrapWs = createWsHandlerWrapper({}, logger, contextStore)
+    const ws = { id: 'ws-1' }
+
+    const hooks = wrapWs('/chat', {
+      open() {
+        /* noop */
+      },
+      message() {
+        /* noop */
+      },
+      close() {
+        /* noop */
+      }
+    })
+
+    hooks.open?.(ws)
+    hooks.message?.(ws, { hello: 'world' })
+    hooks.close?.(ws)
+
+    expect(transport).toHaveBeenCalledTimes(3)
+    const messages = transport.mock.calls.map(call => String(call[1]))
+    expect(messages).toContain('WebSocket opened')
+    expect(messages).toContain('WebSocket message')
+    expect(messages).toContain('WebSocket closed')
+  })
+})

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -4,6 +4,7 @@ import { createRequestContextStore } from './context/request-context'
 import { startServer } from './extensions'
 import type { LogixlysiaStore, Options } from './interfaces'
 import { createPluginLogger } from './logger'
+import { createWsHandlerWrapper } from './websocket/wrap-ws'
 
 /**
  * Empty singleton slots must not use `Record<string, never>`: intersecting that with Elysia's `Context`
@@ -28,11 +29,16 @@ export interface LogixlysiaSingleton {
 // @ts-expect-error — closed store is correct at runtime and for merged `ws.data` inference.
 export type Logixlysia = Elysia<'', LogixlysiaSingleton>
 
-export const logixlysia = (rawOptions: Options = {}): Logixlysia => {
+export type LogixlysiaPlugin = Logixlysia & {
+  wrapWs: ReturnType<typeof createWsHandlerWrapper>
+}
+
+export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
   const options = resolveOptions(rawOptions)
   const didCustomLog = new WeakSet<Request>()
   const contextStore = createRequestContextStore()
   const baseLogger = createPluginLogger(options, contextStore)
+  const wrapWs = createWsHandlerWrapper(options, baseLogger, contextStore)
   const logger = {
     ...baseLogger,
     debug: (
@@ -78,7 +84,7 @@ export const logixlysia = (rawOptions: Options = {}): Logixlysia => {
     }
   })
 
-  return app
+  const plugin = app
     .state('logger', logger)
     .state('pino', logger.pino)
     .state('beforeTime', BigInt(0))
@@ -127,6 +133,8 @@ export const logixlysia = (rawOptions: Options = {}): Logixlysia => {
       }
     })
     .as('scoped') as Logixlysia
+
+  return Object.assign(plugin, { wrapWs }) as LogixlysiaPlugin
 }
 
 // biome-ignore lint/performance/noBarrelFile: public package entry re-exports
@@ -143,5 +151,7 @@ export type {
   Transport
 } from './interfaces'
 export { createLogger, createPluginLogger } from './logger'
+export type { WsHandlerHooks } from './websocket/wrap-ws'
+export { createWsHandlerWrapper } from './websocket/wrap-ws'
 
 export default logixlysia

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -90,6 +90,9 @@ export interface Options {
     /** Include query parameters in the logged URL path; default false. */
     logQueryParams?: boolean
 
+    /** Skip automatic WebSocket lifecycle logs from `wrapWs`; default false. */
+    disableWebSocketLogging?: boolean
+
     // Filtering
     logFilter?: LogFilter
 

--- a/packages/logixlysia/src/websocket/wrap-ws.ts
+++ b/packages/logixlysia/src/websocket/wrap-ws.ts
@@ -1,0 +1,86 @@
+import type { RequestContextStore } from '../context/request-context'
+import type { Logger, Options, StoreData } from '../interfaces'
+
+export interface WebSocketLike {
+  readonly data?: { store?: { logger?: Logger } }
+  readonly id?: string
+}
+
+export interface WsHandlerHooks<
+  TMessage = unknown,
+  TWs extends WebSocketLike = WebSocketLike
+> {
+  close?: (ws: TWs) => void
+  message?: (ws: TWs, message: TMessage) => void
+  open?: (ws: TWs) => void
+}
+
+const wsSyntheticRequest = (path: string): Request =>
+  new Request(`http://logixlysia.local${path}`, { method: 'WS' })
+
+export const createWsHandlerWrapper = (
+  options: Options,
+  logger: Logger,
+  contextStore: RequestContextStore
+) => {
+  const wsTimings = new WeakMap<object, bigint>()
+
+  const logWs = (
+    level: 'INFO' | 'WARNING' | 'ERROR',
+    ws: WebSocketLike,
+    path: string,
+    message: string,
+    extra?: Record<string, unknown>
+  ): void => {
+    const key = ws as object
+    const beforeTime = wsTimings.get(key) ?? process.hrtime.bigint()
+    const store: StoreData = { beforeTime }
+    const accumulated = contextStore.getContext(key)
+    const context =
+      Object.keys(accumulated).length > 0 || extra
+        ? { ...accumulated, ...extra, wsId: ws.id }
+        : { wsId: ws.id }
+
+    logger.log(
+      level,
+      wsSyntheticRequest(path),
+      { message, context, status: 200 },
+      store
+    )
+  }
+
+  return <
+    TMessage,
+    TWs extends WebSocketLike,
+    const THooks extends WsHandlerHooks<TMessage, TWs>
+  >(
+    path: string,
+    hooks: THooks
+  ): THooks =>
+    ({
+      ...hooks,
+      open(ws) {
+        wsTimings.set(ws as object, process.hrtime.bigint())
+        hooks.open?.(ws)
+        if (options.config?.disableWebSocketLogging !== true) {
+          logWs('INFO', ws, path, 'WebSocket opened')
+        }
+      },
+      message(ws, message) {
+        hooks.message?.(ws, message)
+        if (options.config?.disableWebSocketLogging !== true) {
+          logWs('INFO', ws, path, 'WebSocket message', {
+            payloadType: typeof message
+          })
+        }
+      },
+      close(ws) {
+        hooks.close?.(ws)
+        if (options.config?.disableWebSocketLogging !== true) {
+          logWs('INFO', ws, path, 'WebSocket closed')
+        }
+        contextStore.clearContext(ws as object)
+        wsTimings.delete(ws as object)
+      }
+    }) as THooks
+}


### PR DESCRIPTION
## Description

Adds `plugin.wrapWs(path, hooks)` to log WebSocket open, message, and close events with method `WS`, route path, duration, and optional `wsId` in context. Reuses the request context bag when handlers call `mergeContext` on the socket object.

### Problem

HTTP logging was solid, but WebSocket routes had no built-in lifecycle logging or context accumulation comparable to HTTP wide events.

### Result

- `createWsHandlerWrapper` + `wrapWs` on `LogixlysiaPlugin`
- `config.disableWebSocketLogging` to opt out
- Tests for transport output on open/message/close
- Docs: `features/websocket.mdx`
- Changeset: minor bump for `logixlysia`

## Related Issues

N/A

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Additional Notes

**Stack:** PR 3 of 8 — base: `feat/presets`.

Made with [Cursor](https://cursor.com)