### PR TITLE
chore(bench): add Elysia plugin path benchmarks

### DIFF
--- a/.changeset/ai-subpath.md
+++ b/.changeset/ai-subpath.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": minor
+---
+
+Add `logixlysia/ai` subpath with `mergeAIMetrics` for LLM usage fields on access logs.

--- a/.changeset/otel-subpath.md
+++ b/.changeset/otel-subpath.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": minor
+---
+
+Add `logixlysia/otel` subpath with `injectTraceContext` for optional OpenTelemetry span correlation.

--- a/apps/docs/content/integrations/ai.mdx
+++ b/apps/docs/content/integrations/ai.mdx
@@ -1,0 +1,31 @@
+---
+title: AI SDK metrics
+description: Attach LLM usage metrics to request logs
+---
+
+Import from the `logixlysia/ai` subpath (no required peer dependency):
+
+```ts
+import logixlysia from 'logixlysia'
+import { mergeAIMetrics } from 'logixlysia/ai'
+
+const plugin = logixlysia()
+
+const app = new Elysia()
+  .use(plugin)
+  .post('/chat', async ({ request, store }) => {
+    // After your AI SDK call:
+    mergeAIMetrics(store.logger, request, {
+      model: 'claude-sonnet',
+      provider: 'anthropic',
+      inputTokens: 1200,
+      outputTokens: 400,
+      totalTokens: 1600,
+      msToFinish: 2300
+    })
+
+    return { ok: true }
+  })
+```
+
+The final access log `context.ai` object mirrors evlog’s wide-event `ai` field for easier migration.

--- a/apps/docs/content/integrations/meta.json
+++ b/apps/docs/content/integrations/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Integrations",
   "description": "Third-party integrations for Logixlysia",
-  "pages": ["pino", "otel", "..."],
+  "pages": ["pino", "otel", "ai", "..."],
   "root": true
 }

--- a/apps/docs/content/integrations/meta.json
+++ b/apps/docs/content/integrations/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Integrations",
   "description": "Third-party integrations for Logixlysia",
-  "pages": ["pino", "..."],
+  "pages": ["pino", "otel", "..."],
   "root": true
 }

--- a/apps/docs/content/integrations/otel.mdx
+++ b/apps/docs/content/integrations/otel.mdx
@@ -1,0 +1,28 @@
+---
+title: OpenTelemetry
+description: Correlate logs with active trace and span IDs
+---
+
+Install the optional peer dependency:
+
+```bash
+bun add @opentelemetry/api
+```
+
+Import from the `logixlysia/otel` subpath:
+
+```ts
+import logixlysia from 'logixlysia'
+import { injectTraceContext } from 'logixlysia/otel'
+
+const plugin = logixlysia()
+
+const app = new Elysia()
+  .use(plugin)
+  .onRequest(({ request, store }) => {
+    injectTraceContext(store.logger, request)
+  })
+  .get('/', () => 'ok')
+```
+
+When an active span exists, `trace_id` and `span_id` are merged into the request context bag and appear on the access log. Logixlysia does not start an OpenTelemetry SDK—you bring your own tracer provider and instrumentation.

--- a/packages/bench/index.bench.ts
+++ b/packages/bench/index.bench.ts
@@ -1,7 +1,12 @@
-import { createPinoLogger as createBogeychan } from '@bogeychan/elysia-logger'
+import {
+  logger as bogeychanLogger,
+  createPinoLogger as createBogeychan
+} from '@bogeychan/elysia-logger'
 import { consola } from 'consola'
+import { Elysia } from 'elysia'
 import { createLogger as createEvlog } from 'evlog'
-import { createLogger } from 'logixlysia/src/logger/index.js'
+import { evlog } from 'evlog/elysia'
+import logixlysia, { createLogger } from 'logixlysia'
 import pino from 'pino'
 import { bench, describe } from 'vitest'
 import winston from 'winston'
@@ -145,5 +150,47 @@ describe('Deep Nested Log', () => {
 
   bench('bogeychan', () => {
     bc.info(deepData, 'Deep nested')
+  })
+})
+
+const silentLogixConfig = {
+  disableInternalLogger: true,
+  disableFileLogging: true,
+  pino: { enabled: false }
+} as const
+
+const logixlysiaApp = new Elysia()
+  .use(logixlysia({ config: silentLogixConfig }))
+  .get('/', () => 'ok')
+
+const evlogApp = new Elysia()
+  .use(
+    evlog({
+      drain: () => {
+        /* benchmark noop */
+      }
+    })
+  )
+  .get('/', () => 'ok')
+
+const bogeychanApp = new Elysia()
+  .use(
+    bogeychanLogger({
+      enabled: false
+    })
+  )
+  .get('/', () => 'ok')
+
+describe('Elysia plugin request path', () => {
+  bench('logixlysia', async () => {
+    await logixlysiaApp.handle(new Request('http://localhost/'))
+  })
+
+  bench('evlog', async () => {
+    await evlogApp.handle(new Request('http://localhost/'))
+  })
+
+  bench('bogeychan', async () => {
+    await bogeychanApp.handle(new Request('http://localhost/'))
   })
 })

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@bogeychan/elysia-logger": "^0.1.10",
     "consola": "^3.4.2",
+    "elysia": "^1.4.28",
     "evlog": "^2.17.0",
     "logixlysia": "workspace:*",
     "pino": "^10.3.1",

--- a/packages/bench/tsconfig.json
+++ b/packages/bench/tsconfig.json
@@ -1,9 +1,4 @@
 {
   "extends": "../typescript-config/base.json",
-  "compilerOptions": {
-    "paths": {
-      "logixlysia": ["../logixlysia/src"]
-    }
-  },
   "include": ["**/*.ts"]
 }

--- a/packages/logixlysia/__tests__/ai/ai.test.ts
+++ b/packages/logixlysia/__tests__/ai/ai.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { Elysia } from 'elysia'
+
+import { logixlysia } from '../../src'
+import { mergeAIMetrics } from '../../src/ai'
+
+describe('logixlysia/ai', () => {
+  test('mergeAIMetrics adds ai object to access log context', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+
+    const app = new Elysia()
+      .use(
+        logixlysia({
+          config: {
+            transports: [{ log: transport }],
+            disableInternalLogger: true,
+            disableFileLogging: true
+          }
+        })
+      )
+      .get('/chat', ({ request, store }) => {
+        mergeAIMetrics(store.logger, request, {
+          model: 'claude-sonnet',
+          inputTokens: 100,
+          outputTokens: 50,
+          totalTokens: 150
+        })
+        return 'ok'
+      })
+
+    await app.handle(new Request('http://localhost/chat'))
+
+    const meta = transport.mock.calls[0]?.[2] as
+      | { context?: { ai?: Record<string, unknown> } }
+      | undefined
+    expect(meta?.context?.ai).toMatchObject({
+      model: 'claude-sonnet',
+      totalTokens: 150
+    })
+  })
+})

--- a/packages/logixlysia/__tests__/otel/otel.test.ts
+++ b/packages/logixlysia/__tests__/otel/otel.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createLogger } from '../../src/logger'
+import { injectTraceContext } from '../../src/otel'
+
+describe('logixlysia/otel', () => {
+  test('injectTraceContext is a no-op when OpenTelemetry is not installed', () => {
+    const logger = createLogger({
+      config: {
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    })
+    const request = new Request('http://localhost/')
+
+    expect(injectTraceContext(logger, request)).toBeUndefined()
+    expect(logger.getContext(request)).toEqual({})
+  })
+})

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'bunup'
 const config = defineConfig({
   name: 'Logixlysia',
   outDir: 'dist',
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/otel.ts'],
   format: ['esm'],
   dts: true,
   minify: true,

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'bunup'
 const config = defineConfig({
   name: 'Logixlysia',
   outDir: 'dist',
-  entry: ['src/index.ts', 'src/otel.ts'],
+  entry: ['src/index.ts', 'src/otel.ts', 'src/ai.ts'],
   format: ['esm'],
   dts: true,
   minify: true,

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -4,6 +4,16 @@
   "description": "🦊 Logixlysia is a logger for Elysia",
   "type": "module",
   "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./otel": {
+      "types": "./dist/otel.d.ts",
+      "import": "./dist/otel.js"
+    }
+  },
   "files": [
     "dist",
     "README.md"
@@ -46,7 +56,13 @@
     "elysia": "^1.4.28"
   },
   "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "elysia": "^1.4.28",
     "typescript": "^6.0.2"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    }
   }
 }

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -12,7 +12,12 @@
     "./otel": {
       "types": "./dist/otel.d.ts",
       "import": "./dist/otel.js"
-    }
+    },
+    "./ai": {
+      "types": "./dist/ai.d.ts",
+      "import": "./dist/ai.js"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",
@@ -57,11 +62,15 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",
+    "ai": "^6.0.0",
     "elysia": "^1.4.28",
     "typescript": "^6.0.2"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {
+      "optional": true
+    },
+    "ai": {
       "optional": true
     }
   }

--- a/packages/logixlysia/src/ai.ts
+++ b/packages/logixlysia/src/ai.ts
@@ -1,0 +1,32 @@
+import type { Logger } from './interfaces'
+
+export interface AIMetrics {
+  calls?: number
+  finishReason?: string
+  inputTokens?: number
+  model?: string
+  msToFinish?: number
+  msToFirstChunk?: number
+  outputTokens?: number
+  provider?: string
+  reasoningTokens?: number
+  tokensPerSecond?: number
+  totalTokens?: number
+}
+
+/**
+ * Merges AI SDK / LLM usage metrics into the request context bag so they appear
+ * on the final access log (evlog-style `ai` object).
+ */
+export const mergeAIMetrics = (
+  logger: Pick<Logger, 'mergeContext'>,
+  request: Request,
+  metrics: AIMetrics
+): void => {
+  if (Object.keys(metrics).length === 0) {
+    return
+  }
+  logger.mergeContext(request, { ai: metrics })
+}
+
+export { mergeAIMetrics as default }

--- a/packages/logixlysia/src/otel.ts
+++ b/packages/logixlysia/src/otel.ts
@@ -1,0 +1,61 @@
+import { createRequire } from 'node:module'
+import type { Logger } from './interfaces'
+
+const requireOtel = createRequire(import.meta.url)
+
+export interface TraceContextFields {
+  span_id?: string
+  trace_id?: string
+}
+
+interface OtelApi {
+  context: { active: () => unknown }
+  trace: {
+    getSpan: (
+      ctx: unknown
+    ) => { spanContext: () => { traceId: string; spanId: string } } | undefined
+  }
+}
+
+let otelApi: OtelApi | null | undefined
+
+const getOtelApi = (): OtelApi | null => {
+  if (otelApi !== undefined) {
+    return otelApi
+  }
+  try {
+    otelApi = requireOtel('@opentelemetry/api') as OtelApi
+  } catch {
+    otelApi = null
+  }
+  return otelApi
+}
+
+/**
+ * Injects active OpenTelemetry span IDs into the request context bag when
+ * `@opentelemetry/api` is installed and a span is active.
+ */
+export const injectTraceContext = (
+  logger: Pick<Logger, 'mergeContext'>,
+  request: Request
+): TraceContextFields | undefined => {
+  const api = getOtelApi()
+  if (!api) {
+    return
+  }
+
+  const span = api.trace.getSpan(api.context.active())
+  if (!span) {
+    return
+  }
+
+  const { traceId, spanId } = span.spanContext()
+  const fields = {
+    trace_id: traceId,
+    span_id: spanId
+  } satisfies TraceContextFields
+  logger.mergeContext(request, fields)
+  return fields
+}
+
+export { injectTraceContext as default }


### PR DESCRIPTION
## Description

Extends `@repo/bench` with Vitest benchmarks comparing Elysia plugin overhead for Logixlysia, evlog, and `@bogeychan/elysia-logger` on a minimal `GET /` route (logging output silenced for fair comparison).

### Problem

We had logger-creation and direct log-call benches but no apples-to-apples measure of **plugin path** cost on a real Elysia app—important for competitive positioning vs evlog.

### Result

- Plugin-path bench group in `packages/bench/index.bench.ts`
- Workspace import `logixlysia` + `createLogger`; evlog Elysia plugin; bogeychan `.use(logger())`
- `elysia` added as a bench dependency
- No changeset (bench package ignored in changeset config)

## Related Issues

N/A

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Additional Notes

**Stack:** PR 6 of 8 — base: `feat/ai-subpath`. Branch also contains a `fix(logixlysia): restore package.json` commit from the stacked split; safe to merge with PR 5.

Made with [Cursor](https://cursor.com)