### PR TITLE
feat(logixlysia): support structured HTTP error logging

### DIFF
--- a/.changeset/feat-structured-errors.md
+++ b/.changeset/feat-structured-errors.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": minor
+---
+
+Add support for structured HTTP error logging, formatting properties such as `why`, `fix`, `link`, and `internal` inside the development context tree console log.

--- a/apps/docs/content/features/formatting.mdx
+++ b/apps/docs/content/features/formatting.mdx
@@ -125,9 +125,12 @@ Logixlysia natively supports structured errors (similar to the `evlog` pattern) 
 - `why`: Explains the root cause of the error.
 - `fix`: Suggests actionable remediation.
 - `link`: Provides a URL to documentation or troubleshooting help.
-- `internal`: Contains sensitive or deep metadata.
+- `internal`: Log-safe diagnostic metadata (e.g. error codes, non-sensitive context).
 
-If a caught error contains any of these fields, they are automatically extracted and rendered under the `error.` namespace (`error.why`, `error.fix`, `error.link`, and `error.internal`) as individual tree branches:
+If a caught error contains any of these fields, they are automatically extracted and rendered under the `error.` namespace (`error.why`, `error.fix`, `error.link`, and `error.internal`) as individual tree branches.
+
+> [!WARNING]
+> Because `error.internal` is emitted verbatim to logs, it should contain only log-safe diagnostic metadata. Do not place sensitive secrets, credentials, or PII (Personally Identifiable Information) in this field.
 
 ```ts
 // Custom error implementation

--- a/apps/docs/content/features/formatting.mdx
+++ b/apps/docs/content/features/formatting.mdx
@@ -118,6 +118,40 @@ Example (no ANSI colors), after a main line like `… GET /orders 500 3ms Checko
   └─ error  Card declined
 ```
 
+### Structured Error Logs
+
+Logixlysia natively supports structured errors (similar to the `evlog` pattern) when thrown exceptions contain specific troubleshooting fields:
+
+- `why`: Explains the root cause of the error.
+- `fix`: Suggests actionable remediation.
+- `link`: Provides a URL to documentation or troubleshooting help.
+- `internal`: Contains sensitive or deep metadata.
+
+If a caught error contains any of these fields, they are automatically extracted and rendered under the `error.` namespace (`error.why`, `error.fix`, `error.link`, and `error.internal`) as individual tree branches:
+
+```ts
+// Custom error implementation
+class CheckoutError extends Error {
+  why = 'Card declined by issuer due to insufficient funds.'
+  fix = 'Please try a different credit card or payment method.'
+  link = 'https://docs.example.com/payments/declined'
+  internal = { gatewayCode: 'NSF', raw: '...' }
+}
+
+throw new CheckoutError('Payment failed')
+```
+
+Console output tree:
+
+```
+  ├─ orderId  ord_123
+  ├─ error  Payment failed
+  ├─ error.why  Card declined by issuer due to insufficient funds.
+  ├─ error.fix  Please try a different credit card or payment method.
+  ├─ error.link  https://docs.example.com/payments/declined
+  └─ error.internal  {"gatewayCode":"NSF","raw":"..."}
+```
+
 Set `showContextTree: false` to disable the tree and put stringified context back on the main line via `{context}` when you include that token.
 
 ## Error Log Formatting

--- a/packages/logixlysia/__tests__/logger/format-output.test.ts
+++ b/packages/logixlysia/__tests__/logger/format-output.test.ts
@@ -247,4 +247,31 @@ describe('buildContextTreeLines', () => {
     expect(lines.some(l => l.includes('user.id'))).toBe(true)
     expect(lines.some(l => l.includes('user.name'))).toBe(true)
   })
+
+  test('adds structured error fields (why, fix, link, internal) for StructuredError', () => {
+    class CustomStructuredError extends Error {
+      why = 'Card declined'
+      fix = 'Try another card'
+      link = 'https://link.com'
+      internal = { code: 'NSF' }
+    }
+
+    const lines = buildContextTreeLines(
+      'ERROR',
+      { error: new CustomStructuredError('Payment Failed') },
+      { config: { useColors: false } }
+    )
+
+    expect(lines.length).toBe(5)
+    expect(lines[0]).toContain('error')
+    expect(lines[0]).toContain('Payment Failed')
+    expect(lines[1]).toContain('error.why')
+    expect(lines[1]).toContain('Card declined')
+    expect(lines[2]).toContain('error.fix')
+    expect(lines[2]).toContain('Try another card')
+    expect(lines[3]).toContain('error.link')
+    expect(lines[3]).toContain('https://link.com')
+    expect(lines[4]).toContain('error.internal')
+    expect(lines[4]).toContain('{"code":"NSF"}')
+  })
 })

--- a/packages/logixlysia/src/logger/create-logger.ts
+++ b/packages/logixlysia/src/logger/create-logger.ts
@@ -8,7 +8,7 @@ import type {
   RequestInfo,
   StoreData
 } from '../interfaces'
-import { parseError } from '../utils/error'
+import { isStructuredError, parseError } from '../utils/error'
 
 const pad2 = (value: number): string => String(value).padStart(2, '0')
 const pad3 = (value: number): string => String(value).padStart(3, '0')
@@ -348,6 +348,29 @@ export const renderContextTreeLines = (
   return formatEntriesToTreeLines(entries, useColors)
 }
 
+const collectStructuredErrorEntries = (error: unknown): [string, string][] => {
+  const entries: [string, string][] = []
+  const msg = parseError(error)
+  if (msg) {
+    entries.push(['error', msg])
+  }
+  if (isStructuredError(error)) {
+    if (error.why !== undefined) {
+      entries.push(['error.why', String(error.why)])
+    }
+    if (error.fix !== undefined) {
+      entries.push(['error.fix', String(error.fix)])
+    }
+    if (error.link !== undefined) {
+      entries.push(['error.link', String(error.link)])
+    }
+    if (error.internal !== undefined) {
+      entries.push(['error.internal', stringifyTreeValue(error.internal)])
+    }
+  }
+  return entries
+}
+
 export const buildContextTreeLines = (
   level: LogLevel,
   data: Record<string, unknown>,
@@ -376,10 +399,7 @@ export const buildContextTreeLines = (
   }
 
   if (level === 'ERROR' && 'error' in data && data.error !== undefined) {
-    const msg = parseError(data.error)
-    if (msg) {
-      entries.push(['error', msg])
-    }
+    entries.push(...collectStructuredErrorEntries(data.error))
   }
 
   return formatEntriesToTreeLines(entries, useColors)
@@ -516,7 +536,7 @@ export const formatLine = (input: {
     options: {
       ...input.options,
       config: {
-        ...(input.options.config ?? {}),
+        ...input.options.config,
         showContextTree: false
       }
     }

--- a/packages/logixlysia/src/utils/error.ts
+++ b/packages/logixlysia/src/utils/error.ts
@@ -11,3 +11,17 @@ export const parseError = (error: unknown): string => {
 
   return message
 }
+
+export interface StructuredError {
+  fix?: string
+  internal?: unknown
+  link?: string
+  why?: string
+}
+
+export const isStructuredError = (
+  value: unknown
+): value is StructuredError & Record<string, unknown> =>
+  typeof value === 'object' &&
+  value !== null &&
+  ('why' in value || 'fix' in value || 'link' in value || 'internal' in value)


### PR DESCRIPTION
## Description

This pull request introduces support for structured HTTP error logging (similar to `evlog.dev`'s structured errors) in `logixlysia`. It formats specific properties (`why`, `fix`, `link`, `internal`) when they are present on thrown errors, providing actionable troubleshooting contexts natively in Elysia server logs.

Key changes:
- Created a `StructuredError` interface and type-guard helper `isStructuredError` in `packages/logixlysia/src/utils/error.ts`.
- Extracted and simplified error processing logic in `packages/logixlysia/src/logger/create-logger.ts` to build console ASCII tree lines for `error.why`, `error.fix`, `error.link`, and `error.internal`.
- Extracted inner logic to a separate helper to keep cognitive complexity low and satisfy Biome rules.
- Added comprehensive unit tests in `packages/logixlysia/__tests__/logger/format-output.test.ts`.

## Related Issues

Closes #

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

All monorepo formats, lint checks, and typechecks pass successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured error logging that automatically extracts and renders `error.why`, `error.fix`, `error.link`, and `error.internal` alongside the main error message in the context tree.
* **Bug Fixes**
  * Improved how logger options merge for context-tree display behavior.
* **Documentation**
  * Documented “Structured Error Logs” under the Context tree section with examples of the resulting output.
* **Tests**
  * Added tests covering structured error context-tree formatting for all supported fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->