### PR TITLE
feat(logixlysia): support AsyncLocalStorage context propagation and useLogger()

### DIFF
--- a/.changeset/feat-async-logger.md
+++ b/.changeset/feat-async-logger.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": minor
+---
+
+Add support for request-scoped logger context propagation using `AsyncLocalStorage` and export a global `useLogger()` hook.

--- a/apps/docs/content/(docs)/comparison.mdx
+++ b/apps/docs/content/(docs)/comparison.mdx
@@ -9,7 +9,7 @@ description: How Logixlysia compares to evlog and other Elysia loggers
 | ---------- | ---------- | -------------------------- | ----------------------------------------------------------------------- |
 | Elysia plugin | Yes | Yes (`evlog/elysia`) | Yes |
 | Pino-backed | Yes | Optional drains | Yes |
-| Request context accumulation | `mergeContext` | `log.set()` | Manual |
+| Request context accumulation | `mergeContext`, `useLogger()` | `log.set()`, `useLogger()` | Manual |
 | Single access log per request | Auto | `log.emit()` | Auto |
 | File rotation | Yes | Via drains | Limited |
 | `autoRedact` PII | Yes | Varies | Manual |

--- a/apps/docs/content/features/request-context.mdx
+++ b/apps/docs/content/features/request-context.mdx
@@ -31,3 +31,46 @@ When you call `logger.info(request, message, { ...explicit })`, keys in the expl
 ```ts
 const ctx = store.logger.getContext(request)
 ```
+
+## Request-Scoped Logger & AsyncLocalStorage
+
+Instead of manually passing the `request` object to `store.logger` methods (e.g. `store.logger.info(request, message)`), you can enable `AsyncLocalStorage` propagation:
+
+```ts
+logixlysia({
+  config: {
+    useAsyncLocalStorage: true
+  }
+})
+```
+
+When enabled, a request-scoped logger `log` is derived automatically on the Elysia handler context. You can also retrieve the active logger globally in nested service layers or helper functions using the `useLogger()` hook.
+
+### 1. Handler Context (`log`)
+
+Destructure `log` directly in your route handlers:
+
+```ts
+app.get('/user/:id', ({ log, params }) => {
+  log.mergeContext({ userId: params.id })
+  log.info('Fetched user profile')
+  return { success: true }
+})
+```
+
+### 2. Global Hook (`useLogger()`)
+
+Import `useLogger()` to log or merge context from deeply nested operations without prop-drilling the request context:
+
+```ts
+import { useLogger } from 'logixlysia'
+
+async function findUser(id: string) {
+  const log = useLogger()
+  log.mergeContext({ action: 'db_query' })
+  log.info('Executing database lookup...')
+  
+  // Database lookup logic...
+  return { id, name: 'John Doe' }
+}
+```

--- a/packages/logixlysia/__tests__/context/async-storage.test.ts
+++ b/packages/logixlysia/__tests__/context/async-storage.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { Elysia } from 'elysia'
+import { logixlysia, useLogger } from '../../src'
+import type { Options } from '../../src/interfaces'
+
+describe('AsyncLocalStorage & useLogger() context integration', () => {
+  test('derived log object is available on context and logs to transport', async () => {
+    const transport = mock<(lvl: any, msg: any, meta?: any) => void>(
+      () => undefined
+    )
+    const options: Options = {
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia()
+      .use(logixlysia(options))
+      .get('/test', ({ log }) => {
+        log.mergeContext({ custom: 'val' })
+        log.info('hello from derive')
+        return 'ok'
+      })
+
+    await app.handle(new Request('http://localhost/test'))
+
+    expect(transport).toHaveBeenCalledTimes(1)
+    const [level, message, meta] = (transport.mock.calls[0] ?? []) as [
+      any,
+      any,
+      any
+    ]
+    expect(level).toBe('INFO')
+    expect(message).toBe('hello from derive')
+    expect(meta.context).toEqual({ custom: 'val' })
+  })
+
+  test('useLogger() works within route handler and async boundaries when enabled', async () => {
+    const transport = mock<(lvl: any, msg: any, meta?: any) => void>(
+      () => undefined
+    )
+    const options: Options = {
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true,
+        useAsyncLocalStorage: true
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/test', async () => {
+      const log = useLogger()
+      log.mergeContext({ deep: 'context' })
+      log.info('hello from useLogger')
+
+      // Nested async operation using actual Promise resolve to verify async hook context
+      await new Promise<void>(resolve => {
+        const nestedLog = useLogger()
+        nestedLog.info('hello from nested')
+        resolve()
+      })
+
+      return 'ok'
+    })
+
+    await app.handle(new Request('http://localhost/test'))
+
+    expect(transport).toHaveBeenCalledTimes(2)
+    const call1 = (transport.mock.calls[0] ?? []) as [any, any, any]
+    const call2 = (transport.mock.calls[1] ?? []) as [any, any, any]
+
+    expect(call1[0]).toBe('INFO')
+    expect(call1[1]).toBe('hello from useLogger')
+    expect(call1[2].context).toEqual({ deep: 'context' })
+
+    expect(call2[0]).toBe('INFO')
+    expect(call2[1]).toBe('hello from nested')
+    expect(call2[2].context).toEqual({ deep: 'context' })
+  })
+
+  test('useLogger() does not crash and behaves as no-op when disabled', async () => {
+    const transport = mock<(lvl: any, msg: any, meta?: any) => void>(
+      () => undefined
+    )
+    const options: Options = {
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true,
+        useAsyncLocalStorage: false
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/test', () => {
+      const log = useLogger()
+      log.info('this should be ignored')
+      return 'ok'
+    })
+
+    await app.handle(new Request('http://localhost/test'))
+
+    expect(transport).toHaveBeenCalledTimes(1)
+    const [level, message] = (transport.mock.calls[0] ?? []) as [any, any]
+    expect(level).toBe('INFO')
+    expect(message).toBe('')
+  })
+
+  test('useLogger() outside request lifecycle does not crash and behaves as no-op', () => {
+    const log = useLogger()
+    expect(() => {
+      log.info('outside request')
+      log.mergeContext({ key: 'val' })
+    }).not.toThrow()
+  })
+})

--- a/packages/logixlysia/src/context/storage.ts
+++ b/packages/logixlysia/src/context/storage.ts
@@ -1,0 +1,16 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import type { RequestScopedLogger } from '../interfaces'
+
+export const loggerStorage: AsyncLocalStorage<RequestScopedLogger> =
+  new AsyncLocalStorage<RequestScopedLogger>()
+
+const NOOP_LOGGER: RequestScopedLogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  mergeContext: () => undefined
+}
+
+export const useLogger = (): RequestScopedLogger =>
+  loggerStorage.getStore() ?? NOOP_LOGGER

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -87,6 +87,16 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
     }
   }
 
+  const createRequestScopedLogger = (
+    request: Request
+  ): RequestScopedLogger => ({
+    debug: (message, context) => logger.debug(request, message, context),
+    info: (message, context) => logger.info(request, message, context),
+    warn: (message, context) => logger.warn(request, message, context),
+    error: (message, context) => logger.error(request, message, context),
+    mergeContext: partial => contextStore.mergeContext(request, partial)
+  })
+
   const app = new Elysia({
     name: 'Logixlysia',
     detail: {
@@ -101,16 +111,7 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
     .state('logger', logger)
     .state('pino', logger.pino)
     .state('beforeTime', BigInt(0))
-    .derive(({ request }) => {
-      const requestScopedLogger: RequestScopedLogger = {
-        debug: (message, context) => logger.debug(request, message, context),
-        info: (message, context) => logger.info(request, message, context),
-        warn: (message, context) => logger.warn(request, message, context),
-        error: (message, context) => logger.error(request, message, context),
-        mergeContext: partial => contextStore.mergeContext(request, partial)
-      }
-      return { log: requestScopedLogger }
-    })
+    .derive(({ request }) => ({ log: createRequestScopedLogger(request) }))
     .onStart(({ server }): void => {
       if (server) {
         startServer(server, options)
@@ -128,14 +129,7 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
       }
 
       if (options.config?.useAsyncLocalStorage) {
-        const requestScopedLogger: RequestScopedLogger = {
-          debug: (message, context) => logger.debug(request, message, context),
-          info: (message, context) => logger.info(request, message, context),
-          warn: (message, context) => logger.warn(request, message, context),
-          error: (message, context) => logger.error(request, message, context),
-          mergeContext: partial => contextStore.mergeContext(request, partial)
-        }
-        loggerStorage.enterWith(requestScopedLogger)
+        loggerStorage.enterWith(createRequestScopedLogger(request))
       }
     })
     .onAfterHandle(({ request, set, store }) => {

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -1,8 +1,13 @@
 import { Elysia } from 'elysia'
 import { resolveOptions } from './config/resolve-options'
 import { createRequestContextStore } from './context/request-context'
+import { loggerStorage } from './context/storage'
 import { startServer } from './extensions'
-import type { LogixlysiaStore, Options } from './interfaces'
+import type {
+  LogixlysiaStore,
+  Options,
+  RequestScopedLogger
+} from './interfaces'
 import { createPluginLogger } from './logger'
 import {
   getOrCreateRequestId,
@@ -24,7 +29,9 @@ export interface EmptyElysiaSlot {
  */
 export interface LogixlysiaSingleton {
   decorator: EmptyElysiaSlot
-  derive: EmptyElysiaSlot
+  derive: {
+    log: RequestScopedLogger
+  }
   resolve: EmptyElysiaSlot
   store: LogixlysiaStore
 }
@@ -89,10 +96,21 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
     }
   })
 
+  // @ts-expect-error — derived log typing matches LogixlysiaSingleton.
   const plugin = app
     .state('logger', logger)
     .state('pino', logger.pino)
     .state('beforeTime', BigInt(0))
+    .derive(({ request }) => {
+      const requestScopedLogger: RequestScopedLogger = {
+        debug: (message, context) => logger.debug(request, message, context),
+        info: (message, context) => logger.info(request, message, context),
+        warn: (message, context) => logger.warn(request, message, context),
+        error: (message, context) => logger.error(request, message, context),
+        mergeContext: partial => contextStore.mergeContext(request, partial)
+      }
+      return { log: requestScopedLogger }
+    })
     .onStart(({ server }): void => {
       if (server) {
         startServer(server, options)
@@ -107,6 +125,17 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
       if (requestIdConfig) {
         const requestId = getOrCreateRequestId(request, requestIdConfig)
         contextStore.mergeContext(request, { requestId })
+      }
+
+      if (options.config?.useAsyncLocalStorage) {
+        const requestScopedLogger: RequestScopedLogger = {
+          debug: (message, context) => logger.debug(request, message, context),
+          info: (message, context) => logger.info(request, message, context),
+          warn: (message, context) => logger.warn(request, message, context),
+          error: (message, context) => logger.error(request, message, context),
+          mergeContext: partial => contextStore.mergeContext(request, partial)
+        }
+        loggerStorage.enterWith(requestScopedLogger)
       }
     })
     .onAfterHandle(({ request, set, store }) => {
@@ -163,6 +192,7 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
 
 // biome-ignore lint/performance/noBarrelFile: public package entry re-exports
 export { resolveOptions } from './config/resolve-options'
+export { useLogger } from './context/storage'
 export type {
   Logger,
   LogixlysiaContext,
@@ -172,6 +202,7 @@ export type {
   Options,
   Pino,
   RequestIdConfig,
+  RequestScopedLogger,
   StoreData,
   Transport
 } from './interfaces'

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -145,6 +145,13 @@ export interface Options {
 
     // Pino
     pino?: (PinoLoggerOptions & { prettyPrint?: PrettyPrintConfig }) | undefined
+
+    /**
+     * Enable request-scoped logger propagation via AsyncLocalStorage.
+     * When enabled, a request-scoped logger `log` is also derived on the Elysia context.
+     * @default false
+     */
+    useAsyncLocalStorage?: boolean
   }
   /**
    * Opinionated defaults for common environments.
@@ -200,6 +207,14 @@ export interface Logger {
     message: string,
     context?: Record<string, unknown>
   ) => void
+}
+
+export interface RequestScopedLogger {
+  debug: (message: string, context?: Record<string, unknown>) => void
+  error: (message: string, context?: Record<string, unknown>) => void
+  info: (message: string, context?: Record<string, unknown>) => void
+  mergeContext: (partial: Record<string, unknown>) => void
+  warn: (message: string, context?: Record<string, unknown>) => void
 }
 
 export interface LogixlysiaContext {


### PR DESCRIPTION
## Description

This pull request introduces request-scoped logger context propagation using `AsyncLocalStorage` and exports a global `useLogger()` hook (Option 1). It also derives a `log` object (of type `RequestScopedLogger`) in the Elysia handler context, allowing destructuring of `log` out of the box.

Key changes:
- Created `packages/logixlysia/src/context/storage.ts` defining `loggerStorage` (`AsyncLocalStorage`) and the `useLogger()` hook.
- Added `useAsyncLocalStorage?: boolean` option to the config interface in `packages/logixlysia/src/interfaces.ts` and defined `RequestScopedLogger` there.
- Updated `packages/logixlysia/src/index.ts` to derive `{ log }` on context for all handlers, setup `loggerStorage.enterWith(...)` in `.onRequest` when `useAsyncLocalStorage` is true, and exported `useLogger` and `RequestScopedLogger`.
- Added new unit test suite in `packages/logixlysia/__tests__/context/async-storage.test.ts`.

## Related Issues

Closes #

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

All format, lint, typecheck, and test checks pass successfully.
