### PR TITLE
feat(logixlysia): add logixlysia/ai subpath

### DIFF
--- a/.changeset/ai-subpath.md
+++ b/.changeset/ai-subpath.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": minor
+---
+
+Add `logixlysia/ai` subpath with `mergeAIMetrics` for LLM usage fields on access logs.

--- a/apps/docs/content/integrations/ai.mdx
+++ b/apps/docs/content/integrations/ai.mdx
@@ -1,0 +1,31 @@
+---
+title: AI SDK metrics
+description: Attach LLM usage metrics to request logs
+---
+
+Import from the `logixlysia/ai` subpath (no required peer dependency):
+
+```ts
+import logixlysia from 'logixlysia'
+import { mergeAIMetrics } from 'logixlysia/ai'
+
+const plugin = logixlysia()
+
+const app = new Elysia()
+  .use(plugin)
+  .post('/chat', async ({ request, store }) => {
+    // After your AI SDK call:
+    mergeAIMetrics(store.logger, request, {
+      model: 'claude-sonnet',
+      provider: 'anthropic',
+      inputTokens: 1200,
+      outputTokens: 400,
+      totalTokens: 1600,
+      msToFinish: 2300
+    })
+
+    return { ok: true }
+  })
+```
+
+The final access log `context.ai` object mirrors evlog’s wide-event `ai` field for easier migration.

--- a/apps/docs/content/integrations/meta.json
+++ b/apps/docs/content/integrations/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Integrations",
   "description": "Third-party integrations for Logixlysia",
-  "pages": ["pino", "otel", "..."],
+  "pages": ["pino", "otel", "ai", "..."],
   "root": true
 }

--- a/packages/logixlysia/__tests__/ai/ai.test.ts
+++ b/packages/logixlysia/__tests__/ai/ai.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { Elysia } from 'elysia'
+
+import { logixlysia } from '../../src'
+import { mergeAIMetrics } from '../../src/ai'
+
+describe('logixlysia/ai', () => {
+  test('mergeAIMetrics adds ai object to access log context', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+
+    const app = new Elysia()
+      .use(
+        logixlysia({
+          config: {
+            transports: [{ log: transport }],
+            disableInternalLogger: true,
+            disableFileLogging: true
+          }
+        })
+      )
+      .get('/chat', ({ request, store }) => {
+        mergeAIMetrics(store.logger, request, {
+          model: 'claude-sonnet',
+          inputTokens: 100,
+          outputTokens: 50,
+          totalTokens: 150
+        })
+        return 'ok'
+      })
+
+    await app.handle(new Request('http://localhost/chat'))
+
+    const meta = transport.mock.calls[0]?.[2] as
+      | { context?: { ai?: Record<string, unknown> } }
+      | undefined
+    expect(meta?.context?.ai).toMatchObject({
+      model: 'claude-sonnet',
+      totalTokens: 150
+    })
+  })
+})

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'bunup'
 const config = defineConfig({
   name: 'Logixlysia',
   outDir: 'dist',
-  entry: ['src/index.ts', 'src/otel.ts'],
+  entry: ['src/index.ts', 'src/otel.ts', 'src/ai.ts'],
   format: ['esm'],
   dts: true,
   minify: true,

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -12,7 +12,12 @@
     "./otel": {
       "types": "./dist/otel.d.ts",
       "import": "./dist/otel.js"
-    }
+    },
+    "./ai": {
+      "types": "./dist/ai.d.ts",
+      "import": "./dist/ai.js"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",
@@ -57,11 +62,15 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",
+    "ai": "^6.0.0",
     "elysia": "^1.4.28",
     "typescript": "^6.0.2"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {
+      "optional": true
+    },
+    "ai": {
       "optional": true
     }
   }

--- a/packages/logixlysia/src/ai.ts
+++ b/packages/logixlysia/src/ai.ts
@@ -1,0 +1,32 @@
+import type { Logger } from './interfaces'
+
+export interface AIMetrics {
+  calls?: number
+  finishReason?: string
+  inputTokens?: number
+  model?: string
+  msToFinish?: number
+  msToFirstChunk?: number
+  outputTokens?: number
+  provider?: string
+  reasoningTokens?: number
+  tokensPerSecond?: number
+  totalTokens?: number
+}
+
+/**
+ * Merges AI SDK / LLM usage metrics into the request context bag so they appear
+ * on the final access log (evlog-style `ai` object).
+ */
+export const mergeAIMetrics = (
+  logger: Pick<Logger, 'mergeContext'>,
+  request: Request,
+  metrics: AIMetrics
+): void => {
+  if (Object.keys(metrics).length === 0) {
+    return
+  }
+  logger.mergeContext(request, { ai: metrics })
+}
+
+export { mergeAIMetrics as default }


### PR DESCRIPTION
## Description

Adds optional `logixlysia/ai` export with `mergeAIMetrics()` to attach AI SDK / LLM usage fields (`model`, tokens, latency, etc.) to the request context bag under an `ai` object on the access log.

### Problem

LLM-heavy Elysia apps had no standard way to surface token usage and model metadata on the same access line as HTTP logs.

### Result

- Subpath build entry + exports (alongside `otel`)
- Optional peer dependency `ai`
- Tests for merged `ai` context on access logs
- Docs: `integrations/ai.mdx`
- Changeset: minor bump for `logixlysia`

## Related Issues

N/A

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Additional Notes

**Stack:** PR 5 of 8 — base: `feat/otel-subpath`. Includes `package.json` exports for `./ai` and `./package.json`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI SDK metrics integration available via `logixlysia/ai` subpath
  * New `mergeAIMetrics` function to attach LLM usage metrics (model, provider, token counts, timing) to request logs
  * Access logs now include `context.ai` object for easier integration

* **Documentation**
  * Added comprehensive guide for AI SDK metrics integration with TypeScript examples

* **Tests**
  * Added test suite for AI metrics functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PunGrumpy/logixlysia/pull/314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->