### PR TITLE
fix(logixlysia): prevent thread-stream worker crash under Bun using synchronous pretty stream

### DIFF
--- a/.changeset/fix-pino-worker-crash.md
+++ b/.changeset/fix-pino-worker-crash.md
@@ -1,0 +1,5 @@
+---
+"logixlysia": patch
+---
+
+Fix thread-stream worker crash when using pino-pretty in Bun by initializing pretty print streams synchronously on the main thread.

--- a/packages/logixlysia/__tests__/logger/create-logger.test.ts
+++ b/packages/logixlysia/__tests__/logger/create-logger.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, mock, test } from 'bun:test'
 import type pino from 'pino'
 import type { Options, Pino } from '../../src/interfaces'
+
+let prettyOptionsCaptured: any = null
+mock.module('pino-pretty', () => ({
+  default: (opts: any) => {
+    prettyOptionsCaptured = opts
+    return { prettyStreamMock: true }
+  }
+}))
+
 import { createLogger } from '../../src/logger'
 import { spyConsole } from '../_helpers/console'
 import { createMockRequest } from '../_helpers/request'
@@ -122,9 +131,11 @@ describe('createLogger', () => {
   })
 
   test('prettyPrint true configures pino-pretty transport', () => {
-    const captured: { options?: unknown } = {}
-    const fakePino = (options: unknown) => {
+    prettyOptionsCaptured = null
+    const captured: { options?: any; stream?: any } = {}
+    const fakePino = (options: any, stream: any) => {
       captured.options = options
+      captured.stream = stream
       return {} as unknown as Pino
     }
 
@@ -139,15 +150,18 @@ describe('createLogger', () => {
       fakePino as unknown as typeof pino
     )
 
-    expect(captured.options).toMatchObject({
-      transport: { target: 'pino-pretty' }
+    expect(captured.stream).toEqual({ prettyStreamMock: true })
+    expect(prettyOptionsCaptured).toMatchObject({
+      colorize: process.stdout?.isTTY === true
     })
   })
 
   test('prettyPrint options override defaults', () => {
-    const captured: { options?: unknown } = {}
-    const fakePino = (options: unknown) => {
+    prettyOptionsCaptured = null
+    const captured: { options?: any; stream?: any } = {}
+    const fakePino = (options: any, stream: any) => {
       captured.options = options
+      captured.stream = stream
       return {} as unknown as Pino
     }
 
@@ -164,8 +178,9 @@ describe('createLogger', () => {
       fakePino as unknown as typeof pino
     )
 
-    expect(captured.options).toMatchObject({
-      transport: { options: { colorize: false } }
+    expect(captured.stream).toEqual({ prettyStreamMock: true })
+    expect(prettyOptionsCaptured).toMatchObject({
+      colorize: false
     })
   })
 
@@ -199,9 +214,11 @@ describe('createLogger', () => {
   })
 
   test('prettyPrint uses messageKey override when provided', () => {
-    const captured: { options?: unknown } = {}
-    const fakePino = (options: unknown) => {
+    prettyOptionsCaptured = null
+    const captured: { options?: any; stream?: any } = {}
+    const fakePino = (options: any, stream: any) => {
       captured.options = options
+      captured.stream = stream
       return {} as unknown as Pino
     }
 
@@ -218,17 +235,17 @@ describe('createLogger', () => {
       fakePino as unknown as typeof pino
     )
 
-    expect(captured.options).toMatchObject({
-      transport: {
-        options: { messageKey: 'customMessage' }
-      }
+    expect(prettyOptionsCaptured).toMatchObject({
+      messageKey: 'customMessage'
     })
   })
 
   test('prettyPrint uses errorKey override when provided', () => {
-    const captured: { options?: unknown } = {}
-    const fakePino = (options: unknown) => {
+    prettyOptionsCaptured = null
+    const captured: { options?: any; stream?: any } = {}
+    const fakePino = (options: any, stream: any) => {
       captured.options = options
+      captured.stream = stream
       return {} as unknown as Pino
     }
 
@@ -245,17 +262,17 @@ describe('createLogger', () => {
       fakePino as unknown as typeof pino
     )
 
-    expect(captured.options).toMatchObject({
-      transport: {
-        options: { errorKey: 'customError' }
-      }
+    expect(prettyOptionsCaptured).toMatchObject({
+      errorKey: 'customError'
     })
   })
 
   test('prettyPrint merges with default translateTime from config', () => {
-    const captured: { options?: unknown } = {}
-    const fakePino = (options: unknown) => {
+    prettyOptionsCaptured = null
+    const captured: { options?: any; stream?: any } = {}
+    const fakePino = (options: any, stream: any) => {
       captured.options = options
+      captured.stream = stream
       return {} as unknown as Pino
     }
 
@@ -275,13 +292,9 @@ describe('createLogger', () => {
       fakePino as unknown as typeof pino
     )
 
-    expect(captured.options).toMatchObject({
-      transport: {
-        options: {
-          translateTime: 'yyyy-mm-dd HH:MM:ss',
-          colorize: true
-        }
-      }
+    expect(prettyOptionsCaptured).toMatchObject({
+      translateTime: 'yyyy-mm-dd HH:MM:ss',
+      colorize: true
     })
   })
 })

--- a/packages/logixlysia/src/logger/index.ts
+++ b/packages/logixlysia/src/logger/index.ts
@@ -1,4 +1,5 @@
 import pino from 'pino'
+import pretty from 'pino-pretty'
 import {
   createRequestContextStore,
   mergeLogDataContext,
@@ -47,26 +48,31 @@ export const createLogger = (
   const errorKey =
     (prettyPrintOptions?.errorKey as string | undefined) ?? pinoOptions.errorKey
 
-  const transport = shouldPrettyPrint
-    ? {
-        target: 'pino-pretty',
-        options: {
-          colorize: process.stdout?.isTTY === true,
-          translateTime: config?.timestamp?.translateTime,
-          ...prettyPrintOptions,
-          messageKey,
-          errorKey
-        }
-      }
-    : pinoOptions.transport
-
-  const pinoLogger: Pino = pinoFactory({
+  const basePinoOptions = {
     ...pinoOptions,
     level: pinoOptions.level ?? 'info',
     messageKey,
-    errorKey,
-    transport
-  })
+    errorKey
+  }
+
+  let pinoLogger: Pino
+
+  if (shouldPrettyPrint) {
+    const prettyStream = pretty({
+      colorize: process.stdout?.isTTY === true,
+      translateTime: config?.timestamp?.translateTime,
+      ...prettyPrintOptions,
+      messageKey,
+      errorKey
+    } as Record<string, unknown>)
+
+    pinoLogger = pinoFactory(basePinoOptions, prettyStream)
+  } else {
+    pinoLogger = pinoFactory({
+      ...basePinoOptions,
+      transport: pinoOptions.transport
+    })
+  }
 
   const shouldLog = (level: LogLevel, logFilter?: LogFilter): boolean => {
     if (!logFilter?.level || logFilter.level.length === 0) {


### PR DESCRIPTION
## Description

This pull request resolves the `thread-stream` worker exit crash under Bun when running `pino-pretty` in development.

Key changes:
- In `packages/logixlysia/src/logger/index.ts`, when `prettyPrint` is enabled, instead of passing the programmatic transport object which spawns worker threads under the hood via `thread-stream` (which is highly unstable/unsupported under Bun), we instantiate the pretty stream synchronously on the main thread using `pretty(...)` from `pino-pretty` and pass it directly to `pinoFactory(options, stream)`.
- Updated mock expectations in `packages/logixlysia/__tests__/logger/create-logger.test.ts` to mock the `pino-pretty` module using Bun's mock utility and verify formatting option parameters on the stream.

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
