### PR TITLE
feat(redact): key/header-name-based redaction

### DIFF
--- a/.changeset/key-based-redaction.md
+++ b/.changeset/key-based-redaction.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+`autoRedact` now redacts by sensitive key/header names (authorization, cookie, x-api-key, password, secret, token, session, …) in addition to value patterns; new `config.redactKeys` extends the list, and pino gets matching `redact.paths` defaults.

--- a/apps/docs/content/configuration.mdx
+++ b/apps/docs/content/configuration.mdx
@@ -76,13 +76,30 @@ These headers are typically set by reverse proxies (nginx, Caddy, Cloudflare, et
 
 ### `autoRedact`
 
-Automatically redacts sensitive PII (emails, IPs, credit cards, JWTs) from log messages, context objects, and errors before they are outputted.
+Automatically redacts sensitive data from log messages, context objects, errors, and request headers before they are outputted. Redaction runs in two ways:
+
+1. **By key/header name** — a built-in, case-insensitive denylist (`authorization`, `cookie`, `x-api-key`, `password`, `secret`, `token`, `session`, and more) wholly redacts the value of any matching object key or request header, regardless of what the value looks like. `-`, `_`, and camelCase variants (`x-api-key`, `x_api_key`, `xApiKey`) all match.
+2. **By value pattern** — emails, IP addresses, Luhn-valid payment card numbers, and JWTs are redacted wherever they appear in strings, even in fields not covered by the key denylist.
+
+Value-pattern redaction is best-effort — it only catches values matching those specific shapes. Always prefer key-based redaction (`redactKeys`) for known sensitive fields instead of relying on their value happening to match a pattern.
 
 - **Type:** `boolean`
 - **Default:** `false`
 
 ```ts
 autoRedact: true
+```
+
+### `redactKeys`
+
+Additional key/header names to redact when `autoRedact` is enabled, extending the built-in denylist. Matching is case-insensitive and normalizes `-`, `_`, and camelCase variants.
+
+- **Type:** `string[]`
+- **Default:** `undefined`
+
+```ts
+autoRedact: true,
+redactKeys: ['x-internal-token', 'customerSsn']
 ```
 
 ### `logQueryParams`

--- a/packages/logixlysia/__tests__/utils/redact.test.ts
+++ b/packages/logixlysia/__tests__/utils/redact.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 import { HttpError } from '../../src/interfaces'
-import { redact, redactRequest, redactString } from '../../src/utils/redact'
+import {
+  buildPinoRedactPaths,
+  isSensitiveKey,
+  redact,
+  redactRequest,
+  redactString
+} from '../../src/utils/redact'
 
 describe('redactString', () => {
   test('redacts emails', () => {
@@ -136,6 +142,45 @@ describe('redact', () => {
     expect(result.b.email).toBe('[REDACTED]')
     expect(result.a).not.toBe(result.b)
   })
+
+  test('redacts sensitive object keys by name', () => {
+    expect(redact({ password: 'hunter2' })).toEqual({
+      password: '[REDACTED]'
+    })
+  })
+
+  test('redacts sensitive nested keys but keeps unrelated keys', () => {
+    const result = redact({ user: { apiKey: 'abc', name: 'ok' } })
+    expect(result).toEqual({ user: { apiKey: '[REDACTED]', name: 'ok' } })
+  })
+
+  test('redacts a key added via extraKeys', () => {
+    expect(redact({ custom: 'v' }, ['custom'])).toEqual({
+      custom: '[REDACTED]'
+    })
+  })
+})
+
+describe('isSensitiveKey', () => {
+  test('matches case/format variants of built-in names', () => {
+    expect(isSensitiveKey('Authorization')).toBe(true)
+    expect(isSensitiveKey('x_api_key')).toBe(true)
+    expect(isSensitiveKey('accessToken')).toBe(true)
+  })
+
+  test('does not match on substring (no false positives)', () => {
+    expect(isSensitiveKey('tokenizer')).toBe(false)
+    expect(isSensitiveKey('sessions')).toBe(false)
+  })
+})
+
+describe('buildPinoRedactPaths', () => {
+  test('includes bare and nested paths for simple keys, bracket-quoted for hyphenated keys', () => {
+    const paths = buildPinoRedactPaths()
+    expect(paths).toContain('password')
+    expect(paths).toContain('*.password')
+    expect(paths).toContain('["x-api-key"]')
+  })
 })
 
 const sampleJwt =
@@ -164,12 +209,18 @@ describe('redactRequest', () => {
     expect(out.url).toBe('http://redacted:8080/')
   })
 
-  test('redacts sensitive header values', () => {
+  test('redacts sensitive header values wholly by name, regardless of value pattern', () => {
     const req = new Request('http://localhost/', {
-      headers: { authorization: `Bearer ${sampleJwt}` }
+      headers: {
+        authorization: `Bearer ${sampleJwt}`,
+        'content-type': 'application/json',
+        cookie: 'session=xyz'
+      }
     })
     const out = redactRequest(req)
-    expect(out.headers.get('authorization')).toBe('Bearer [REDACTED]')
+    expect(out.headers.get('authorization')).toBe('[REDACTED]')
+    expect(out.headers.get('cookie')).toBe('[REDACTED]')
+    expect(out.headers.get('content-type')).toBe('application/json')
   })
 
   test('returns same request when nothing would change', () => {

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -143,6 +143,14 @@ export interface Options {
      */
     autoRedact?: boolean
 
+    /**
+     * Additional key/header names (case-insensitive; `-`/`_`/camelCase variants
+     * are normalized) whose values are redacted when `autoRedact` is enabled.
+     * Extends the built-in list (authorization, cookie, x-api-key, password,
+     * secret, token, session, …).
+     */
+    redactKeys?: string[]
+
     // Pino
     pino?: (PinoLoggerOptions & { prettyPrint?: PrettyPrintConfig }) | undefined
 

--- a/packages/logixlysia/src/logger/handle-http-error.ts
+++ b/packages/logixlysia/src/logger/handle-http-error.ts
@@ -52,9 +52,13 @@ export const handleHttpError = (
     ? mergeLogDataContext(data, contextStore.getContext(request))
     : data
   const logData =
-    config?.autoRedact === true ? redact(dataWithContext) : dataWithContext
+    config?.autoRedact === true
+      ? redact(dataWithContext, config?.redactKeys)
+      : dataWithContext
   const logRequest =
-    config?.autoRedact === true ? redactRequest(request) : request
+    config?.autoRedact === true
+      ? redactRequest(request, config?.redactKeys)
+      : request
 
   logToTransports({ data: logData, level, options, request: logRequest, store })
 

--- a/packages/logixlysia/src/logger/index.ts
+++ b/packages/logixlysia/src/logger/index.ts
@@ -110,9 +110,13 @@ export const createLogger = (
       contextStore.getContext(request)
     )
     const logData =
-      config?.autoRedact === true ? redact(dataWithContext) : dataWithContext
+      config?.autoRedact === true
+        ? redact(dataWithContext, config?.redactKeys)
+        : dataWithContext
     const logRequest =
-      config?.autoRedact === true ? redactRequest(request) : request
+      config?.autoRedact === true
+        ? redactRequest(request, config?.redactKeys)
+        : request
 
     if (hasTransports) {
       logToTransports({

--- a/packages/logixlysia/src/logger/index.ts
+++ b/packages/logixlysia/src/logger/index.ts
@@ -16,7 +16,7 @@ import type {
 } from '../interfaces'
 import { logToTransports } from '../output'
 import { logToFile } from '../output/file'
-import { redact, redactRequest } from '../utils/redact'
+import { buildPinoRedactPaths, redact, redactRequest } from '../utils/redact'
 import { formatLogOutput } from './create-logger'
 import { handleHttpError } from './handle-http-error'
 
@@ -52,7 +52,15 @@ export const createLogger = (
     ...pinoOptions,
     errorKey,
     level: pinoOptions.level ?? 'info',
-    messageKey
+    messageKey,
+    ...(config?.autoRedact === true && pinoOptions.redact === undefined
+      ? {
+          redact: {
+            censor: '[REDACTED]',
+            paths: buildPinoRedactPaths(config?.redactKeys)
+          }
+        }
+      : {})
   }
 
   let pinoLogger: Pino

--- a/packages/logixlysia/src/utils/redact.ts
+++ b/packages/logixlysia/src/utils/redact.ts
@@ -62,6 +62,19 @@ export const isSensitiveKey = (
   )
 }
 
+/** pino redact paths for one key: top-level and one nesting level. */
+export const buildPinoRedactPaths = (
+  extraKeys?: readonly string[]
+): string[] => {
+  const keys = [...DEFAULT_REDACT_KEYS, ...(extraKeys ?? [])]
+  return keys.flatMap(key => {
+    // pino paths don't allow `-` in bare identifiers; bracket-quote them.
+    const path = key.includes('-') ? `["${key}"]` : key
+    const nested = key.includes('-') ? `*["${key}"]` : `*.${key}`
+    return [path, nested]
+  })
+}
+
 /**
  * Host and userinfo cannot contain `[REDACTED]` — `[` begins an IPv6 literal in URLs and breaks parsing.
  */

--- a/packages/logixlysia/src/utils/redact.ts
+++ b/packages/logixlysia/src/utils/redact.ts
@@ -69,9 +69,10 @@ export const buildPinoRedactPaths = (
   const keys = [...DEFAULT_REDACT_KEYS, ...(extraKeys ?? [])]
   return keys.flatMap(key => {
     // pino paths don't allow `-` in bare identifiers; bracket-quote them.
-    const path = key.includes('-') ? `["${key}"]` : key
-    const nested = key.includes('-') ? `*["${key}"]` : `*.${key}`
-    return [path, nested]
+    if (key.includes('-')) {
+      return [`["${key}"]`, `*["${key}"]`]
+    }
+    return [key, `*.${key}`]
   })
 }
 

--- a/packages/logixlysia/src/utils/redact.ts
+++ b/packages/logixlysia/src/utils/redact.ts
@@ -12,6 +12,56 @@ const PAN_MAX_LEN = 19
 const REDACTED_TEXT = '[REDACTED]'
 const CIRCULAR_REF = '[Circular]'
 
+/** Case-insensitive key/header names whose VALUES are always redacted. */
+export const DEFAULT_REDACT_KEYS: readonly string[] = [
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'api-key',
+  'apikey',
+  'x-auth-token',
+  'password',
+  'passwd',
+  'secret',
+  'client-secret',
+  'token',
+  'access-token',
+  'refresh-token',
+  'id-token',
+  'session',
+  'session-id',
+  'private-key',
+  'credit-card',
+  'card-number',
+  'cvv',
+  'ssn'
+]
+
+const CAMEL_CASE_BOUNDARY_REGEX = /([a-z0-9])([A-Z])/g
+
+/** Normalize `X_Api-Key` / `apiKey` style variants to `x-api-key` form. */
+const normalizeKeyName = (key: string): string =>
+  key
+    .replace(CAMEL_CASE_BOUNDARY_REGEX, '$1-$2')
+    .replaceAll('_', '-')
+    .toLowerCase()
+
+export const isSensitiveKey = (
+  key: string,
+  extraKeys?: readonly string[]
+): boolean => {
+  const normalized = normalizeKeyName(key)
+  if (DEFAULT_REDACT_KEYS.includes(normalized)) {
+    return true
+  }
+  return (
+    extraKeys?.some(extraKey => normalizeKeyName(extraKey) === normalized) ??
+    false
+  )
+}
+
 /**
  * Host and userinfo cannot contain `[REDACTED]` — `[` begins an IPv6 literal in URLs and breaks parsing.
  */
@@ -94,7 +144,8 @@ export const redactString = (text: string): string => {
 
 const redactErrorClone = (
   originalError: Error,
-  inProgress: WeakSet<object>
+  inProgress: WeakSet<object>,
+  extraKeys?: readonly string[]
 ): Error & Record<string, unknown> => {
   const redactedMessage = redactString(originalError.message)
   const proto = Object.getPrototypeOf(originalError) as object
@@ -111,7 +162,9 @@ const redactErrorClone = (
 
   for (const key of Object.keys(errorRecord)) {
     if (key !== 'message' && key !== 'name' && key !== 'stack') {
-      newError[key] = redactInner(errorRecord[key], inProgress)
+      newError[key] = isSensitiveKey(key, extraKeys)
+        ? REDACTED_TEXT
+        : redactInner(errorRecord[key], inProgress, extraKeys)
     }
   }
 
@@ -120,22 +173,26 @@ const redactErrorClone = (
 
 const redactArrayItems = (
   value: unknown[],
-  inProgress: WeakSet<object>
+  inProgress: WeakSet<object>,
+  extraKeys?: readonly string[]
 ): unknown[] => {
   const redactedArray: unknown[] = Array.from({ length: value.length })
   for (let i = 0; i < value.length; i += 1) {
-    redactedArray[i] = redactInner(value[i], inProgress)
+    redactedArray[i] = redactInner(value[i], inProgress, extraKeys)
   }
   return redactedArray
 }
 
 const redactRecordEntries = (
   recordValue: Record<string, unknown>,
-  inProgress: WeakSet<object>
+  inProgress: WeakSet<object>,
+  extraKeys?: readonly string[]
 ): Record<string, unknown> => {
   const redactedRecord: Record<string, unknown> = {}
   for (const key of Object.keys(recordValue)) {
-    redactedRecord[key] = redactInner(recordValue[key], inProgress)
+    redactedRecord[key] = isSensitiveKey(key, extraKeys)
+      ? REDACTED_TEXT
+      : redactInner(recordValue[key], inProgress, extraKeys)
   }
   return redactedRecord
 }
@@ -153,7 +210,11 @@ const withReentrancyGuard = <T>(
   }
 }
 
-const redactInner = <T>(value: T, inProgress: WeakSet<object>): T => {
+const redactInner = <T>(
+  value: T,
+  inProgress: WeakSet<object>,
+  extraKeys?: readonly string[]
+): T => {
   if (value === null || value === undefined) {
     return value
   }
@@ -178,22 +239,23 @@ const redactInner = <T>(value: T, inProgress: WeakSet<object>): T => {
 
   if (value instanceof Error) {
     return withReentrancyGuard(obj, inProgress, () =>
-      redactErrorClone(value, inProgress)
+      redactErrorClone(value, inProgress, extraKeys)
     ) as unknown as T
   }
 
   if (Array.isArray(value)) {
     return withReentrancyGuard(obj, inProgress, () =>
-      redactArrayItems(value, inProgress)
+      redactArrayItems(value, inProgress, extraKeys)
     ) as unknown as T
   }
 
   return withReentrancyGuard(obj, inProgress, () =>
-    redactRecordEntries(value as Record<string, unknown>, inProgress)
+    redactRecordEntries(value as Record<string, unknown>, inProgress, extraKeys)
   ) as unknown as T
 }
 
-export const redact = <T>(value: T): T => redactInner(value, new WeakSet())
+export const redact = <T>(value: T, extraKeys?: readonly string[]): T =>
+  redactInner(value, new WeakSet(), extraKeys)
 
 /**
  * Clone request URL, method and headers for logging with the same string redaction as {@link redact}.
@@ -201,13 +263,18 @@ export const redact = <T>(value: T): T => redactInner(value, new WeakSet())
  * omits the body so it never re-uses the original (possibly already-consumed) request stream. The
  * original request is left untouched and remains usable.
  */
-export const redactRequest = (request: Request): Request => {
+export const redactRequest = (
+  request: Request,
+  extraKeys?: readonly string[]
+): Request => {
   const redactedUrl = redactRequestUrl(request.url)
   const nextHeaders = new Headers()
   let headersChanged = false
 
   for (const [name, value] of request.headers.entries()) {
-    const redacted = redactString(value)
+    const redacted = isSensitiveKey(name, extraKeys)
+      ? REDACTED_TEXT
+      : redactString(value)
     if (redacted !== value) {
       headersChanged = true
     }


### PR DESCRIPTION
## Description

`autoRedact` previously matched **value patterns only** (emails, IPs, Luhn-valid card numbers, JWTs) — a logged `{ password: 'hunter2' }` or a `Cookie: session=…` header passed through untouched. This PR adds name-based redaction on top:

- **Built-in case-insensitive denylist** (`DEFAULT_REDACT_KEYS`: authorization, cookie, set-cookie, x-api-key, password, secret, token, session, …) applied to object keys (deep, including cloned `Error` extra properties) and request header names. `-`/`_`/camelCase variants (`x-api-key`, `x_api_key`, `xApiKey`) all normalize to the same name; matching is **exact on the normalized name, never substring** — `tokenizer` and `sessions` are not redacted.
- **`config.redactKeys`** — user-extendable list threaded through both call sites (`createLogger.log` and `handleHttpError`).
- **pino `redact.paths` defaults** — when `autoRedact: true` and the user has not supplied their own `pino.redact`, the same list is compiled to pino paths (bare + one nesting level, hyphenated names bracket-quoted). A user-supplied `redact` always wins.
- Docs: `configuration.mdx` now describes both mechanisms and states plainly that value-pattern redaction is best-effort — prefer `redactKeys` for known sensitive fields.

**Behavior change:** an `authorization: Bearer <jwt>` header previously became `Bearer [REDACTED]` (only the JWT-shaped part matched); it is now wholly `[REDACTED]` by name. The pre-existing test asserting the partial form was updated accordingly — that gap is exactly what this PR closes.

## Related Issues

None — from the improvement-plan backlog (plan 006, security).

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

N/A — logging library change.

## Additional Notes

Verification gates (re-run independently at review):

- `bun test` (packages/logixlysia): **165 pass / 0 fail**, 411 expect() calls (+6 tests: key-based object/nested/extraKeys redaction, `isSensitiveKey` variant + no-substring negatives, `buildPinoRedactPaths` shape)
- `bun run typecheck`: exit 0 (5/5 packages)
- `bun x ultracite check`: clean, 109 files, no suppressions
- `bun run build --filter logixlysia`: exit 0
- Live pino check: constructed a logger from `buildPinoRedactPaths(['customField', 'x-custom-header'])` (50 paths) — no throw; `password` and nested `x-api-key` both censored in output

Changeset: `key-based-redaction.md`, **minor** bump (new public config surface `redactKeys`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic redaction now removes sensitive values from logs, errors, and request headers using built-in key detection.
  * Added configurable `redactKeys` support for custom sensitive fields and headers.
  * Added best-effort detection for emails, IP addresses, payment cards, and JWTs.
  * Automatic Pino log redaction now includes configured sensitive keys.

* **Documentation**
  * Updated configuration guidance and examples for automatic and custom redaction.

* **Tests**
  * Expanded coverage for sensitive keys, custom fields, headers, and false-positive prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->