### PR TITLE
fix(rotation): validate rotation config, add characterization tests

### DIFF
--- a/.changeset/rotation-hardening.md
+++ b/.changeset/rotation-hardening.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': patch
+---
+
+Reject invalid log-rotation sizes (empty, negative, non-finite) and validate `logRotation`/`preset` config at plugin construction instead of failing silently per write.

--- a/packages/logixlysia/__tests__/config/resolve-options.test.ts
+++ b/packages/logixlysia/__tests__/config/resolve-options.test.ts
@@ -30,4 +30,67 @@ describe('resolveOptions', () => {
     expect(resolved.config?.pino?.prettyPrint).toBe(true)
     expect(resolved.config?.showStartupMessage).toBe(true)
   })
+
+  test('valid logRotation config passes through unchanged', () => {
+    const resolved = resolveOptions({
+      config: {
+        logRotation: {
+          maxSize: '10m',
+          maxFiles: 5,
+          interval: '1d',
+          compression: 'gzip'
+        }
+      }
+    })
+
+    expect(resolved.config?.logRotation).toEqual({
+      maxSize: '10m',
+      maxFiles: 5,
+      interval: '1d',
+      compression: 'gzip'
+    })
+  })
+
+  test('throws on an invalid logRotation.maxSize', () => {
+    expect(() =>
+      resolveOptions({ config: { logRotation: { maxSize: '' } } })
+    ).toThrow('logixlysia: invalid logRotation config')
+  })
+
+  test('throws on an invalid logRotation.interval', () => {
+    expect(() =>
+      resolveOptions({ config: { logRotation: { interval: 'nope' } } })
+    ).toThrow('logixlysia: invalid logRotation config')
+  })
+
+  test('throws on an invalid logRotation.maxFiles', () => {
+    expect(() =>
+      resolveOptions({ config: { logRotation: { maxFiles: 'nope' } } })
+    ).toThrow('logixlysia: invalid logRotation config')
+  })
+
+  test('throws on an invalid logRotation.compression', () => {
+    expect(() =>
+      resolveOptions({
+        config: {
+          logRotation: { compression: 'brotli' as never }
+        }
+      })
+    ).toThrow('logixlysia: invalid logRotation config')
+  })
+
+  test('validates logRotation after preset merge', () => {
+    expect(() =>
+      resolveOptions({
+        preset: 'prod',
+        config: { logRotation: { maxSize: -5 } }
+      })
+    ).toThrow('logixlysia: invalid logRotation config')
+  })
+
+  test('throws on an unknown preset', () => {
+    expect(() => resolveOptions({ preset: 'staging' as never })).toThrow(
+      'logixlysia: invalid preset'
+    )
+  })
 })

--- a/packages/logixlysia/__tests__/output/rotation-manager.test.ts
+++ b/packages/logixlysia/__tests__/output/rotation-manager.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  getRotatedFileName,
+  performRotation,
+  shouldRotate
+} from '../../src/output/rotation-manager'
+import { createTempDir, removeTempDir } from '../_helpers/tmp'
+
+const DAY_MS = 86_400_000
+
+describe('getRotatedFileName', () => {
+  test('formats a fixed date deterministically', () => {
+    const date = new Date(2026, 0, 2, 3, 4, 5, 123)
+    expect(getRotatedFileName('/tmp/app.log', date)).toBe(
+      '/tmp/app.log.2026-01-02-03-04-05-123'
+    )
+  })
+})
+
+describe('shouldRotate', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await createTempDir()
+  })
+
+  afterEach(async () => {
+    await removeTempDir(dir)
+  })
+
+  test('returns false when maxSize is undefined', async () => {
+    const filePath = join(dir, 'app.log')
+    await fs.writeFile(filePath, 'x'.repeat(100))
+    expect(await shouldRotate(filePath, {})).toBe(false)
+  })
+
+  test('returns true when the file exceeds maxSize', async () => {
+    const filePath = join(dir, 'app.log')
+    await fs.writeFile(filePath, 'x'.repeat(100))
+    expect(await shouldRotate(filePath, { maxSize: 10 })).toBe(true)
+  })
+
+  test('returns false when the file is smaller than maxSize', async () => {
+    const filePath = join(dir, 'app.log')
+    await fs.writeFile(filePath, 'x'.repeat(10))
+    expect(await shouldRotate(filePath, { maxSize: 1000 })).toBe(false)
+  })
+})
+
+describe('performRotation retention', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await createTempDir()
+  })
+
+  afterEach(async () => {
+    await removeTempDir(dir)
+  })
+
+  test('count retention keeps only the newest maxFiles rotated files', async () => {
+    const filePath = join(dir, 'app.log')
+    await fs.writeFile(filePath, 'live content')
+
+    const now = Date.now()
+    const rotatedPaths = [
+      `${filePath}.2026-01-01-00-00-00-000`,
+      `${filePath}.2026-01-02-00-00-00-000`,
+      `${filePath}.2026-01-03-00-00-00-000`,
+      `${filePath}.2026-01-04-00-00-00-000`
+    ]
+
+    // Stagger mtimes: index 0 is oldest, index 3 is newest.
+    for (const [index, rotatedPath] of rotatedPaths.entries()) {
+      await fs.writeFile(rotatedPath, `rotated-${index}`)
+      const mtimeSeconds = now / 1000 - (rotatedPaths.length - index) * 60
+      await fs.utimes(rotatedPath, mtimeSeconds, mtimeSeconds)
+    }
+
+    // performRotation rotates the live file first, producing a 5th rotated
+    // file (the newest of all), then cleans up down to maxFiles.
+    await performRotation(filePath, { maxFiles: 2 })
+
+    const entries = await fs.readdir(dir)
+    const remainingRotated = entries.filter(name => name.startsWith('app.log.'))
+
+    expect(remainingRotated).toHaveLength(2)
+    // The two oldest pre-existing rotated files must be gone.
+    expect(remainingRotated).not.toContain('app.log.2026-01-01-00-00-00-000')
+    expect(remainingRotated).not.toContain('app.log.2026-01-02-00-00-00-000')
+    // The newest pre-existing rotated file survives.
+    expect(remainingRotated).toContain('app.log.2026-01-04-00-00-00-000')
+  })
+
+  test('time retention deletes only files older than the retention window', async () => {
+    const filePath = join(dir, 'app.log')
+    await fs.writeFile(filePath, 'live content')
+
+    const now = Date.now()
+    const oldPath = `${filePath}.2020-01-01-00-00-00-000`
+    const recentPath = `${filePath}.2026-01-01-00-00-00-000`
+
+    await fs.writeFile(oldPath, 'old')
+    await fs.writeFile(recentPath, 'recent')
+
+    const oldMtimeSeconds = (now - 10 * DAY_MS) / 1000
+    const recentMtimeSeconds = (now - 1000) / 1000
+    await fs.utimes(oldPath, oldMtimeSeconds, oldMtimeSeconds)
+    await fs.utimes(recentPath, recentMtimeSeconds, recentMtimeSeconds)
+
+    await performRotation(filePath, { maxFiles: '7d' })
+
+    const entries = await fs.readdir(dir)
+    expect(entries).not.toContain('app.log.2020-01-01-00-00-00-000')
+    expect(entries).toContain('app.log.2026-01-01-00-00-00-000')
+  })
+
+  test('is a no-op for an empty live file', async () => {
+    const filePath = join(dir, 'app.log')
+    await fs.writeFile(filePath, '')
+
+    await performRotation(filePath, { maxFiles: 2 })
+
+    const entries = await fs.readdir(dir)
+    expect(entries).toEqual(['app.log'])
+    const stat = await fs.stat(filePath)
+    expect(stat.size).toBe(0)
+  })
+})

--- a/packages/logixlysia/__tests__/utils/rotation.test.ts
+++ b/packages/logixlysia/__tests__/utils/rotation.test.ts
@@ -49,6 +49,17 @@ describe('parseSize', () => {
     expect(() => parseSize('abc')).toThrow('Invalid size format')
     expect(() => parseSize('10x')).toThrow('Invalid size format')
   })
+
+  test('rejects empty and negative string sizes', () => {
+    expect(() => parseSize('')).toThrow('Invalid size')
+    expect(() => parseSize('-5')).toThrow('Invalid size')
+  })
+
+  test('rejects zero, negative, and non-finite number sizes', () => {
+    expect(() => parseSize(0)).toThrow('Invalid size')
+    expect(() => parseSize(-1)).toThrow('Invalid size')
+    expect(() => parseSize(Number.NaN)).toThrow('Invalid size')
+  })
 })
 
 describe('parseInterval', () => {

--- a/packages/logixlysia/__tests__/utils/rotation.test.ts
+++ b/packages/logixlysia/__tests__/utils/rotation.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test'
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  getRotatedFiles,
+  parseInterval,
+  parseRetention,
+  parseSize
+} from '../../src/utils/rotation'
+import { createTempDir, removeTempDir } from '../_helpers/tmp'
+
+const KB = 1024
+const MB = 1024 * 1024
+const GB = 1024 * 1024 * 1024
+
+const HOUR_MS = 3_600_000
+const DAY_MS = 86_400_000
+const WEEK_MS = 604_800_000
+
+describe('parseSize', () => {
+  test('passes a plain number through', () => {
+    expect(parseSize(1024)).toBe(1024)
+  })
+
+  test('parses a plain numeric string', () => {
+    expect(parseSize('2048')).toBe(2048)
+  })
+
+  test('parses kilobyte forms', () => {
+    expect(parseSize('10k')).toBe(10 * KB)
+    expect(parseSize('10kb')).toBe(10 * KB)
+  })
+
+  test('parses megabyte forms', () => {
+    expect(parseSize('1m')).toBe(1 * MB)
+    expect(parseSize('1MB')).toBe(1 * MB)
+  })
+
+  test('parses gigabyte forms', () => {
+    expect(parseSize('1g')).toBe(1 * GB)
+  })
+
+  test('parses fractional sizes', () => {
+    expect(parseSize('1.5k')).toBe(1536)
+  })
+
+  test('throws on unparseable strings', () => {
+    expect(() => parseSize('abc')).toThrow('Invalid size format')
+    expect(() => parseSize('10x')).toThrow('Invalid size format')
+  })
+})
+
+describe('parseInterval', () => {
+  test('parses hours', () => {
+    expect(parseInterval('1h')).toBe(HOUR_MS)
+  })
+
+  test('parses days', () => {
+    expect(parseInterval('2d')).toBe(2 * DAY_MS)
+  })
+
+  test('parses weeks', () => {
+    expect(parseInterval('1w')).toBe(WEEK_MS)
+  })
+
+  test('throws on invalid formats', () => {
+    expect(() => parseInterval('1x')).toThrow('Invalid interval format')
+    expect(() => parseInterval('')).toThrow('Invalid interval format')
+    expect(() => parseInterval('h')).toThrow('Invalid interval format')
+  })
+})
+
+describe('parseRetention', () => {
+  test('treats a number as a count', () => {
+    expect(parseRetention(5)).toEqual({ type: 'count', value: 5 })
+  })
+
+  test('treats a string as a time interval', () => {
+    expect(parseRetention('7d')).toEqual({ type: 'time', value: 7 * DAY_MS })
+  })
+})
+
+describe('getRotatedFiles', () => {
+  test('returns only rotated sibling files', async () => {
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'app.log')
+
+      await fs.writeFile(filePath, 'live')
+      await fs.writeFile(`${filePath}.2026-01-02-03-04-05`, 'a')
+      await fs.writeFile(`${filePath}.2026-01-02-03-04-05-123-9999999`, 'b')
+      await fs.writeFile(`${filePath}.2026-01-02-03-04-05.gz`, 'c')
+      await fs.writeFile(`${filePath}.backup`, 'd')
+
+      const rotated = await getRotatedFiles(filePath)
+      const names = rotated.map(p => p.slice(dir.length + 1)).sort()
+
+      expect(names).toEqual(
+        [
+          'app.log.2026-01-02-03-04-05',
+          'app.log.2026-01-02-03-04-05-123-9999999',
+          'app.log.2026-01-02-03-04-05.gz'
+        ].sort()
+      )
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('returns an empty array when the directory is missing', async () => {
+    const rotated = await getRotatedFiles('/nonexistent-dir-xyz/app.log')
+    expect(rotated).toEqual([])
+  })
+})

--- a/packages/logixlysia/src/config/resolve-options.ts
+++ b/packages/logixlysia/src/config/resolve-options.ts
@@ -115,20 +115,17 @@ const mergeConfig = (
 /** Applies preset defaults; explicit `config` keys override preset values. */
 export const resolveOptions = (options: Options = {}): Options => {
   const preset = options.preset
-  if (!preset) {
-    validateLogRotation(options.config)
-    return options
-  }
-
-  if (!VALID_PRESETS.includes(preset)) {
+  if (preset && !VALID_PRESETS.includes(preset)) {
     throw new Error(`logixlysia: invalid preset — ${preset}`)
   }
 
-  const presetConfig = PRESET_DEFAULTS[preset]
-  const resolved = {
-    ...options,
-    config: mergeConfig(presetConfig, options.config)
-  }
+  const resolved = preset
+    ? {
+        ...options,
+        config: mergeConfig(PRESET_DEFAULTS[preset], options.config)
+      }
+    : options
+
   validateLogRotation(resolved.config)
   return resolved
 }

--- a/packages/logixlysia/src/config/resolve-options.ts
+++ b/packages/logixlysia/src/config/resolve-options.ts
@@ -1,6 +1,39 @@
 import type { Options } from '../interfaces'
+import { parseInterval, parseRetention, parseSize } from '../utils/rotation'
 
 export type LogPreset = 'dev' | 'prod' | 'json'
+
+const VALID_PRESETS: readonly LogPreset[] = ['dev', 'prod', 'json']
+
+const validateLogRotation = (config: Options['config']): void => {
+  const logRotation = config?.logRotation
+  if (!logRotation) {
+    return
+  }
+
+  try {
+    if (logRotation.maxSize !== undefined) {
+      parseSize(logRotation.maxSize)
+    }
+    if (logRotation.maxFiles !== undefined) {
+      parseRetention(logRotation.maxFiles)
+    }
+    if (logRotation.interval !== undefined) {
+      parseInterval(logRotation.interval)
+    }
+    if (
+      logRotation.compression !== undefined &&
+      logRotation.compression !== 'gzip'
+    ) {
+      throw new Error(
+        `Invalid compression algorithm: ${logRotation.compression}`
+      )
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`logixlysia: invalid logRotation config — ${message}`)
+  }
+}
 
 const PRESET_DEFAULTS: Record<LogPreset, NonNullable<Options['config']>> = {
   dev: {
@@ -83,12 +116,19 @@ const mergeConfig = (
 export const resolveOptions = (options: Options = {}): Options => {
   const preset = options.preset
   if (!preset) {
+    validateLogRotation(options.config)
     return options
   }
 
+  if (!VALID_PRESETS.includes(preset)) {
+    throw new Error(`logixlysia: invalid preset — ${preset}`)
+  }
+
   const presetConfig = PRESET_DEFAULTS[preset]
-  return {
+  const resolved = {
     ...options,
     config: mergeConfig(presetConfig, options.config)
   }
+  validateLogRotation(resolved.config)
+  return resolved
 }

--- a/packages/logixlysia/src/utils/rotation.ts
+++ b/packages/logixlysia/src/utils/rotation.ts
@@ -8,13 +8,21 @@ const ROTATED_REGEX =
 
 export const parseSize = (value: number | string): number => {
   if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error(`Invalid size: ${value}`)
+    }
     return value
   }
 
   const trimmed = value.trim()
-  const asNumber = Number(trimmed)
-  if (Number.isFinite(asNumber)) {
-    return asNumber
+  if (trimmed !== '') {
+    const asNumber = Number(trimmed)
+    if (Number.isFinite(asNumber)) {
+      if (asNumber <= 0) {
+        throw new Error(`Invalid size: ${value}`)
+      }
+      return asNumber
+    }
   }
 
   const match = trimmed.match(SIZE_REGEX)


### PR DESCRIPTION
## Description

Characterize and harden the log-rotation subsystem (implements `plans/001-rotation-characterization-tests.md`, planned at 4974d53):

- First direct unit tests for `parseSize` / `parseInterval` / `parseRetention` / `getRotatedFiles` (17 cases) and `shouldRotate` / `performRotation` count+time retention cleanup (7 cases, temp dirs + staggered `utimes`)
- `parseSize` now rejects empty strings (previously `'' → 0`, which rotated the log file on **every write**), negative, zero, and non-finite sizes on both the number and string paths
- `logRotation` (`maxSize`, `maxFiles`, `interval` format, `compression`) and `preset` are validated at `resolveOptions` time, so misconfiguration fails loudly at plugin construction instead of being silently swallowed per write

Groundwork for the file-write mutex fix (plan 002) and file-sink rework (plan 011).

## Related Issues

None — part of the `plans/` improvement series (plan 001).

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary (not needed — behavior now matches what the docs already promise)

## Screenshots (if applicable)

N/A — no UI changes.

## Additional Notes

Verification gates (re-run at review):

- `bun test` (packages/logixlysia): **149 pass, 0 fail** (353 expect() calls, 22 files)
- `bun run typecheck`: exit 0 (turbo 5/5)
- `bun x ultracite check`: 98 files clean
- `bun run build --filter logixlysia`: exit 0
- Changeset: `.changeset/rotation-hardening.md` (`logixlysia: patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid log-rotation settings (including empty, zero, negative, or non-finite sizes) are now rejected with clearer configuration errors.
  * Log rotation and preset configuration are validated up front, reducing the chance of silent misconfiguration during writes.
  * Unknown presets are now reported as configuration errors.
  * Improved reliability for size/retention/compression handling, including correct no-op behavior for empty live logs.

* **Tests**
  * Added coverage for log-rotation option validation, preset merging, and rotation utility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->