### PR TITLE
feat(logixlysia): add logixlysia/otel subpath

### DIFF
--- a/.changeset/otel-subpath.md
+++ b/.changeset/otel-subpath.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": minor
+---
+
+Add `logixlysia/otel` subpath with `injectTraceContext` for optional OpenTelemetry span correlation.

--- a/apps/docs/content/integrations/meta.json
+++ b/apps/docs/content/integrations/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Integrations",
   "description": "Third-party integrations for Logixlysia",
-  "pages": ["pino", "..."],
+  "pages": ["pino", "otel", "..."],
   "root": true
 }

--- a/apps/docs/content/integrations/otel.mdx
+++ b/apps/docs/content/integrations/otel.mdx
@@ -1,0 +1,28 @@
+---
+title: OpenTelemetry
+description: Correlate logs with active trace and span IDs
+---
+
+Install the optional peer dependency:
+
+```bash
+bun add @opentelemetry/api
+```
+
+Import from the `logixlysia/otel` subpath:
+
+```ts
+import logixlysia from 'logixlysia'
+import { injectTraceContext } from 'logixlysia/otel'
+
+const plugin = logixlysia()
+
+const app = new Elysia()
+  .use(plugin)
+  .onRequest(({ request, store }) => {
+    injectTraceContext(store.logger, request)
+  })
+  .get('/', () => 'ok')
+```
+
+When an active span exists, `trace_id` and `span_id` are merged into the request context bag and appear on the access log. Logixlysia does not start an OpenTelemetry SDK—you bring your own tracer provider and instrumentation.

--- a/packages/logixlysia/__tests__/otel/otel.test.ts
+++ b/packages/logixlysia/__tests__/otel/otel.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createLogger } from '../../src/logger'
+import { injectTraceContext } from '../../src/otel'
+
+describe('logixlysia/otel', () => {
+  test('injectTraceContext is a no-op when OpenTelemetry is not installed', () => {
+    const logger = createLogger({
+      config: {
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    })
+    const request = new Request('http://localhost/')
+
+    expect(injectTraceContext(logger, request)).toBeUndefined()
+    expect(logger.getContext(request)).toEqual({})
+  })
+})

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'bunup'
 const config = defineConfig({
   name: 'Logixlysia',
   outDir: 'dist',
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/otel.ts'],
   format: ['esm'],
   dts: true,
   minify: true,

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -4,6 +4,16 @@
   "description": "🦊 Logixlysia is a logger for Elysia",
   "type": "module",
   "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./otel": {
+      "types": "./dist/otel.d.ts",
+      "import": "./dist/otel.js"
+    }
+  },
   "files": [
     "dist",
     "README.md"
@@ -46,7 +56,13 @@
     "elysia": "^1.4.28"
   },
   "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "elysia": "^1.4.28",
     "typescript": "^6.0.2"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    }
   }
 }

--- a/packages/logixlysia/src/otel.ts
+++ b/packages/logixlysia/src/otel.ts
@@ -1,0 +1,61 @@
+import { createRequire } from 'node:module'
+import type { Logger } from './interfaces'
+
+const requireOtel = createRequire(import.meta.url)
+
+export interface TraceContextFields {
+  span_id?: string
+  trace_id?: string
+}
+
+interface OtelApi {
+  context: { active: () => unknown }
+  trace: {
+    getSpan: (
+      ctx: unknown
+    ) => { spanContext: () => { traceId: string; spanId: string } } | undefined
+  }
+}
+
+let otelApi: OtelApi | null | undefined
+
+const getOtelApi = (): OtelApi | null => {
+  if (otelApi !== undefined) {
+    return otelApi
+  }
+  try {
+    otelApi = requireOtel('@opentelemetry/api') as OtelApi
+  } catch {
+    otelApi = null
+  }
+  return otelApi
+}
+
+/**
+ * Injects active OpenTelemetry span IDs into the request context bag when
+ * `@opentelemetry/api` is installed and a span is active.
+ */
+export const injectTraceContext = (
+  logger: Pick<Logger, 'mergeContext'>,
+  request: Request
+): TraceContextFields | undefined => {
+  const api = getOtelApi()
+  if (!api) {
+    return
+  }
+
+  const span = api.trace.getSpan(api.context.active())
+  if (!span) {
+    return
+  }
+
+  const { traceId, spanId } = span.spanContext()
+  const fields = {
+    trace_id: traceId,
+    span_id: spanId
+  } satisfies TraceContextFields
+  logger.mergeContext(request, fields)
+  return fields
+}
+
+export { injectTraceContext as default }


### PR DESCRIPTION
## Description

Adds optional `logixlysia/otel` export with `injectTraceContext()` to merge active OpenTelemetry `trace_id` and `span_id` into the request context bag when `@opentelemetry/api` is installed.

### Problem

Teams running OTel had no lightweight bridge from active spans into Logixlysia access logs without custom middleware.

### Result

- Subpath build entry + `package.json` exports
- Optional peer dependency `@opentelemetry/api`
- No-op when OTel is not installed (tested)
- Docs: `integrations/otel.mdx`
- Changeset: minor bump for `logixlysia`

## Related Issues

N/A

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Additional Notes

**Stack:** PR 4 of 8 — base: `feat/websocket-logging`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WebSocket lifecycle logging with request context support.
  * Added OpenTelemetry integration for trace and span context injection.
  * Added configuration option to disable WebSocket logging.

* **Documentation**
  * Added WebSocket logging feature documentation.
  * Added OpenTelemetry integration guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PunGrumpy/logixlysia/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->