### PR TITLE
fix(logixlysia): prevent autoRedact crash on consumed request bodies

### DIFF
--- a/.changeset/fix-autoredact-consumed-body.md
+++ b/.changeset/fix-autoredact-consumed-body.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": patch
+---
+
+Fix `autoRedact` crashing routes with a request body. `redactRequest` no longer re-attaches the original (possibly already-consumed) request stream to its logging-only clone, which avoids the `ReadableStream has already been used` error when a redacted URL/header/method coincides with a parsed body (#329).

--- a/packages/logixlysia/__tests__/utils/redact.test.ts
+++ b/packages/logixlysia/__tests__/utils/redact.test.ts
@@ -176,4 +176,24 @@ describe('redactRequest', () => {
     const req = new Request('http://localhost/plain')
     expect(redactRequest(req)).toBe(req)
   })
+
+  test('does not throw when the body was already consumed and a header needs redaction', async () => {
+    const req = new Request('http://localhost/user', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-forwarded-for': '10.0.0.1'
+      },
+      body: JSON.stringify({ name: 'alice' })
+    })
+
+    // Mirror Elysia consuming the body before logging runs.
+    await req.text()
+
+    let out: Request
+    expect(() => {
+      out = redactRequest(req)
+    }).not.toThrow()
+    expect(out!.headers.get('x-forwarded-for')).toBe('[REDACTED]')
+  })
 })

--- a/packages/logixlysia/__tests__/utils/redact.test.ts
+++ b/packages/logixlysia/__tests__/utils/redact.test.ts
@@ -190,10 +190,7 @@ describe('redactRequest', () => {
     // Mirror Elysia consuming the body before logging runs.
     await req.text()
 
-    let out: Request
-    expect(() => {
-      out = redactRequest(req)
-    }).not.toThrow()
-    expect(out!.headers.get('x-forwarded-for')).toBe('[REDACTED]')
+    const out = redactRequest(req)
+    expect(out.headers.get('x-forwarded-for')).toBe('[REDACTED]')
   })
 })

--- a/packages/logixlysia/__tests__/utils/redact.test.ts
+++ b/packages/logixlysia/__tests__/utils/redact.test.ts
@@ -177,7 +177,7 @@ describe('redactRequest', () => {
     expect(redactRequest(req)).toBe(req)
   })
 
-  test('does not throw when the body was already consumed and a header needs redaction', async () => {
+  test('redacts a header without re-using the body of a consumed request', async () => {
     const req = new Request('http://localhost/user', {
       method: 'POST',
       headers: {
@@ -192,5 +192,10 @@ describe('redactRequest', () => {
 
     const out = redactRequest(req)
     expect(out.headers.get('x-forwarded-for')).toBe('[REDACTED]')
+    // The logging-only clone must not carry the original (already-consumed)
+    // stream — re-attaching it is what threw "ReadableStream has already been
+    // used" on Bun <=1.2.x. Asserting a null body guards the fix on every Bun
+    // version, not just the ones where the reuse happens to throw.
+    expect(out.body).toBeNull()
   })
 })

--- a/packages/logixlysia/src/utils/redact.ts
+++ b/packages/logixlysia/src/utils/redact.ts
@@ -196,8 +196,10 @@ const redactInner = <T>(value: T, inProgress: WeakSet<object>): T => {
 export const redact = <T>(value: T): T => redactInner(value, new WeakSet())
 
 /**
- * Clone request URL and headers for logging with the same string redaction as {@link redact}.
- * Preserves body and signal so the original request is still usable.
+ * Clone request URL, method and headers for logging with the same string redaction as {@link redact}.
+ * The returned request is a logging-only artifact carrying url/method/headers/signal; it intentionally
+ * omits the body so it never re-uses the original (possibly already-consumed) request stream. The
+ * original request is left untouched and remains usable.
  */
 export const redactRequest = (request: Request): Request => {
   const redactedUrl = redactRequestUrl(request.url)
@@ -220,16 +222,11 @@ export const redactRequest = (request: Request): Request => {
     return request
   }
 
-  const init: RequestInit & { duplex?: 'half' } = {
+  const init: RequestInit = {
     method: redactedMethod,
     headers: nextHeaders,
     redirect: request.redirect,
     signal: request.signal
-  }
-
-  if (request.body !== null) {
-    init.body = request.body
-    init.duplex = 'half'
   }
 
   return new Request(redactedUrl, init)


### PR DESCRIPTION
## Description

When `autoRedact: true` (the default in the `prod` preset), logging crashed on routes whose request body had already been parsed by Elysia. `redactRequest` re-attached the original request stream to its logging-only clone, so when the URL/headers/method contained PII to redact, constructing the new `Request` reused an exhausted `ReadableStream` and threw `ReadableStream has already been used`.

The request body is never read for logging (only `url`, `method`, and `headers` are), so this drops the body/`duplex` re-attachment from `redactRequest`. The clone is now strictly a logging artifact, and the original request is left untouched.

## Related Issues

Closes #329

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Screenshots (if applicable)

<!-- Not applicable — non-UI bugfix. -->

## Additional Notes

Added a regression test (`__tests__/utils/redact.test.ts`) covering a consumed body alongside a PII header (`x-forwarded-for`); it fails before the fix and passes after. Full suite: 113 pass, 0 fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed autoRedact crashes when routes include request bodies; logging no longer attempts to reuse already-consumed request streams and avoids "ReadableStream has already been used" errors.
* **Tests**
  * Added a test that covers redaction after a request body has been consumed.
* **Documentation**
  * Clarified that logged redactions include URL/method/headers/signal and do not preserve the original request body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->