### PR TITLE
fix(output): JSON-serializable transport meta, observable failures

### DIFF
--- a/.changeset/transport-meta-serialization.md
+++ b/.changeset/transport-meta-serialization.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': patch
+---
+
+Transport meta now carries a JSON-serializable `durationMs` number instead of a BigInt `beforeTime` (which made `JSON.stringify` throw in every serializing transport), and transport failures are reported to stderr (rate-limited) instead of being silently swallowed.

--- a/packages/logixlysia/__tests__/output/transports.test.ts
+++ b/packages/logixlysia/__tests__/output/transports.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test'
 import type { Options } from '../../src/interfaces'
 import { logToTransports } from '../../src/output'
+import { spyConsole } from '../_helpers/console'
 import { createMockRequest } from '../_helpers/request'
 
 describe('logToTransports', () => {
@@ -47,11 +48,104 @@ describe('logToTransports', () => {
     expect(messageValue).toBe('Test message')
     expect(metaValue).toBeTypeOf('object')
     const meta = metaValue as unknown as Record<string, unknown>
-    expect(meta.beforeTime).toBe(store.beforeTime)
+    expect(meta.beforeTime).toBeUndefined()
+    expect(meta.durationMs).toBeTypeOf('number')
+    expect(() => JSON.stringify(meta)).not.toThrow()
 
     const req = meta.request as { method?: unknown; url?: unknown } | undefined
     expect(req?.method).toBe('GET')
     expect(req?.url).toBe('http://localhost/hello')
+  })
+
+  test('computes durationMs from store.beforeTime', () => {
+    const t1 = mock<(lvl: unknown, msg: unknown, metaArg?: unknown) => void>(
+      () => {
+        /* noop */
+      }
+    )
+    const options: Options = { config: { transports: [{ log: t1 }] } }
+    const request = createMockRequest('http://localhost/hello')
+
+    const beforeTime = process.hrtime.bigint()
+    const store = { beforeTime }
+
+    logToTransports({
+      level: 'INFO',
+      request,
+      data: { message: 'Test message' },
+      store,
+      options
+    })
+
+    const meta = t1.mock.calls[0]?.[2] as Record<string, unknown>
+    expect(meta.durationMs).toBeTypeOf('number')
+    expect(meta.durationMs as number).toBeGreaterThan(0)
+    expect(Number.isFinite(meta.durationMs as number)).toBe(true)
+
+    const t2 = mock<(lvl: unknown, msg: unknown, metaArg?: unknown) => void>(
+      () => {
+        /* noop */
+      }
+    )
+    const zeroOptions: Options = { config: { transports: [{ log: t2 }] } }
+    const zeroStore = { beforeTime: BigInt(0) }
+
+    logToTransports({
+      level: 'INFO',
+      request,
+      data: { message: 'Test message' },
+      store: zeroStore,
+      options: zeroOptions
+    })
+
+    const zeroMeta = t2.mock.calls[0]?.[2] as Record<string, unknown>
+    expect(zeroMeta.durationMs).toBe(0)
+  })
+
+  // This test must run before any other test that triggers a transport
+  // failure (e.g. the "never throws"/"swallows async rejections" tests
+  // below): `reportTransportError`'s rate limit is module-scoped state that
+  // persists across tests in this file, so it must observe the very first
+  // failure to reliably assert both the log and the rate limit.
+  test('reports a throwing transport to stderr, rate-limited', () => {
+    const { spies, restore } = spyConsole(['error'])
+
+    try {
+      const throwing = mock<
+        (lvl: unknown, msg: unknown, metaArg?: unknown) => void
+      >(() => {
+        throw new Error('boom')
+      })
+
+      const options: Options = { config: { transports: [{ log: throwing }] } }
+      const request = createMockRequest('http://localhost/throw')
+      const store = { beforeTime: BigInt(0) }
+
+      logToTransports({
+        level: 'INFO',
+        request,
+        data: { message: 'ignored' },
+        store,
+        options
+      })
+
+      expect(spies.error).toHaveBeenCalledTimes(1)
+      const firstErrorCall = spies.error.mock.calls[0]
+      expect(firstErrorCall?.[0]).toContain('transport failed')
+
+      // A second immediate failure must not log again (rate limit).
+      logToTransports({
+        level: 'INFO',
+        request,
+        data: { message: 'ignored again' },
+        store,
+        options
+      })
+
+      expect(spies.error).toHaveBeenCalledTimes(1)
+    } finally {
+      restore()
+    }
   })
 
   test('never throws when a transport throws', () => {

--- a/packages/logixlysia/__tests__/plugin/concurrent-timing.test.ts
+++ b/packages/logixlysia/__tests__/plugin/concurrent-timing.test.ts
@@ -9,20 +9,16 @@ const sleep = (ms: number): Promise<void> =>
 
 describe('logixlysia plugin - per-request timing under concurrency', () => {
   test('overlapping requests report independent, correct durations', async () => {
-    const calls: { url: string; beforeTime: bigint; capturedAt: bigint }[] = []
+    const calls: { url: string; durationMs: number }[] = []
     const transport = (
       _level: unknown,
       _message: unknown,
       meta?: unknown
     ): void => {
-      const record = meta as { request: { url: string }; beforeTime: bigint }
+      const record = meta as { request: { url: string }; durationMs: number }
       calls.push({
         url: record.request.url,
-        beforeTime: record.beforeTime,
-        // Captured at the same instant `logToTransports` runs, mirroring
-        // how `formatLogOutput` samples `process.hrtime.bigint()` when it
-        // computes `durationMs` in production.
-        capturedAt: process.hrtime.bigint()
+        durationMs: record.durationMs
       })
     }
 
@@ -52,17 +48,17 @@ describe('logixlysia plugin - per-request timing under concurrency', () => {
       if (!call) {
         throw new Error(`no transport call recorded for ${path}`)
       }
-      return Number(call.capturedAt - call.beforeTime) / 1_000_000
+      return call.durationMs
     }
 
     const slowDurationMs = durationFor('/slow')
     const fastDurationMs = durationFor('/fast')
 
-    // Pre-fix, `store.beforeTime` was mutated in Elysia's app-global state:
-    // the `/fast` request (started ~30ms after `/slow`) overwrites the single
-    // shared slot before `/slow`'s `onAfterHandle` reads it, so `/slow`'s
-    // logged duration collapses to roughly `120 - 30 = 90ms` instead of
-    // reflecting its true ~120ms runtime.
+    // Pre-fix, the request start time was mutated in Elysia's app-global
+    // state: the `/fast` request (started ~30ms after `/slow`) overwrites the
+    // single shared slot before `/slow`'s `onAfterHandle` reads it, so
+    // `/slow`'s logged duration collapses to roughly `120 - 30 = 90ms`
+    // instead of reflecting its true ~120ms runtime.
     expect(slowDurationMs).toBeGreaterThanOrEqual(100)
     expect(fastDurationMs).toBeLessThan(100)
   })

--- a/packages/logixlysia/src/output/index.ts
+++ b/packages/logixlysia/src/output/index.ts
@@ -37,7 +37,10 @@ export const logToTransports = (
       url: request.url
     },
     ...data,
-    beforeTime: store.beforeTime
+    durationMs:
+      store.beforeTime === BigInt(0)
+        ? 0
+        : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000
   }
 
   for (const transport of transports) {

--- a/packages/logixlysia/src/output/index.ts
+++ b/packages/logixlysia/src/output/index.ts
@@ -1,5 +1,17 @@
 import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
 
+let lastTransportErrorAt = 0
+const TRANSPORT_ERROR_INTERVAL_MS = 5000
+
+const reportTransportError = (error: unknown): void => {
+  const now = Date.now()
+  if (now - lastTransportErrorAt < TRANSPORT_ERROR_INTERVAL_MS) {
+    return
+  }
+  lastTransportErrorAt = now
+  console.error('[logixlysia] transport failed:', error)
+}
+
 interface LogToTransportsInput {
   data: Record<string, unknown>
   level: LogLevel
@@ -50,12 +62,10 @@ export const logToTransports = (
         result &&
         typeof (result as { catch?: unknown }).catch === 'function'
       ) {
-        ;(result as Promise<void>).catch(() => {
-          // Ignore errors
-        })
+        ;(result as Promise<void>).catch(reportTransportError)
       }
-    } catch {
-      // Transport failures must never crash application logging.
+    } catch (error) {
+      reportTransportError(error)
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes silently broken transports (implements `plans/004-transport-meta-serialization.md`, planned at 4974d53):

- Transport meta carried `beforeTime` as a **BigInt** — `JSON.stringify(meta)` throws `TypeError` on BigInt, so any transport that serializes its meta (HTTP shippers, queues, files) threw on **every log call**, and the empty `catch {}` swallowed it: zero logs, zero errors. Meta now carries `durationMs: number` (computed the same way the file sink computes it), which is both serializable and actually useful to transports.
- Transport failures (sync throws and async rejections) are now reported to stderr as `[logixlysia] transport failed:`, rate-limited to one report per 5s, instead of vanishing. The never-crash-application-logging guarantee is preserved. (An optional `config.onError` hook supersedes this in plan 017.)
- The unit test pinning the BigInt bug now asserts the opposite (`JSON.stringify(meta)` must not throw), and plan 003's concurrency test simplifies to read `meta.durationMs` directly while keeping its ≥100ms/<100ms assertions.

Note for transport authors: the `beforeTime` meta key is replaced by `durationMs`. Patch bump because the old key was unusable (any JSON serialization threw).

## Related Issues

None — part of the `plans/` improvement series (plan 004, depends on #351).

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary (checked: no doc documents the transport meta shape; the `beforeTime` hits in api-reference.mdx describe the unrelated `LogixlysiaStore` type)

## Screenshots (if applicable)

N/A — no UI changes.

## Additional Notes

Verification gates (re-run at review):

- `bun test` (packages/logixlysia): **153 pass, 0 fail** (386 expect() calls, 23 files)
- `grep "beforeTime:" src/output/index.ts` → no meta-key match; serializability assertion passes
- `bun run typecheck`: exit 0 (turbo 5/5) · `bun x ultracite check`: 99 files clean · `bun run build --filter logixlysia`: exit 0
- Changeset: `.changeset/transport-meta-serialization.md` (`logixlysia: patch`)

Review note: the rate-limit test must run before the pre-existing throwing-transport tests in the same file (the limiter is module-scoped state) — the test file carries a comment explaining this ordering constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transport metadata now includes a JSON-serializable `durationMs` value, preventing serialization failures.
  * Transport errors are reported to stderr instead of being silently ignored.
  * Repeated transport failures are rate-limited to reduce excessive error output.
  * Request metadata continues to include relevant HTTP method and URL details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->