### PR TITLE
fix(plugin): correct request durations under concurrency

### DIFF
--- a/.changeset/per-request-timing.md
+++ b/.changeset/per-request-timing.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': patch
+---
+
+Track request start time per-request instead of in Elysia app-global state; logged durations are now correct when requests overlap.

--- a/packages/logixlysia/__tests__/plugin/concurrent-timing.test.ts
+++ b/packages/logixlysia/__tests__/plugin/concurrent-timing.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { Elysia } from 'elysia'
+
+import { logixlysia } from '../../src'
+import type { Options } from '../../src/interfaces'
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms))
+
+describe('logixlysia plugin - per-request timing under concurrency', () => {
+  test('overlapping requests report independent, correct durations', async () => {
+    const calls: { url: string; beforeTime: bigint; capturedAt: bigint }[] = []
+    const transport = mock(
+      (_level: unknown, _message: unknown, meta?: unknown) => {
+        const record = meta as { request: { url: string }; beforeTime: bigint }
+        calls.push({
+          url: record.request.url,
+          beforeTime: record.beforeTime,
+          // Captured at the same instant `logToTransports` runs, mirroring
+          // how `formatLogOutput` samples `process.hrtime.bigint()` when it
+          // computes `durationMs` in production.
+          capturedAt: process.hrtime.bigint()
+        })
+      }
+    )
+
+    const options: Options = {
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia()
+      .use(logixlysia(options))
+      .get('/slow', async () => {
+        await sleep(120)
+        return 'slow'
+      })
+      .get('/fast', () => 'fast')
+
+    const slowPromise = app.handle(new Request('http://localhost/slow'))
+    await sleep(30)
+    await app.handle(new Request('http://localhost/fast'))
+    await slowPromise
+
+    const durationFor = (path: string): number => {
+      const call = calls.find(c => c.url.endsWith(path))
+      if (!call) {
+        throw new Error(`no transport call recorded for ${path}`)
+      }
+      return Number(call.capturedAt - call.beforeTime) / 1_000_000
+    }
+
+    const slowDurationMs = durationFor('/slow')
+    const fastDurationMs = durationFor('/fast')
+
+    // Pre-fix, `store.beforeTime` was mutated in Elysia's app-global state:
+    // the `/fast` request (started ~30ms after `/slow`) overwrites the single
+    // shared slot before `/slow`'s `onAfterHandle` reads it, so `/slow`'s
+    // logged duration collapses to roughly `120 - 30 = 90ms` instead of
+    // reflecting its true ~120ms runtime.
+    expect(slowDurationMs).toBeGreaterThanOrEqual(100)
+    expect(fastDurationMs).toBeLessThan(100)
+  })
+})

--- a/packages/logixlysia/__tests__/plugin/concurrent-timing.test.ts
+++ b/packages/logixlysia/__tests__/plugin/concurrent-timing.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 import { Elysia } from 'elysia'
 
 import { logixlysia } from '../../src'
@@ -10,19 +10,21 @@ const sleep = (ms: number): Promise<void> =>
 describe('logixlysia plugin - per-request timing under concurrency', () => {
   test('overlapping requests report independent, correct durations', async () => {
     const calls: { url: string; beforeTime: bigint; capturedAt: bigint }[] = []
-    const transport = mock(
-      (_level: unknown, _message: unknown, meta?: unknown) => {
-        const record = meta as { request: { url: string }; beforeTime: bigint }
-        calls.push({
-          url: record.request.url,
-          beforeTime: record.beforeTime,
-          // Captured at the same instant `logToTransports` runs, mirroring
-          // how `formatLogOutput` samples `process.hrtime.bigint()` when it
-          // computes `durationMs` in production.
-          capturedAt: process.hrtime.bigint()
-        })
-      }
-    )
+    const transport = (
+      _level: unknown,
+      _message: unknown,
+      meta?: unknown
+    ): void => {
+      const record = meta as { request: { url: string }; beforeTime: bigint }
+      calls.push({
+        url: record.request.url,
+        beforeTime: record.beforeTime,
+        // Captured at the same instant `logToTransports` runs, mirroring
+        // how `formatLogOutput` samples `process.hrtime.bigint()` when it
+        // computes `durationMs` in production.
+        capturedAt: process.hrtime.bigint()
+      })
+    }
 
     const options: Options = {
       config: {

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -47,6 +47,7 @@ export type LogixlysiaPlugin = Logixlysia & {
 export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
   const options = resolveOptions(rawOptions)
   const didCustomLog = new WeakSet<Request>()
+  const requestStartTimes = new WeakMap<Request, bigint>()
   const contextStore = createRequestContextStore()
   const baseLogger = createPluginLogger(options, contextStore)
   const wrapWs = createWsHandlerWrapper(options, baseLogger, contextStore)
@@ -121,8 +122,8 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
         startServer({ port, hostname, protocol: 'http' }, options)
       }
     })
-    .onRequest(({ request, store }) => {
-      store.beforeTime = process.hrtime.bigint()
+    .onRequest(({ request }) => {
+      requestStartTimes.set(request, process.hrtime.bigint())
       if (requestIdConfig) {
         const requestId = getOrCreateRequestId(request, requestIdConfig)
         contextStore.mergeContext(request, { requestId })
@@ -132,7 +133,7 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
         loggerStorage.enterWith(createRequestScopedLogger(request))
       }
     })
-    .onAfterHandle(({ request, set, store }) => {
+    .onAfterHandle(({ request, set }) => {
       try {
         if (requestIdConfig) {
           const ctx = contextStore.getContext(request)
@@ -160,12 +161,15 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
           data.context = { ...accumulated }
         }
 
-        logger.log(level, request, data, store)
+        logger.log(level, request, data, {
+          beforeTime: requestStartTimes.get(request) ?? BigInt(0)
+        })
       } finally {
+        requestStartTimes.delete(request)
         contextStore.clearContext(request)
       }
     })
-    .onError(({ request, error, set, store }) => {
+    .onError(({ request, error, set }) => {
       try {
         if (requestIdConfig) {
           const ctx = contextStore.getContext(request)
@@ -174,8 +178,11 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
             set.headers[requestIdConfig.header] = id
           }
         }
-        logger.handleHttpError(request, error, store)
+        logger.handleHttpError(request, error, {
+          beforeTime: requestStartTimes.get(request) ?? BigInt(0)
+        })
       } finally {
+        requestStartTimes.delete(request)
         contextStore.clearContext(request)
       }
     })


### PR DESCRIPTION
## Description

Fixes wrong logged durations under concurrent load (implements `plans/003-per-request-timing.md`, planned at 4974d53):

- Elysia's `.state()` is app-global, and the plugin stored the request start time there — every incoming request overwrote the single `beforeTime` slot, so with overlapping requests the earlier request's duration was computed against the later request's start time. Under load, every `durationMs` (and the slow-threshold coloring built on it) was wrong.
- Start times now live in a per-request `WeakMap<Request, bigint>` inside the plugin closure; `onAfterHandle`/`onError` pass a per-request `StoreData` to the logger and clean the map in their `finally` blocks.
- Public API unchanged: `Logger.log`/`handleHttpError` signatures and the `StoreData.beforeTime` shape are preserved; `.state('beforeTime', BigInt(0))` intentionally remains for store-shape compatibility (it just never mutates now). The WebSocket wrapper's own per-connection timing is untouched.

## Related Issues

None — part of the `plans/` improvement series (plan 003).

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary (not needed — behavior now matches what the docs already claim)

## Screenshots (if applicable)

N/A — no UI changes.

## Additional Notes

Verification gates (re-run at review):

- `bun test` (packages/logixlysia): **151 pass, 0 fail** (377 expect() calls, 23 files)
- **Regression proof, reproduced twice** (executor + reviewer): with the fix reverted, the new concurrency test fails at `Expected: >= 100, Received: ~90ms` — the exact error mode (slow request's 120ms duration collapsing to `120 − 30 = 90ms` after a fast request overwrites the shared slot). With the fix, it passes.
- `bun run typecheck`: exit 0 (turbo 5/5) · `bun x ultracite check`: 99 files clean · `bun run build --filter logixlysia`: exit 0
- Changeset: `.changeset/per-request-timing.md` (`logixlysia: patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)