### PR TITLE
example(elysia): demo request context, AI metrics, OTel, and wrapWs

### DIFF
--- a/.changeset/ai-subpath.md
+++ b/.changeset/ai-subpath.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": minor
+---
+
+Add `logixlysia/ai` subpath with `mergeAIMetrics` for LLM usage fields on access logs.

--- a/.changeset/otel-subpath.md
+++ b/.changeset/otel-subpath.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": minor
+---
+
+Add `logixlysia/otel` subpath with `injectTraceContext` for optional OpenTelemetry span correlation.

--- a/apps/docs/content/(docs)/comparison.mdx
+++ b/apps/docs/content/(docs)/comparison.mdx
@@ -1,0 +1,40 @@
+---
+title: Comparison
+description: How Logixlysia compares to evlog and other Elysia loggers
+---
+
+## Feature matrix
+
+| Capability | Logixlysia | [evlog](https://evlog.dev) | [@bogeychan/elysia-logger](https://github.com/bogeychan/elysia-logger) |
+| ---------- | ---------- | -------------------------- | ----------------------------------------------------------------------- |
+| Elysia plugin | Yes | Yes (`evlog/elysia`) | Yes |
+| Pino-backed | Yes | Optional drains | Yes |
+| Request context accumulation | `mergeContext` | `log.set()` | Manual |
+| Single access log per request | Auto | `log.emit()` | Auto |
+| File rotation | Yes | Via drains | Limited |
+| `autoRedact` PII | Yes | Varies | Manual |
+| WebSocket lifecycle logs | `wrapWs` | Manual | Manual |
+| OTel trace correlation | `logixlysia/otel` | Built-in integrations | Manual |
+| AI usage on access log | `logixlysia/ai` | `evlog/ai` | Manual |
+| Presets (`dev` / `prod`) | Yes | N/A | N/A |
+
+## When to choose Logixlysia
+
+- You want **Pino** performance with Elysia-native `store.logger` ergonomics.
+- You need **file logging and rotation** without wiring a separate drain.
+- You prefer **incremental context** (`mergeContext`) plus automatic access logs instead of migrating to a wide-event-only API.
+
+## When to consider evlog
+
+- You want a **unified wide-event pipeline** across many frameworks with managed drains (Axiom, etc.).
+- You rely heavily on **`evlog/ai`** and **`evlog` auth** integrations out of the box.
+
+## Benchmarks
+
+Run the monorepo benchmark package:
+
+```bash
+bun run bench
+```
+
+The `Elysia plugin request path` suite compares full `handle()` overhead for Logixlysia, evlog, and elysia-logger. Results vary by machine—use them for regression tracking, not absolute rankings.

--- a/apps/docs/content/(docs)/meta.json
+++ b/apps/docs/content/(docs)/meta.json
@@ -3,6 +3,8 @@
   "description": "Documentation for Logixlysia",
   "pages": [
     "introduction",
+    "comparison",
+    "migration-from-evlog",
     "examples",
     "faq",
     "contributing",

--- a/apps/docs/content/(docs)/migration-from-evlog.mdx
+++ b/apps/docs/content/(docs)/migration-from-evlog.mdx
@@ -1,0 +1,84 @@
+---
+title: Migrating from evlog
+description: Map evlog wide events to Logixlysia request context and access logs
+---
+
+## Plugin setup
+
+**evlog**
+
+```ts
+import { evlog } from 'evlog/elysia'
+
+new Elysia().use(evlog({ drain: myDrain }))
+```
+
+**Logixlysia**
+
+```ts
+import logixlysia from 'logixlysia'
+
+new Elysia().use(logixlysia({ preset: 'prod' }))
+```
+
+## Context accumulation
+
+| evlog | Logixlysia |
+| ----- | ---------- |
+| `log.set({ userId: 'x' })` | `store.logger.mergeContext(request, { userId: 'x' })` |
+| `log.set({ cart: { total: 99 } })` | `store.logger.mergeContext(request, { cart: { total: 99 } })` |
+| `useLogger()` | `store.logger` in handlers |
+
+## Emitting the request log
+
+evlog:
+
+```ts
+log.emit({ status: 200 })
+```
+
+Logixlysia emits the access log automatically in `onAfterHandle`. Use a custom log only when you need to skip the default line:
+
+```ts
+store.logger.info(request, 'handled manually')
+```
+
+## AI metrics
+
+**evlog** — automatic via `evlog/ai`.
+
+**Logixlysia**
+
+```ts
+import { mergeAIMetrics } from 'logixlysia/ai'
+
+mergeAIMetrics(store.logger, request, {
+  model: 'claude-sonnet',
+  inputTokens: 100,
+  outputTokens: 50,
+  totalTokens: 150
+})
+```
+
+## Tracing
+
+Use `injectTraceContext` from `logixlysia/otel` in `onRequest` (see [OpenTelemetry](/integrations/otel)).
+
+## Drains vs transports
+
+evlog **drains** map to Logixlysia **transports**:
+
+```ts
+logixlysia({
+  config: {
+    transports: [
+      {
+        log: (level, message, meta) => {
+          myDrain.write({ level, message, ...meta })
+        }
+      }
+    ],
+    useTransportsOnly: true
+  }
+})
+```

--- a/apps/docs/content/integrations/ai.mdx
+++ b/apps/docs/content/integrations/ai.mdx
@@ -1,0 +1,31 @@
+---
+title: AI SDK metrics
+description: Attach LLM usage metrics to request logs
+---
+
+Import from the `logixlysia/ai` subpath (no required peer dependency):
+
+```ts
+import logixlysia from 'logixlysia'
+import { mergeAIMetrics } from 'logixlysia/ai'
+
+const plugin = logixlysia()
+
+const app = new Elysia()
+  .use(plugin)
+  .post('/chat', async ({ request, store }) => {
+    // After your AI SDK call:
+    mergeAIMetrics(store.logger, request, {
+      model: 'claude-sonnet',
+      provider: 'anthropic',
+      inputTokens: 1200,
+      outputTokens: 400,
+      totalTokens: 1600,
+      msToFinish: 2300
+    })
+
+    return { ok: true }
+  })
+```
+
+The final access log `context.ai` object mirrors evlog’s wide-event `ai` field for easier migration.

--- a/apps/docs/content/integrations/meta.json
+++ b/apps/docs/content/integrations/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Integrations",
   "description": "Third-party integrations for Logixlysia",
-  "pages": ["pino", "otel", "..."],
+  "pages": ["pino", "otel", "ai", "..."],
   "root": true
 }

--- a/apps/docs/content/integrations/meta.json
+++ b/apps/docs/content/integrations/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Integrations",
   "description": "Third-party integrations for Logixlysia",
-  "pages": ["pino", "..."],
+  "pages": ["pino", "otel", "..."],
   "root": true
 }

--- a/apps/docs/content/integrations/otel.mdx
+++ b/apps/docs/content/integrations/otel.mdx
@@ -1,0 +1,28 @@
+---
+title: OpenTelemetry
+description: Correlate logs with active trace and span IDs
+---
+
+Install the optional peer dependency:
+
+```bash
+bun add @opentelemetry/api
+```
+
+Import from the `logixlysia/otel` subpath:
+
+```ts
+import logixlysia from 'logixlysia'
+import { injectTraceContext } from 'logixlysia/otel'
+
+const plugin = logixlysia()
+
+const app = new Elysia()
+  .use(plugin)
+  .onRequest(({ request, store }) => {
+    injectTraceContext(store.logger, request)
+  })
+  .get('/', () => 'ok')
+```
+
+When an active span exists, `trace_id` and `span_id` are merged into the request context bag and appear on the access log. Logixlysia does not start an OpenTelemetry SDK—you bring your own tracer provider and instrumentation.

--- a/apps/elysia/src/routers/ai-metrics.ts
+++ b/apps/elysia/src/routers/ai-metrics.ts
@@ -1,0 +1,29 @@
+import type { Logixlysia } from 'logixlysia'
+import { mergeAIMetrics } from 'logixlysia/ai'
+
+export const aiMetricsRouter = <App extends Logixlysia>(app: App) =>
+  app.post(
+    '/chat',
+    ({ request, store }) => {
+      mergeAIMetrics(store.logger, request, {
+        model: 'demo-model',
+        provider: 'example',
+        inputTokens: 1200,
+        outputTokens: 320,
+        totalTokens: 1520,
+        msToFinish: 890
+      })
+      return {
+        ok: true,
+        reply: 'Demo response — check access log for `context.ai`'
+      }
+    },
+    {
+      detail: {
+        summary: 'AI metrics on access log',
+        description:
+          'Uses `mergeAIMetrics` from `logixlysia/ai` so LLM usage appears in the request context tree.',
+        tags: ['logging', 'ai']
+      }
+    }
+  )

--- a/apps/elysia/src/routers/index.ts
+++ b/apps/elysia/src/routers/index.ts
@@ -1,28 +1,43 @@
 import Elysia from 'elysia'
 import { logixlysia } from 'logixlysia'
+import { aiMetricsRouter } from './ai-metrics'
 import { autoRedactRouter } from './auto-redact'
 import { boomRouter } from './boom'
 import { customRouter } from './custom'
+import { otelRouter } from './otel'
 import { pinoRouter } from './pino'
+import { requestContextRouter } from './request-context'
 import { statusRouter } from './status'
 
-export const routers = new Elysia()
-  .use(
-    logixlysia({
-      config: {
-        service: 'elysia-demo',
-        timestamp: {
-          translateTime: 'HH:MM:ss.SSS'
-        },
-        slowThreshold: 500,
-        verySlowThreshold: 1000,
-        showContextTree: true,
-        logFilePath: './logs/example.log',
-        ip: true,
-        autoRedact: true
+type DemoWs = {
+  data: {
+    store: {
+      logger: {
+        mergeContext: (key: unknown, partial: Record<string, unknown>) => void
       }
-    })
-  )
+    }
+  }
+  send: (payload: unknown) => void
+  id?: string
+}
+
+export const logging = logixlysia({
+  preset: 'dev',
+  config: {
+    service: 'elysia-demo',
+    timestamp: {
+      translateTime: 'HH:MM:ss.SSS'
+    },
+    slowThreshold: 500,
+    verySlowThreshold: 1000,
+    logFilePath: './logs/example.log',
+    ip: true,
+    autoRedact: true
+  }
+})
+
+export const routers = new Elysia()
+  .use(logging)
   .get(
     '/',
     () => ({
@@ -36,29 +51,30 @@ export const routers = new Elysia()
     }
   )
   .use(customRouter)
+  .use(requestContextRouter)
+  .use(aiMetricsRouter)
+  .use(otelRouter)
   .use(pinoRouter)
   .use(statusRouter)
   .use(autoRedactRouter)
   .ws('/ws', {
     detail: {
-      summary: 'WebSocket echo',
+      summary: 'WebSocket echo (wrapWs)',
       description:
-        'Connect with a WebSocket client to `ws://localhost:<PORT>/ws`. Incoming messages are echoed back. Open/close events are logged via Logixlysia.',
+        'Lifecycle logs via `plugin.wrapWs`. Connect to `ws://localhost:<PORT>/ws`. Messages are echoed back.',
       tags: ['websocket']
     },
-    open(ws) {
-      ws.data.store.logger.info(ws.data.request, 'WebSocket opened', {
-        demo: 'echo'
-      })
-    },
-    message(ws, message) {
-      ws.send(message)
-    },
-    close(ws, code, reason) {
-      ws.data.store.logger.info(ws.data.request, 'WebSocket closed', {
-        code,
-        reason
-      })
-    }
+    ...logging.wrapWs('/ws', {
+      open(ws) {
+        const socket = ws as unknown as DemoWs
+        socket.data.store.logger.mergeContext(ws, { room: 'lobby' })
+      },
+      message(ws, message: unknown) {
+        ;(ws as unknown as DemoWs).send(message)
+      },
+      close() {
+        /* wrapWs logs close automatically */
+      }
+    })
   })
   .use(boomRouter)

--- a/apps/elysia/src/routers/otel.ts
+++ b/apps/elysia/src/routers/otel.ts
@@ -1,0 +1,23 @@
+import type { Logixlysia } from 'logixlysia'
+import { injectTraceContext } from 'logixlysia/otel'
+
+export const otelRouter = <App extends Logixlysia>(app: App) =>
+  app
+    .onRequest(({ request, store }) => {
+      injectTraceContext(store.logger, request)
+    })
+    .get(
+      '/trace',
+      () => ({
+        ok: true,
+        note: 'When @opentelemetry/api is installed and a span is active, trace_id / span_id appear in logs'
+      }),
+      {
+        detail: {
+          summary: 'OpenTelemetry trace correlation',
+          description:
+            'Runs `injectTraceContext` on each request. Install `@opentelemetry/api` and your tracer for live trace IDs.',
+          tags: ['logging', 'otel']
+        }
+      }
+    )

--- a/apps/elysia/src/routers/request-context.ts
+++ b/apps/elysia/src/routers/request-context.ts
@@ -1,0 +1,21 @@
+import type { Logixlysia } from 'logixlysia'
+
+export const requestContextRouter = <App extends Logixlysia>(app: App) =>
+  app.get(
+    '/checkout',
+    ({ request, store }) => {
+      store.logger.mergeContext(request, { userId: 'usr_demo' })
+      store.logger.mergeContext(request, {
+        cart: { items: 2, total: 4999 }
+      })
+      return { ok: true, note: 'See access log — context merged automatically' }
+    },
+    {
+      detail: {
+        summary: 'Request context accumulation',
+        description:
+          'Calls `mergeContext` during the handler. Fields appear on the automatic access log (no extra `logger.info` required).',
+        tags: ['logging', 'request-context']
+      }
+    }
+  )

--- a/packages/bench/index.bench.ts
+++ b/packages/bench/index.bench.ts
@@ -1,7 +1,12 @@
-import { createPinoLogger as createBogeychan } from '@bogeychan/elysia-logger'
+import {
+  logger as bogeychanLogger,
+  createPinoLogger as createBogeychan
+} from '@bogeychan/elysia-logger'
 import { consola } from 'consola'
+import { Elysia } from 'elysia'
 import { createLogger as createEvlog } from 'evlog'
-import { createLogger } from 'logixlysia/src/logger/index.js'
+import { evlog } from 'evlog/elysia'
+import logixlysia, { createLogger } from 'logixlysia'
 import pino from 'pino'
 import { bench, describe } from 'vitest'
 import winston from 'winston'
@@ -145,5 +150,47 @@ describe('Deep Nested Log', () => {
 
   bench('bogeychan', () => {
     bc.info(deepData, 'Deep nested')
+  })
+})
+
+const silentLogixConfig = {
+  disableInternalLogger: true,
+  disableFileLogging: true,
+  pino: { enabled: false }
+} as const
+
+const logixlysiaApp = new Elysia()
+  .use(logixlysia({ config: silentLogixConfig }))
+  .get('/', () => 'ok')
+
+const evlogApp = new Elysia()
+  .use(
+    evlog({
+      drain: () => {
+        /* benchmark noop */
+      }
+    })
+  )
+  .get('/', () => 'ok')
+
+const bogeychanApp = new Elysia()
+  .use(
+    bogeychanLogger({
+      enabled: false
+    })
+  )
+  .get('/', () => 'ok')
+
+describe('Elysia plugin request path', () => {
+  bench('logixlysia', async () => {
+    await logixlysiaApp.handle(new Request('http://localhost/'))
+  })
+
+  bench('evlog', async () => {
+    await evlogApp.handle(new Request('http://localhost/'))
+  })
+
+  bench('bogeychan', async () => {
+    await bogeychanApp.handle(new Request('http://localhost/'))
   })
 })

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@bogeychan/elysia-logger": "^0.1.10",
     "consola": "^3.4.2",
+    "elysia": "^1.4.28",
     "evlog": "^2.17.0",
     "logixlysia": "workspace:*",
     "pino": "^10.3.1",

--- a/packages/bench/tsconfig.json
+++ b/packages/bench/tsconfig.json
@@ -1,9 +1,4 @@
 {
   "extends": "../typescript-config/base.json",
-  "compilerOptions": {
-    "paths": {
-      "logixlysia": ["../logixlysia/src"]
-    }
-  },
   "include": ["**/*.ts"]
 }

--- a/packages/logixlysia/__tests__/ai/ai.test.ts
+++ b/packages/logixlysia/__tests__/ai/ai.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { Elysia } from 'elysia'
+
+import { logixlysia } from '../../src'
+import { mergeAIMetrics } from '../../src/ai'
+
+describe('logixlysia/ai', () => {
+  test('mergeAIMetrics adds ai object to access log context', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+
+    const app = new Elysia()
+      .use(
+        logixlysia({
+          config: {
+            transports: [{ log: transport }],
+            disableInternalLogger: true,
+            disableFileLogging: true
+          }
+        })
+      )
+      .get('/chat', ({ request, store }) => {
+        mergeAIMetrics(store.logger, request, {
+          model: 'claude-sonnet',
+          inputTokens: 100,
+          outputTokens: 50,
+          totalTokens: 150
+        })
+        return 'ok'
+      })
+
+    await app.handle(new Request('http://localhost/chat'))
+
+    const meta = transport.mock.calls[0]?.[2] as
+      | { context?: { ai?: Record<string, unknown> } }
+      | undefined
+    expect(meta?.context?.ai).toMatchObject({
+      model: 'claude-sonnet',
+      totalTokens: 150
+    })
+  })
+})

--- a/packages/logixlysia/__tests__/otel/otel.test.ts
+++ b/packages/logixlysia/__tests__/otel/otel.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createLogger } from '../../src/logger'
+import { injectTraceContext } from '../../src/otel'
+
+describe('logixlysia/otel', () => {
+  test('injectTraceContext is a no-op when OpenTelemetry is not installed', () => {
+    const logger = createLogger({
+      config: {
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    })
+    const request = new Request('http://localhost/')
+
+    expect(injectTraceContext(logger, request)).toBeUndefined()
+    expect(logger.getContext(request)).toEqual({})
+  })
+})

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'bunup'
 const config = defineConfig({
   name: 'Logixlysia',
   outDir: 'dist',
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/otel.ts'],
   format: ['esm'],
   dts: true,
   minify: true,

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'bunup'
 const config = defineConfig({
   name: 'Logixlysia',
   outDir: 'dist',
-  entry: ['src/index.ts', 'src/otel.ts'],
+  entry: ['src/index.ts', 'src/otel.ts', 'src/ai.ts'],
   format: ['esm'],
   dts: true,
   minify: true,

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -4,6 +4,16 @@
   "description": "🦊 Logixlysia is a logger for Elysia",
   "type": "module",
   "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./otel": {
+      "types": "./dist/otel.d.ts",
+      "import": "./dist/otel.js"
+    }
+  },
   "files": [
     "dist",
     "README.md"
@@ -46,7 +56,13 @@
     "elysia": "^1.4.28"
   },
   "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "elysia": "^1.4.28",
     "typescript": "^6.0.2"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    }
   }
 }

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -12,7 +12,12 @@
     "./otel": {
       "types": "./dist/otel.d.ts",
       "import": "./dist/otel.js"
-    }
+    },
+    "./ai": {
+      "types": "./dist/ai.d.ts",
+      "import": "./dist/ai.js"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",
@@ -57,11 +62,15 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",
+    "ai": "^6.0.0",
     "elysia": "^1.4.28",
     "typescript": "^6.0.2"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {
+      "optional": true
+    },
+    "ai": {
       "optional": true
     }
   }

--- a/packages/logixlysia/src/ai.ts
+++ b/packages/logixlysia/src/ai.ts
@@ -1,0 +1,32 @@
+import type { Logger } from './interfaces'
+
+export interface AIMetrics {
+  calls?: number
+  finishReason?: string
+  inputTokens?: number
+  model?: string
+  msToFinish?: number
+  msToFirstChunk?: number
+  outputTokens?: number
+  provider?: string
+  reasoningTokens?: number
+  tokensPerSecond?: number
+  totalTokens?: number
+}
+
+/**
+ * Merges AI SDK / LLM usage metrics into the request context bag so they appear
+ * on the final access log (evlog-style `ai` object).
+ */
+export const mergeAIMetrics = (
+  logger: Pick<Logger, 'mergeContext'>,
+  request: Request,
+  metrics: AIMetrics
+): void => {
+  if (Object.keys(metrics).length === 0) {
+    return
+  }
+  logger.mergeContext(request, { ai: metrics })
+}
+
+export { mergeAIMetrics as default }

--- a/packages/logixlysia/src/otel.ts
+++ b/packages/logixlysia/src/otel.ts
@@ -1,0 +1,61 @@
+import { createRequire } from 'node:module'
+import type { Logger } from './interfaces'
+
+const requireOtel = createRequire(import.meta.url)
+
+export interface TraceContextFields {
+  span_id?: string
+  trace_id?: string
+}
+
+interface OtelApi {
+  context: { active: () => unknown }
+  trace: {
+    getSpan: (
+      ctx: unknown
+    ) => { spanContext: () => { traceId: string; spanId: string } } | undefined
+  }
+}
+
+let otelApi: OtelApi | null | undefined
+
+const getOtelApi = (): OtelApi | null => {
+  if (otelApi !== undefined) {
+    return otelApi
+  }
+  try {
+    otelApi = requireOtel('@opentelemetry/api') as OtelApi
+  } catch {
+    otelApi = null
+  }
+  return otelApi
+}
+
+/**
+ * Injects active OpenTelemetry span IDs into the request context bag when
+ * `@opentelemetry/api` is installed and a span is active.
+ */
+export const injectTraceContext = (
+  logger: Pick<Logger, 'mergeContext'>,
+  request: Request
+): TraceContextFields | undefined => {
+  const api = getOtelApi()
+  if (!api) {
+    return
+  }
+
+  const span = api.trace.getSpan(api.context.active())
+  if (!span) {
+    return
+  }
+
+  const { traceId, spanId } = span.spanContext()
+  const fields = {
+    trace_id: traceId,
+    span_id: spanId
+  } satisfies TraceContextFields
+  logger.mergeContext(request, fields)
+  return fields
+}
+
+export { injectTraceContext as default }


### PR DESCRIPTION
## Description

Updates the `apps/elysia` demo to showcase new Logixlysia capabilities: request context accumulation, AI metrics, OTel trace injection, `preset: 'dev'`, and WebSocket logging via `wrapWs`.

### Problem

The example app only demonstrated basic HTTP logging; new APIs had no live routes for reviewers or users trying the repo locally.

### Result

- Routers: `request-context`, `ai-metrics`, `otel`
- `logging` plugin uses `preset: 'dev'` and `wrapWs` on `/ws` with context merge
- Typecheck passes against workspace `logixlysia` build
- No changeset (elysia-example ignored)

## Related Issues

N/A

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Additional Notes

**Stack:** PR 8 of 8 — base: `docs/competitive-adoption`. Run demo: `cd apps/elysia && bun run dev`.

Made with [Cursor](https://cursor.com)