### PR TITLE
feat(logixlysia): implement request ID middleware and telemetry unit tests

### DIFF
--- a/.changeset/add-request-id-feature.md
+++ b/.changeset/add-request-id-feature.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": patch
+---
+
+Add Request ID middleware, `{requestId}` custom log token, preset integrations, and expand telemetry unit tests for OTel & AI.

--- a/apps/docs/content/features/meta.json
+++ b/apps/docs/content/features/meta.json
@@ -6,6 +6,7 @@
     "startup",
     "presets",
     "request-context",
+    "request-id",
     "websocket",
     "formatting",
     "filtering",

--- a/apps/docs/content/features/request-id.mdx
+++ b/apps/docs/content/features/request-id.mdx
@@ -1,0 +1,87 @@
+---
+title: Request ID
+description: Generate or honor unique request identifiers across requests and responses
+---
+
+Logixlysia can automatically generate or retrieve unique request identifiers (Request IDs) and attach them to the request context, response headers, and log outputs.
+
+## Basic Usage
+
+You can enable the request ID feature using the `requestId` config option. When set to `true`, it uses the default configuration (`X-Request-Id` header and UUID v4 generator).
+
+```ts
+import { Elysia } from 'elysia'
+import { logixlysia } from 'logixlysia'
+
+const app = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        requestId: true
+      }
+    })
+  )
+```
+
+## Production Preset
+
+The `prod` preset enables `requestId` automatically by default:
+
+```ts
+const app = new Elysia()
+  .use(
+    logixlysia({
+      preset: 'prod' // requestId is enabled automatically
+    })
+  )
+```
+
+## Custom Configuration
+
+For advanced use cases, you can pass a configuration object instead of a boolean:
+
+```ts
+const app = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        requestId: {
+          // Custom header name to read from / write to
+          header: 'X-Correlation-Id',
+          // Custom request ID generator function
+          generator: () => `req-${crypto.randomUUID()}`
+        }
+      }
+    })
+  )
+```
+
+### Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | `boolean` | `true` | Turn request ID generation on or off when using object configuration. |
+| `header` | `string` | `'X-Request-Id'` | The header key to check on incoming requests (honoring upstream proxies) and to set on responses. |
+| `generator` | `() => string` | `crypto.randomUUID` | A function that returns a unique string to use as the request ID. |
+
+## Log Formatting
+
+When Request ID is enabled, you can output it in your custom log format using the `{requestId}` token:
+
+```ts
+const app = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        requestId: true,
+        customLogFormat: '{method} {pathname} - Request ID: {requestId}'
+      }
+    })
+  )
+```
+
+If Request ID is disabled or not present, the token will render as an empty string.
+
+## Error Responses
+
+If a request fails (e.g. throws an exception), the request ID is still propagated in the response headers (like `X-Request-Id`) and is correctly logged in the HTTP error telemetry context, allowing trace correlation for failed requests.

--- a/packages/logixlysia/__tests__/ai/ai.test.ts
+++ b/packages/logixlysia/__tests__/ai/ai.test.ts
@@ -42,4 +42,78 @@ describe('logixlysia/ai', () => {
       totalTokens: 150
     })
   })
+
+  test('all AIMetrics fields are preserved in context', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+
+    const allMetrics = {
+      calls: 3,
+      finishReason: 'stop',
+      inputTokens: 200,
+      model: 'gpt-4o',
+      msToFinish: 1200,
+      msToFirstChunk: 80,
+      outputTokens: 400,
+      provider: 'openai',
+      reasoningTokens: 50,
+      tokensPerSecond: 120,
+      totalTokens: 650
+    }
+
+    const app = new Elysia()
+      .use(
+        logixlysia({
+          config: {
+            transports: [{ log: transport }],
+            disableInternalLogger: true,
+            disableFileLogging: true
+          }
+        })
+      )
+      .get('/all-fields', ({ request, store }) => {
+        mergeAIMetrics(store.logger, request, allMetrics)
+        return 'ok'
+      })
+
+    await app.handle(new Request('http://localhost/all-fields'))
+
+    const meta = transport.mock.calls[0]?.[2] as
+      | { context?: { ai?: Record<string, unknown> } }
+      | undefined
+    expect(meta?.context?.ai).toEqual(allMetrics)
+  })
+
+  test('empty metrics object is a no-op', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+
+    const app = new Elysia()
+      .use(
+        logixlysia({
+          config: {
+            transports: [{ log: transport }],
+            disableInternalLogger: true,
+            disableFileLogging: true
+          }
+        })
+      )
+      .get('/empty', ({ request, store }) => {
+        mergeAIMetrics(store.logger, request, {})
+        return 'ok'
+      })
+
+    await app.handle(new Request('http://localhost/empty'))
+
+    const meta = transport.mock.calls[0]?.[2] as
+      | { context?: { ai?: Record<string, unknown> } }
+      | undefined
+    expect(meta?.context?.ai).toBeUndefined()
+  })
 })

--- a/packages/logixlysia/__tests__/middleware/request-id.test.ts
+++ b/packages/logixlysia/__tests__/middleware/request-id.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  getOrCreateRequestId,
+  type ResolvedRequestIdConfig,
+  resolveRequestIdConfig
+} from '../../src/middleware/request-id'
+
+const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+describe('resolveRequestIdConfig', () => {
+  test('returns null when undefined', () => {
+    expect(resolveRequestIdConfig(undefined)).toBeNull()
+  })
+
+  test('returns null when false', () => {
+    expect(resolveRequestIdConfig(false)).toBeNull()
+  })
+
+  test('returns default config when true', () => {
+    const config = resolveRequestIdConfig(true)
+    expect(config).not.toBeNull()
+    expect(config?.enabled).toBe(true)
+    expect(config?.header).toBe('X-Request-Id')
+    expect(typeof config?.generator).toBe('function')
+    // default generator produces UUID v4 format
+    const id = config?.generator?.()
+    expect(id).toMatch(UUID_V4_REGEX)
+  })
+
+  test('returns null when object has enabled: false', () => {
+    expect(resolveRequestIdConfig({ enabled: false })).toBeNull()
+  })
+
+  test('uses custom header name', () => {
+    const config = resolveRequestIdConfig({ header: 'X-Correlation-Id' })
+    expect(config).not.toBeNull()
+    expect(config?.header).toBe('X-Correlation-Id')
+  })
+
+  test('trims whitespace from header name', () => {
+    const config = resolveRequestIdConfig({ header: '  X-Trace-Id  ' })
+    expect(config?.header).toBe('X-Trace-Id')
+  })
+
+  test('falls back to default header when empty string', () => {
+    const config = resolveRequestIdConfig({ header: '  ' })
+    expect(config?.header).toBe('X-Request-Id')
+  })
+
+  test('uses custom generator', () => {
+    const config = resolveRequestIdConfig({
+      generator: () => 'custom-id-123'
+    })
+    expect(config).not.toBeNull()
+    expect(config?.generator?.()).toBe('custom-id-123')
+  })
+
+  test('defaults enabled to true when object is provided without enabled field', () => {
+    const config = resolveRequestIdConfig({})
+    expect(config).not.toBeNull()
+    expect(config?.enabled).toBe(true)
+  })
+})
+
+describe('getOrCreateRequestId', () => {
+  const defaultConfig: ResolvedRequestIdConfig = {
+    enabled: true,
+    header: 'X-Request-Id',
+    generator: () => 'generated-uuid'
+  }
+
+  test('generates new ID when no header present', () => {
+    const request = new Request('http://localhost/test')
+    const id = getOrCreateRequestId(request, defaultConfig)
+    expect(id).toBe('generated-uuid')
+  })
+
+  test('honors existing X-Request-Id header', () => {
+    const request = new Request('http://localhost/test', {
+      headers: { 'X-Request-Id': 'existing-id-from-gateway' }
+    })
+    const id = getOrCreateRequestId(request, defaultConfig)
+    expect(id).toBe('existing-id-from-gateway')
+  })
+
+  test('uses custom header name to read existing ID', () => {
+    const config: ResolvedRequestIdConfig = {
+      enabled: true,
+      header: 'X-Correlation-Id',
+      generator: () => 'fallback'
+    }
+    const request = new Request('http://localhost/test', {
+      headers: { 'X-Correlation-Id': 'corr-456' }
+    })
+    const id = getOrCreateRequestId(request, config)
+    expect(id).toBe('corr-456')
+  })
+
+  test('generates ID when custom header is absent', () => {
+    const config: ResolvedRequestIdConfig = {
+      enabled: true,
+      header: 'X-Correlation-Id',
+      generator: () => 'new-corr-id'
+    }
+    const request = new Request('http://localhost/test')
+    const id = getOrCreateRequestId(request, config)
+    expect(id).toBe('new-corr-id')
+  })
+
+  test('uses custom generator function', () => {
+    let counter = 0
+    const config: ResolvedRequestIdConfig = {
+      enabled: true,
+      header: 'X-Request-Id',
+      generator: () => `req-${++counter}`
+    }
+    const req1 = new Request('http://localhost/1')
+    const req2 = new Request('http://localhost/2')
+    expect(getOrCreateRequestId(req1, config)).toBe('req-1')
+    expect(getOrCreateRequestId(req2, config)).toBe('req-2')
+  })
+})

--- a/packages/logixlysia/__tests__/otel/otel-mock.test.ts
+++ b/packages/logixlysia/__tests__/otel/otel-mock.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+import { createLogger } from '../../src/logger'
+import { __resetForTesting, injectTraceContext } from '../../src/otel'
+
+const fakeSpanContext = {
+  traceId: 'abc123def456789012345678abcdef01',
+  spanId: '0123456789abcdef'
+}
+
+const getSpanMock = mock(() => ({
+  spanContext: () => fakeSpanContext
+}))
+
+// Mock @opentelemetry/api so that createRequire('...')('@opentelemetry/api')
+// resolves to our fake API.
+mock.module('@opentelemetry/api', () => ({
+  context: { active: () => ({}) },
+  trace: { getSpan: getSpanMock }
+}))
+
+describe('logixlysia/otel (mocked)', () => {
+  afterEach(() => {
+    // Reset the module-level cache so each test starts fresh
+    __resetForTesting()
+    getSpanMock.mockImplementation(() => ({
+      spanContext: () => fakeSpanContext
+    }))
+  })
+
+  test('injects trace_id & span_id when OTel API returns an active span', () => {
+    // Reset cache so it re-resolves from the mock
+    __resetForTesting()
+
+    const logger = createLogger({
+      config: {
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    })
+    const request = new Request('http://localhost/')
+
+    const result = injectTraceContext(logger, request)
+
+    expect(result).toEqual({
+      trace_id: fakeSpanContext.traceId,
+      span_id: fakeSpanContext.spanId
+    })
+    expect(logger.getContext(request)).toMatchObject({
+      trace_id: fakeSpanContext.traceId,
+      span_id: fakeSpanContext.spanId
+    })
+  })
+
+  test('returns undefined when getSpan returns no active span', () => {
+    __resetForTesting()
+    getSpanMock.mockImplementation(() => undefined as any)
+
+    const logger = createLogger({
+      config: {
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    })
+    const request = new Request('http://localhost/')
+
+    const result = injectTraceContext(logger, request)
+
+    expect(result).toBeUndefined()
+    expect(logger.getContext(request)).toEqual({})
+  })
+})

--- a/packages/logixlysia/__tests__/plugin/request-id.test.ts
+++ b/packages/logixlysia/__tests__/plugin/request-id.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { Elysia } from 'elysia'
+
+import { logixlysia } from '../../src'
+import type { Options } from '../../src/interfaces'
+
+const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+describe('request ID plugin integration', () => {
+  test('auto-merges requestId into log context', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const options: Options = {
+      config: {
+        requestId: true,
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/test', () => 'ok')
+
+    await app.handle(new Request('http://localhost/test'))
+
+    expect(transport).toHaveBeenCalledTimes(1)
+    const meta = transport.mock.calls[0]?.[2] as
+      | { context?: { requestId?: string } }
+      | undefined
+    expect(meta?.context?.requestId).toBeDefined()
+    expect(typeof meta?.context?.requestId).toBe('string')
+    // UUID v4 format
+    expect(meta?.context?.requestId).toMatch(UUID_V4_REGEX)
+  })
+
+  test('sets X-Request-Id response header', async () => {
+    const options: Options = {
+      config: {
+        requestId: true,
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/test', () => 'ok')
+
+    const response = await app.handle(new Request('http://localhost/test'))
+
+    const responseId = response.headers.get('X-Request-Id')
+    expect(responseId).toBeDefined()
+    expect(responseId).toMatch(UUID_V4_REGEX)
+  })
+
+  test('honors incoming X-Request-Id header', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const options: Options = {
+      config: {
+        requestId: true,
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/test', () => 'ok')
+
+    const incomingId = 'gateway-req-abc-123'
+    const response = await app.handle(
+      new Request('http://localhost/test', {
+        headers: { 'X-Request-Id': incomingId }
+      })
+    )
+
+    // Response header should reflect the incoming ID
+    expect(response.headers.get('X-Request-Id')).toBe(incomingId)
+
+    // Transport should also receive the incoming ID
+    const meta = transport.mock.calls[0]?.[2] as
+      | { context?: { requestId?: string } }
+      | undefined
+    expect(meta?.context?.requestId).toBe(incomingId)
+  })
+
+  test('disabled by default — no requestId in context', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const options: Options = {
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/test', () => 'ok')
+
+    const response = await app.handle(new Request('http://localhost/test'))
+
+    // No X-Request-Id header on response
+    expect(response.headers.get('X-Request-Id')).toBeNull()
+
+    // No requestId in log context
+    const meta = transport.mock.calls[0]?.[2] as
+      | { context?: { requestId?: string } }
+      | undefined
+    expect(meta?.context?.requestId).toBeUndefined()
+  })
+
+  test('uses custom header name from RequestIdConfig', async () => {
+    const options: Options = {
+      config: {
+        requestId: { header: 'X-Correlation-Id' },
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/test', () => 'ok')
+
+    const response = await app.handle(new Request('http://localhost/test'))
+
+    // Should use the custom header name
+    expect(response.headers.get('X-Correlation-Id')).toBeDefined()
+    // Default header should not be set
+    expect(response.headers.get('X-Request-Id')).toBeNull()
+  })
+
+  test('uses custom generator from RequestIdConfig', async () => {
+    let counter = 0
+    const options: Options = {
+      config: {
+        requestId: { generator: () => `custom-${++counter}` },
+        transports: [
+          {
+            log: () => {
+              /* noop */
+            }
+          }
+        ],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/test', () => 'ok')
+
+    const res1 = await app.handle(new Request('http://localhost/test'))
+    const res2 = await app.handle(new Request('http://localhost/test'))
+
+    expect(res1.headers.get('X-Request-Id')).toBe('custom-1')
+    expect(res2.headers.get('X-Request-Id')).toBe('custom-2')
+  })
+
+  test('{requestId} token works in customLogFormat', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const options: Options = {
+      config: {
+        requestId: { generator: () => 'test-req-id-789' },
+        customLogFormat: '{method} {pathname} {requestId}',
+        transports: [{ log: transport }],
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/test', () => 'ok')
+
+    await app.handle(new Request('http://localhost/test'))
+
+    // The transport receives unformatted data, but the internal logger
+    // uses the format string. We verify via the transport that requestId
+    // is in the context.
+    const meta = transport.mock.calls[0]?.[2] as
+      | { context?: { requestId?: string } }
+      | undefined
+    expect(meta?.context?.requestId).toBe('test-req-id-789')
+  })
+
+  test('prod preset enables requestId by default', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const options: Options = {
+      preset: 'prod',
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/test', () => 'ok')
+
+    await app.handle(new Request('http://localhost/test'))
+
+    const meta = transport.mock.calls[0]?.[2] as
+      | { context?: { requestId?: string } }
+      | undefined
+    expect(meta?.context?.requestId).toBeDefined()
+    expect(typeof meta?.context?.requestId).toBe('string')
+  })
+
+  test('sets X-Request-Id response header on errors', async () => {
+    const options: Options = {
+      config: {
+        requestId: true,
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/error', () => {
+      throw new Error('something went wrong')
+    })
+
+    const response = await app.handle(new Request('http://localhost/error'))
+
+    const responseId = response.headers.get('X-Request-Id')
+    expect(responseId).toBeDefined()
+    expect(responseId).toMatch(UUID_V4_REGEX)
+  })
+})

--- a/packages/logixlysia/src/config/resolve-options.ts
+++ b/packages/logixlysia/src/config/resolve-options.ts
@@ -17,6 +17,7 @@ const PRESET_DEFAULTS: Record<LogPreset, NonNullable<Options['config']>> = {
     useColors: false,
     showContextTree: false,
     autoRedact: true,
+    requestId: true,
     pino: {
       prettyPrint: false
     }

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -4,6 +4,10 @@ import { createRequestContextStore } from './context/request-context'
 import { startServer } from './extensions'
 import type { LogixlysiaStore, Options } from './interfaces'
 import { createPluginLogger } from './logger'
+import {
+  getOrCreateRequestId,
+  resolveRequestIdConfig
+} from './middleware/request-id'
 import { createWsHandlerWrapper } from './websocket/wrap-ws'
 
 /**
@@ -39,6 +43,7 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
   const contextStore = createRequestContextStore()
   const baseLogger = createPluginLogger(options, contextStore)
   const wrapWs = createWsHandlerWrapper(options, baseLogger, contextStore)
+  const requestIdConfig = resolveRequestIdConfig(options.config?.requestId)
   const logger = {
     ...baseLogger,
     debug: (
@@ -97,11 +102,23 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
         startServer({ port, hostname, protocol: 'http' }, options)
       }
     })
-    .onRequest(({ store }) => {
+    .onRequest(({ request, store }) => {
       store.beforeTime = process.hrtime.bigint()
+      if (requestIdConfig) {
+        const requestId = getOrCreateRequestId(request, requestIdConfig)
+        contextStore.mergeContext(request, { requestId })
+      }
     })
     .onAfterHandle(({ request, set, store }) => {
       try {
+        if (requestIdConfig) {
+          const ctx = contextStore.getContext(request)
+          const id = ctx.requestId as string | undefined
+          if (id) {
+            set.headers[requestIdConfig.header] = id
+          }
+        }
+
         if (didCustomLog.has(request)) {
           return
         }
@@ -125,8 +142,15 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
         contextStore.clearContext(request)
       }
     })
-    .onError(({ request, error, store }) => {
+    .onError(({ request, error, set, store }) => {
       try {
+        if (requestIdConfig) {
+          const ctx = contextStore.getContext(request)
+          const id = ctx.requestId as string | undefined
+          if (id) {
+            set.headers[requestIdConfig.header] = id
+          }
+        }
         logger.handleHttpError(request, error, store)
       } finally {
         contextStore.clearContext(request)
@@ -147,10 +171,16 @@ export type {
   LogPreset,
   Options,
   Pino,
+  RequestIdConfig,
   StoreData,
   Transport
 } from './interfaces'
 export { createLogger, createPluginLogger } from './logger'
+export type { ResolvedRequestIdConfig } from './middleware/request-id'
+export {
+  getOrCreateRequestId,
+  resolveRequestIdConfig
+} from './middleware/request-id'
 export type { WsHandlerHooks } from './websocket/wrap-ws'
 export { createWsHandlerWrapper } from './websocket/wrap-ws'
 

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -65,6 +65,24 @@ export type PrettyPrintConfig = boolean | Record<string, unknown>
 
 export type LogPreset = 'dev' | 'prod' | 'json'
 
+export interface RequestIdConfig {
+  /**
+   * Enable request ID generation.
+   * When used as a boolean on `Options.config.requestId`, `true` enables with defaults.
+   */
+  enabled?: boolean
+  /**
+   * Custom ID generator function.
+   * @default crypto.randomUUID()
+   */
+  generator?: () => string
+  /**
+   * Header name to read from the incoming request and write to the response.
+   * @default 'X-Request-Id'
+   */
+  header?: string
+}
+
 export interface Options {
   config?: {
     showStartupMessage?: boolean
@@ -92,6 +110,21 @@ export interface Options {
 
     /** Skip automatic WebSocket lifecycle logs from `wrapWs`; default false. */
     disableWebSocketLogging?: boolean
+
+    /**
+     * Enable automatic request ID generation and propagation.
+     *
+     * - `true`: Enable with defaults (`X-Request-Id` header, `crypto.randomUUID()` generator).
+     * - `false` or `undefined`: Disabled (default).
+     * - `RequestIdConfig` object: Enable with custom header name and/or generator.
+     *
+     * When enabled, the plugin will:
+     * 1. Read `X-Request-Id` (or custom header) from the incoming request — honoring IDs set by upstream proxies.
+     * 2. Generate a new UUID if no header is present.
+     * 3. Merge `{ requestId }` into the request context (appears in logs and context tree).
+     * 4. Set the header on the outgoing response for client-side tracing.
+     */
+    requestId?: boolean | RequestIdConfig
 
     // Filtering
     logFilter?: LogFilter

--- a/packages/logixlysia/src/logger/create-logger.ts
+++ b/packages/logixlysia/src/logger/create-logger.ts
@@ -21,7 +21,7 @@ const DEFAULT_LOG_FORMAT =
   '{now} {service}{icon} {method} {pathname} {status} {duration} {message}{speed}'
 
 const LOG_FORMAT_REGEX =
-  /\{(now|epoch|level|icon|duration|method|pathname|path|query|status|statusText|message|ip|context|service|speed)\}/g
+  /\{(now|epoch|level|icon|duration|method|pathname|path|query|status|statusText|message|ip|context|service|speed|requestId)\}/g
 
 export interface FormattedLogOutput {
   contextLines: string[]
@@ -484,7 +484,13 @@ export const formatLogOutput = ({
     '{ip}': ip,
     '{context}': ctxString,
     '{service}': serviceToken,
-    '{speed}': speedToken
+    '{speed}': speedToken,
+    '{requestId}':
+      typeof data.context === 'object' &&
+      data.context !== null &&
+      'requestId' in data.context
+        ? String((data.context as Record<string, unknown>).requestId)
+        : ''
   }
 
   const main = format.replace(

--- a/packages/logixlysia/src/middleware/request-id.ts
+++ b/packages/logixlysia/src/middleware/request-id.ts
@@ -1,0 +1,58 @@
+import type { RequestIdConfig } from '../interfaces'
+
+const DEFAULT_HEADER = 'X-Request-Id'
+
+export interface ResolvedRequestIdConfig {
+  enabled: boolean
+  generator: () => string
+  header: string
+}
+
+/**
+ * Normalises the `requestId` option into a concrete config object.
+ *
+ * - `undefined` / `false` → `null` (disabled)
+ * - `true` → default config
+ * - `RequestIdConfig` → merged with defaults; `enabled: false` inside the object disables the feature
+ */
+export const resolveRequestIdConfig = (
+  raw?: boolean | RequestIdConfig
+): ResolvedRequestIdConfig | null => {
+  if (raw === undefined || raw === false) {
+    return null
+  }
+
+  if (raw === true) {
+    return {
+      enabled: true,
+      header: DEFAULT_HEADER,
+      generator: () => crypto.randomUUID()
+    }
+  }
+
+  // Object form — `enabled` defaults to `true` when the object is provided
+  if (raw.enabled === false) {
+    return null
+  }
+
+  return {
+    enabled: true,
+    header: raw.header?.trim() || DEFAULT_HEADER,
+    generator: raw.generator ?? (() => crypto.randomUUID())
+  }
+}
+
+/**
+ * Reads an existing request ID from the incoming request header, or generates a
+ * new one using the configured generator.
+ */
+export const getOrCreateRequestId = (
+  request: Request,
+  config: ResolvedRequestIdConfig
+): string => {
+  const existing = request.headers.get(config.header)
+  if (existing) {
+    return existing
+  }
+  return config.generator()
+}

--- a/packages/logixlysia/src/otel.ts
+++ b/packages/logixlysia/src/otel.ts
@@ -58,4 +58,9 @@ export const injectTraceContext = (
   return fields
 }
 
+/** @internal Reset the cached OTel API reference. Only intended for tests. */
+export const __resetForTesting = (): void => {
+  otelApi = undefined
+}
+
 export { injectTraceContext as default }


### PR DESCRIPTION
## Description

This PR implements the Request ID feature for `logixlysia` along with improved test coverage for telemetry components (AI metrics and OpenTelemetry trace context injection). 

Specifically, it:
1. Adds `RequestIdConfig` to options (supporting either boolean shorthand or full custom object configuration).
2. Implements a new Request ID middleware that resolves configuration, honors upstream gateway headers, and uses custom generators if specified.
3. Integrates Request ID tracking in the Elysia plugin hooks (`onRequest`, `onAfterHandle`, and `onError` to ensure headers are sent back in error responses).
4. Registers a `{requestId}` custom log token and enables Request ID by default in the `prod` preset.
5. Adds comprehensive unit and integration tests (including module resets for OpenTelemetry mock verification).
6. Fixes linter rules/formatting using Biome.

## Related Issues

N/A

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

N/A

## Additional Notes

- The Request ID feature is disabled by default, except in the `prod` preset where it is enabled for production observability.
- All 112 tests are passing, and formatting is verified with `ultracite`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Request ID middleware enables automatic request identification and propagation through response headers
  * Support for custom header names and ID generators via configuration
  * Request IDs can be included in custom log formats using the `{requestId}` token
  * Enabled by default in production preset

* **Documentation**
  * Added comprehensive Request ID configuration and usage guide

* **Tests**
  * Expanded test coverage for request ID functionality, telemetry integration, and AI metrics handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->