### PR TITLE
fix(output): make per-file write mutex actually mutually exclusive

### DIFF
--- a/.changeset/fix-file-write-mutex.md
+++ b/.changeset/fix-file-write-mutex.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': patch
+---
+
+Fix the per-file write/compression mutex: locks are now registered synchronously, so concurrent same-tick writes to one log file no longer interleave with rotation (previously could drop or tear lines).

--- a/packages/logixlysia/__tests__/output/race-condition.test.ts
+++ b/packages/logixlysia/__tests__/output/race-condition.test.ts
@@ -113,4 +113,68 @@ describe('logToFile race condition', () => {
       await removeTempDir(dir)
     }
   })
+
+  test('same-tick logToFile calls to one path never interleave writes', async () => {
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'logs', 'exclusion.log')
+      const options: Options = {
+        config: {
+          // Rotate on every write so the critical section races with rotation
+          logRotation: { maxSize: 1, compress: false }
+        }
+      }
+
+      const total = 20
+      // A full-line regex: a torn line (cut mid-write) or a merged line
+      // (two writes concatenated without a newline in between) will not
+      // match this anchored pattern, revealing broken mutual exclusion.
+      const LINE_REGEX =
+        /^(DEBUG|INFO|WARNING|ERROR) [\d.]+ms GET \/test\d+ msg-(\d+)-x+$/
+
+      // Fire all calls in the same tick (no awaits between them) so any
+      // caller that fails to see a same-tick prior lock is exposed.
+      const writes = Array.from({ length: total }, (_, i) =>
+        logToFile({
+          filePath,
+          level: 'INFO',
+          request: createMockRequest(`http://localhost/test${i}`),
+          data: { message: `msg-${i}-${'x'.repeat(50)}` },
+          store: { beforeTime: BigInt(0) },
+          options
+        })
+      )
+
+      await Promise.all(writes)
+
+      const files = await fs.readdir(join(dir, 'logs'))
+      const logFiles = files.filter(
+        name => name === 'exclusion.log' || name.startsWith('exclusion.log.')
+      )
+
+      let totalLines = 0
+      const seenIds = new Set<string>()
+
+      for (const file of logFiles) {
+        const content = await fs.readFile(join(dir, 'logs', file), 'utf-8')
+        const lines = content.split('\n').filter(l => l.length > 0)
+        totalLines += lines.length
+
+        for (const line of lines) {
+          // Every line must be a single, complete, well-formed entry.
+          expect(line).toMatch(LINE_REGEX)
+          const match = line.match(LINE_REGEX)
+          if (match) {
+            seenIds.add(match[2])
+          }
+        }
+      }
+
+      // No lines dropped or torn: exactly `total` distinct, well-formed lines.
+      expect(totalLines).toBe(total)
+      expect(seenIds.size).toBe(total)
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
 })

--- a/packages/logixlysia/__tests__/output/race-condition.test.ts
+++ b/packages/logixlysia/__tests__/output/race-condition.test.ts
@@ -7,6 +7,11 @@ import { createMockRequest } from '../_helpers/request'
 import { createTempDir, removeTempDir } from '../_helpers/tmp'
 
 const MESSAGE_REGEX = /message-(\d+)/
+// A full-line regex: a torn line (cut mid-write) or a merged line (two
+// writes concatenated without a newline in between) will not match this
+// anchored pattern, revealing broken mutual exclusion.
+const EXCLUSION_LINE_REGEX =
+  /^(DEBUG|INFO|WARNING|ERROR) [\d.]+ms GET \/test\d+ msg-(\d+)-x+$/
 
 describe('logToFile race condition', () => {
   test('handles concurrent writes during rotation without data loss', async () => {
@@ -126,11 +131,6 @@ describe('logToFile race condition', () => {
       }
 
       const total = 20
-      // A full-line regex: a torn line (cut mid-write) or a merged line
-      // (two writes concatenated without a newline in between) will not
-      // match this anchored pattern, revealing broken mutual exclusion.
-      const LINE_REGEX =
-        /^(DEBUG|INFO|WARNING|ERROR) [\d.]+ms GET \/test\d+ msg-(\d+)-x+$/
 
       // Fire all calls in the same tick (no awaits between them) so any
       // caller that fails to see a same-tick prior lock is exposed.
@@ -162,8 +162,8 @@ describe('logToFile race condition', () => {
 
         for (const line of lines) {
           // Every line must be a single, complete, well-formed entry.
-          expect(line).toMatch(LINE_REGEX)
-          const match = line.match(LINE_REGEX)
+          expect(line).toMatch(EXCLUSION_LINE_REGEX)
+          const match = line.match(EXCLUSION_LINE_REGEX)
           if (match) {
             seenIds.add(match[2])
           }

--- a/packages/logixlysia/src/output/file.ts
+++ b/packages/logixlysia/src/output/file.ts
@@ -15,16 +15,13 @@ const acquireLock = (filePath: string): Promise<() => void> => {
     resolveLock = resolve
   })
 
-  return prior.then(() => {
-    // Only set the lock after acquiring the prior lock to prevent race conditions
-    fileLocks.set(filePath, newLock)
+  // Register synchronously: same-tick callers must chain onto THIS lock.
+  fileLocks.set(filePath, newLock)
 
-    // Critical section can now proceed
-    return () => {
-      resolveLock?.()
-      if (fileLocks.get(filePath) === newLock) {
-        fileLocks.delete(filePath)
-      }
+  return prior.then(() => () => {
+    resolveLock?.()
+    if (fileLocks.get(filePath) === newLock) {
+      fileLocks.delete(filePath)
     }
   })
 }

--- a/packages/logixlysia/src/output/file.ts
+++ b/packages/logixlysia/src/output/file.ts
@@ -7,7 +7,7 @@ import { performRotation, shouldRotate } from './rotation-manager'
 // Per-file mutex to prevent race conditions during rotation
 const fileLocks = new Map<string, Promise<void>>()
 
-const acquireLock = (filePath: string): Promise<() => void> => {
+const acquireLock = async (filePath: string): Promise<() => void> => {
   const prior = fileLocks.get(filePath) ?? Promise.resolve()
 
   let resolveLock: () => void
@@ -15,15 +15,17 @@ const acquireLock = (filePath: string): Promise<() => void> => {
     resolveLock = resolve
   })
 
-  // Register synchronously: same-tick callers must chain onto THIS lock.
+  // Register before awaiting: same-tick callers must chain onto THIS lock.
   fileLocks.set(filePath, newLock)
 
-  return prior.then(() => () => {
+  await prior
+
+  return () => {
     resolveLock?.()
     if (fileLocks.get(filePath) === newLock) {
       fileLocks.delete(filePath)
     }
-  })
+  }
 }
 
 interface LogToFileInput {

--- a/packages/logixlysia/src/output/rotation-manager.ts
+++ b/packages/logixlysia/src/output/rotation-manager.ts
@@ -14,7 +14,9 @@ const gzipAsync = promisify(gzip)
 // Compression lock to prevent concurrent compression of the same file
 const compressionLocks = new Map<string, Promise<void>>()
 
-const acquireCompressionLock = (filePath: string): Promise<() => void> => {
+const acquireCompressionLock = async (
+  filePath: string
+): Promise<() => void> => {
   const prior = compressionLocks.get(filePath) ?? Promise.resolve()
 
   let resolveLock: () => void
@@ -22,15 +24,17 @@ const acquireCompressionLock = (filePath: string): Promise<() => void> => {
     resolveLock = resolve
   })
 
-  // Register synchronously: same-tick callers must chain onto THIS lock.
+  // Register before awaiting: same-tick callers must chain onto THIS lock.
   compressionLocks.set(filePath, newLock)
 
-  return prior.then(() => () => {
+  await prior
+
+  return () => {
     resolveLock?.()
     if (compressionLocks.get(filePath) === newLock) {
       compressionLocks.delete(filePath)
     }
-  })
+  }
 }
 
 const pad2 = (value: number): string => String(value).padStart(2, '0')

--- a/packages/logixlysia/src/output/rotation-manager.ts
+++ b/packages/logixlysia/src/output/rotation-manager.ts
@@ -22,16 +22,13 @@ const acquireCompressionLock = (filePath: string): Promise<() => void> => {
     resolveLock = resolve
   })
 
-  return prior.then(() => {
-    // Only set the lock after acquiring the prior lock to prevent race conditions
-    compressionLocks.set(filePath, newLock)
+  // Register synchronously: same-tick callers must chain onto THIS lock.
+  compressionLocks.set(filePath, newLock)
 
-    // Critical section can now proceed
-    return () => {
-      resolveLock?.()
-      if (compressionLocks.get(filePath) === newLock) {
-        compressionLocks.delete(filePath)
-      }
+  return prior.then(() => () => {
+    resolveLock?.()
+    if (compressionLocks.get(filePath) === newLock) {
+      compressionLocks.delete(filePath)
     }
   })
 }


### PR DESCRIPTION
## Description

Fixes the broken per-file mutex in the file sink (implements `plans/002-fix-file-write-mutex.md`, planned at 4974d53):

- `acquireLock` (`src/output/file.ts`) registered its lock in the map **inside** `prior.then(...)` — only after the prior holder finished — so any same-tick concurrent callers all saw no prior lock and entered the critical section together, letting `appendFile` interleave with rotation's `fs.rename` (dropped/torn log lines under load). The lock is now registered **synchronously** before chaining on the prior holder.
- The byte-for-byte copy `acquireCompressionLock` (`src/output/rotation-manager.ts`) gets the identical fix. Both copies are kept textually identical on purpose — plan 017 extracts them into one shared keyed-mutex helper.
- New line-integrity test: 20 same-tick `logToFile` calls with rotation on every write → exactly 20 distinct, well-formed lines across live + rotated files.

## Related Issues

None — part of the `plans/` improvement series (plan 002, depends on #348).

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary (not needed — internal concurrency fix)

## Screenshots (if applicable)

N/A — no UI changes.

## Additional Notes

Verification gates (re-run at review):

- `bun test` (packages/logixlysia): **150 pass, 0 fail** (375 expect() calls, 22 files)
- New exclusion test stable across 30 repeated runs (20 by executor + 10 at review)
- `bun run typecheck`: exit 0 (turbo 5/5) · `bun x ultracite check`: 98 files clean · `bun run build --filter logixlysia`: exit 0
- Changeset: `.changeset/fix-file-write-mutex.md` (`logixlysia: patch`)

Reviewer note, recorded honestly: the new test asserts line integrity but was empirically shown **not** to fail on the pre-fix mutex on a fast local fs (the race window is too small without mocking). The fix is verified by inspection (synchronous lock registration is the standard promise-chain mutex pattern). A deterministic max-one-holder unit test is scheduled for plan 017, where the mutex becomes an exported helper and exclusion can be asserted directly without fs mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)