### PR TITLE
fix: correct status/level for string statuses and thrown 4xx

### DIFF
--- a/.changeset/status-code-correctness.md
+++ b/.changeset/status-code-correctness.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': patch
+---
+
+String `set.status` values (e.g. `'Not Found'`) now log their real status code and severity instead of `200 INFO`, and thrown 4xx errors log as WARNING (matching the success-path severity ladder) instead of always ERROR.

--- a/apps/elysia/src/routers/status.ts
+++ b/apps/elysia/src/routers/status.ts
@@ -1,17 +1,32 @@
 import type { Logixlysia } from 'logixlysia'
 
 export const statusRouter = <App extends Logixlysia>(app: App) =>
-  app.get(
-    '/status/:code',
-    ({ params, set }) => {
-      const code = Number(params.code)
-      set.status = Number.isFinite(code) ? code : 400
-      return { status: set.status }
-    },
-    {
-      detail: {
-        summary: 'Status example',
-        tags: ['status']
+  app
+    .get(
+      '/status/:code',
+      ({ params, set }) => {
+        const code = Number(params.code)
+        set.status =
+          Number.isInteger(code) && code >= 200 && code <= 599 ? code : 400
+        return { status: set.status }
+      },
+      {
+        detail: {
+          summary: 'Status example',
+          tags: ['status']
+        }
       }
-    }
-  )
+    )
+    .get(
+      '/status/name/:name',
+      ({ params, set }) => {
+        set.status = decodeURIComponent(params.name) as never // e.g. "Not Found" — exercises string statuses
+        return { status: set.status }
+      },
+      {
+        detail: {
+          summary: 'String status example',
+          tags: ['status']
+        }
+      }
+    )

--- a/packages/logixlysia/__tests__/integration/demo-app.ts
+++ b/packages/logixlysia/__tests__/integration/demo-app.ts
@@ -32,6 +32,16 @@ export const createDemoApp = (options: Options) => {
       injectTraceContext(store.logger, request)
     })
     .get('/trace', () => ({ ok: true }))
+    .get('/status/:code', ({ params, set }) => {
+      const code = Number(params.code)
+      set.status =
+        Number.isInteger(code) && code >= 200 && code <= 599 ? code : 400
+      return { status: set.status }
+    })
+    .get('/status/name/:name', ({ params, set }) => {
+      set.status = decodeURIComponent(params.name) as never // e.g. "Not Found" — exercises string statuses
+      return { status: set.status }
+    })
 }
 
 export const silentTestOptions = (transport: TransportLog): Options => ({

--- a/packages/logixlysia/__tests__/integration/demo-routes.test.ts
+++ b/packages/logixlysia/__tests__/integration/demo-routes.test.ts
@@ -57,6 +57,24 @@ describe('demo routes (Bun)', () => {
     expect(response.status).toBe(200)
     expect(transport).toHaveBeenCalled()
   })
+
+  test('GET /status/9999 clamps out-of-range codes to 400', async () => {
+    const transport = mockTransport()
+    const app = createDemoApp(silentTestOptions(transport))
+    const response = await app.handle(
+      new Request('http://localhost/status/9999')
+    )
+    expect(response.status).toBe(400)
+  })
+
+  test('GET /status/name/Not%20Found resolves the named status', async () => {
+    const transport = mockTransport()
+    const app = createDemoApp(silentTestOptions(transport))
+    const response = await app.handle(
+      new Request('http://localhost/status/name/Not%20Found')
+    )
+    expect(response.status).toBe(404)
+  })
 })
 
 describe('Node adapter', () => {

--- a/packages/logixlysia/__tests__/logger/create-logger.test.ts
+++ b/packages/logixlysia/__tests__/logger/create-logger.test.ts
@@ -122,10 +122,13 @@ describe('createLogger', () => {
     const store = { beforeTime: BigInt(0) }
 
     logger.handleHttpError(request, { status: 400, message: 'bad' }, store)
+    logger.handleHttpError(request, { status: 503, message: 'down' }, store)
 
-    expect(transport).toHaveBeenCalledTimes(1)
-    const [levelValue] = transport.mock.calls[0] ?? [undefined]
-    expect(levelValue).toBe('ERROR')
+    expect(transport).toHaveBeenCalledTimes(2)
+    const [firstLevelValue] = transport.mock.calls[0] ?? [undefined]
+    expect(firstLevelValue).toBe('WARNING')
+    const [secondLevelValue] = transport.mock.calls[1] ?? [undefined]
+    expect(secondLevelValue).toBe('ERROR')
 
     await new Promise(resolve => setTimeout(resolve, 0))
   })

--- a/packages/logixlysia/__tests__/plugin/logixlysia.test.ts
+++ b/packages/logixlysia/__tests__/plugin/logixlysia.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, mock, test } from 'bun:test'
 import { Elysia } from 'elysia'
 
 import { logixlysia } from '../../src'
-import type { Options } from '../../src/interfaces'
+import { HttpError, type Options } from '../../src/interfaces'
 
 describe('logixlysia plugin', () => {
   test('auto-logs once when no custom log was emitted', async () => {
@@ -246,5 +246,120 @@ describe('logixlysia plugin', () => {
     expect(transport).toHaveBeenCalledTimes(1)
     const [levelValue] = transport.mock.calls[0] ?? [undefined]
     expect(levelValue).toBe('ERROR')
+  })
+
+  test('string set.status is resolved to its real code and ERROR level', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const options: Options = {
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia()
+      .use(logixlysia(options))
+      .get('/test', ({ set }) => {
+        set.status = 'Internal Server Error'
+        return 'ok'
+      })
+
+    await app.handle(new Request('http://localhost/test'))
+
+    expect(transport).toHaveBeenCalledTimes(1)
+    const [levelValue, , meta] = transport.mock.calls[0] ?? [
+      undefined,
+      undefined,
+      undefined
+    ]
+    expect(levelValue).toBe('ERROR')
+    expect((meta as Record<string, unknown> | undefined)?.status).toBe(500)
+  })
+
+  test('string set.status "Not Found" logs as 404 / WARNING', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const options: Options = {
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia()
+      .use(logixlysia(options))
+      .get('/test', ({ set }) => {
+        set.status = 'Not Found'
+        return 'ok'
+      })
+
+    await app.handle(new Request('http://localhost/test'))
+
+    expect(transport).toHaveBeenCalledTimes(1)
+    const [levelValue, , meta] = transport.mock.calls[0] ?? [
+      undefined,
+      undefined,
+      undefined
+    ]
+    expect(levelValue).toBe('WARNING')
+    expect((meta as Record<string, unknown> | undefined)?.status).toBe(404)
+  })
+
+  test('thrown HttpError(404) logs at WARNING, not ERROR', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const options: Options = {
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/boom', () => {
+      throw new HttpError(404, 'not found')
+    })
+
+    await app.handle(new Request('http://localhost/boom'))
+
+    const levels = transport.mock.calls.map(call => call[0])
+    expect(levels).toContain('WARNING')
+    expect(levels).not.toContain('ERROR')
+  })
+
+  test('thrown HttpError(503) logs at ERROR', async () => {
+    const transport = mock<
+      (lvl: unknown, msg: unknown, meta?: unknown) => void
+    >(() => {
+      /* noop */
+    })
+    const options: Options = {
+      config: {
+        transports: [{ log: transport }],
+        disableInternalLogger: true,
+        disableFileLogging: true
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/boom', () => {
+      throw new HttpError(503, 'unavailable')
+    })
+
+    await app.handle(new Request('http://localhost/boom'))
+
+    const levels = transport.mock.calls.map(call => call[0])
+    expect(levels).toContain('ERROR')
   })
 })

--- a/packages/logixlysia/__tests__/plugin/logixlysia.test.ts
+++ b/packages/logixlysia/__tests__/plugin/logixlysia.test.ts
@@ -4,6 +4,22 @@ import { Elysia } from 'elysia'
 import { logixlysia } from '../../src'
 import { HttpError, type Options } from '../../src/interfaces'
 
+const createCaptureTransport = () => {
+  const transport = mock<(lvl: unknown, msg: unknown, meta?: unknown) => void>(
+    () => {
+      /* noop */
+    }
+  )
+  const options: Options = {
+    config: {
+      transports: [{ log: transport }],
+      disableInternalLogger: true,
+      disableFileLogging: true
+    }
+  }
+  return { transport, options }
+}
+
 describe('logixlysia plugin', () => {
   test('auto-logs once when no custom log was emitted', async () => {
     const transport = mock<
@@ -249,18 +265,7 @@ describe('logixlysia plugin', () => {
   })
 
   test('string set.status is resolved to its real code and ERROR level', async () => {
-    const transport = mock<
-      (lvl: unknown, msg: unknown, meta?: unknown) => void
-    >(() => {
-      /* noop */
-    })
-    const options: Options = {
-      config: {
-        transports: [{ log: transport }],
-        disableInternalLogger: true,
-        disableFileLogging: true
-      }
-    }
+    const { transport, options } = createCaptureTransport()
 
     const app = new Elysia()
       .use(logixlysia(options))
@@ -282,18 +287,7 @@ describe('logixlysia plugin', () => {
   })
 
   test('string set.status "Not Found" logs as 404 / WARNING', async () => {
-    const transport = mock<
-      (lvl: unknown, msg: unknown, meta?: unknown) => void
-    >(() => {
-      /* noop */
-    })
-    const options: Options = {
-      config: {
-        transports: [{ log: transport }],
-        disableInternalLogger: true,
-        disableFileLogging: true
-      }
-    }
+    const { transport, options } = createCaptureTransport()
 
     const app = new Elysia()
       .use(logixlysia(options))
@@ -315,18 +309,7 @@ describe('logixlysia plugin', () => {
   })
 
   test('thrown HttpError(404) logs at WARNING, not ERROR', async () => {
-    const transport = mock<
-      (lvl: unknown, msg: unknown, meta?: unknown) => void
-    >(() => {
-      /* noop */
-    })
-    const options: Options = {
-      config: {
-        transports: [{ log: transport }],
-        disableInternalLogger: true,
-        disableFileLogging: true
-      }
-    }
+    const { transport, options } = createCaptureTransport()
 
     const app = new Elysia().use(logixlysia(options)).get('/boom', () => {
       throw new HttpError(404, 'not found')
@@ -340,18 +323,7 @@ describe('logixlysia plugin', () => {
   })
 
   test('thrown HttpError(503) logs at ERROR', async () => {
-    const transport = mock<
-      (lvl: unknown, msg: unknown, meta?: unknown) => void
-    >(() => {
-      /* noop */
-    })
-    const options: Options = {
-      config: {
-        transports: [{ log: transport }],
-        disableInternalLogger: true,
-        disableFileLogging: true
-      }
-    }
+    const { transport, options } = createCaptureTransport()
 
     const app = new Elysia().use(logixlysia(options)).get('/boom', () => {
       throw new HttpError(503, 'unavailable')

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -3,6 +3,7 @@ import { resolveOptions } from './config/resolve-options'
 import { createRequestContextStore } from './context/request-context'
 import { loggerStorage } from './context/storage'
 import { startServer } from './extensions'
+import { getStatusCode } from './helpers/status'
 import type {
   LogixlysiaStore,
   Options,
@@ -147,7 +148,10 @@ export const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
           return
         }
 
-        const status = typeof set.status === 'number' ? set.status : 200
+        const status =
+          set.status === undefined || set.status === null
+            ? 200
+            : getStatusCode(set.status)
         let level: 'INFO' | 'WARNING' | 'ERROR' = 'INFO'
         if (status >= 500) {
           level = 'ERROR'

--- a/packages/logixlysia/src/logger/handle-http-error.ts
+++ b/packages/logixlysia/src/logger/handle-http-error.ts
@@ -26,11 +26,17 @@ export const handleHttpError = (
 ): void => {
   const config = options.config
 
+  const status = isErrorWithStatus(error) ? error.status : 500
+  let level: LogLevel = 'ERROR'
+  if (status < 500 && status >= 400) {
+    level = 'WARNING'
+  }
+
   const logFilter = config?.logFilter
   if (
     logFilter?.level &&
     logFilter.level.length > 0 &&
-    !logFilter.level.includes('ERROR')
+    !logFilter.level.includes(level)
   ) {
     return
   }
@@ -39,10 +45,8 @@ export const handleHttpError = (
   const disableInternalLogger = config?.disableInternalLogger === true
   const disableFileLogging = config?.disableFileLogging === true
 
-  const status = isErrorWithStatus(error) ? error.status : 500
   const message = parseError(error)
 
-  const level: LogLevel = 'ERROR'
   const data: Record<string, unknown> = { status, message, error }
   const dataWithContext = contextStore
     ? mergeLogDataContext(data, contextStore.getContext(request))


### PR DESCRIPTION
## Description

Fixes status-code and severity handling (implements `plans/005-status-code-correctness.md`, planned at 4974d53):

- **String `set.status` no longer logs as `200 INFO`**: Elysia allows `set.status = 'Not Found'` (typed `number | keyof StatusMap`), but the success-path hook coerced every non-number to 200. It now resolves through the existing `getStatusCode()` helper — `'Not Found'` logs as `404 WARNING`, `'Internal Server Error'` as `500 ERROR`.
- **Thrown 4xx errors log as WARNING**: the error path hardcoded `ERROR` for everything, so a thrown 404 logged as ERROR while the same 404 via `set.status` logged as WARNING. Both paths now share the same severity ladder, and the `logFilter` early-exit checks the derived level instead of hardcoded `'ERROR'`.
- **Demo app**: `/status/:code` clamps to the valid 200–599 range (was accepting `/status/9999`), and a new `/status/name/:name` route exercises string statuses; both mirrored into the integration demo app with tests.

One pre-existing test updated by reviewer adjudication: `handleHttpError emits transport error log` pinned `ERROR` for a `{ status: 400 }` fixture — an incidental pin of the old hardcoded level, not an intentional contract. It now asserts `WARNING` for 400 and `ERROR` for 503, covering the ladder.

## Related Issues

None — part of the `plans/` improvement series (plan 005).

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary (not needed — docs don't specify error-path severity)

## Screenshots (if applicable)

N/A — no UI changes.

## Additional Notes

Behavior change note: thrown 4xx errors now log at WARNING instead of ERROR (documented in the changeset). If a downstream consumer needs "all thrown errors are ERROR", that would become a config flag — explicitly deferred.

Verification gates (re-run at review):

- `bun test` (packages/logixlysia): **159 pass, 0 fail** (398 expect() calls, 23 files)
- Done-criteria greps: old status coercion and hardcoded level are gone
- `bun run typecheck`: exit 0 (turbo 5/5) · `bun x ultracite check`: 99 files clean · `bun run build --filter logixlysia`: exit 0
- Changeset: `.changeset/status-code-correctness.md` (`logixlysia: patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for named HTTP statuses in status routes, including values such as “Not Found.”
  * Invalid or out-of-range numeric status codes now return HTTP 400.

* **Bug Fixes**
  * Logs now record the correct status code when string statuses are used.
  * Client errors (4xx) are logged as warnings, while server errors remain errors.
  * Log-level filtering now respects the calculated severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->