### PR TITLE
fix(logger): never log request bodies from validation errors by default

### DIFF
--- a/.changeset/validation-error-body.md
+++ b/.changeset/validation-error-body.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Validation errors no longer log the submitted request body (`found`/`errors`) by default — messages are normalized to the failed paths only. Set `config.logErrorPayload: true` to restore payload logging. Raw Error objects are no longer passed into transport meta.

--- a/apps/docs/content/configuration.mdx
+++ b/apps/docs/content/configuration.mdx
@@ -102,6 +102,17 @@ autoRedact: true,
 redactKeys: ['x-internal-token', 'customerSsn']
 ```
 
+### `logErrorPayload`
+
+Log the offending payload (`found`/`errors`) from validation errors. Off by default — a failed schema validation embeds the entire request body (passwords, tokens, card fields) in the error message, so leaving this off keeps those values out of your logs and transports.
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+```ts
+logErrorPayload: true
+```
+
 ### `logQueryParams`
 
 Include query parameters in the logged URL path.

--- a/packages/logixlysia/__tests__/logger/handle-http-error.test.ts
+++ b/packages/logixlysia/__tests__/logger/handle-http-error.test.ts
@@ -138,4 +138,27 @@ describe('handleHttpError', () => {
     expect(metaError.fix).toBe('set the config value')
     expect(metaError.message).toBe('bad config')
   })
+
+  // Class names (and thus `.name`/`.constructor.name`) are mangled under
+  // bundler minification (e.g. `bun build --minify`, esbuild). Elysia's
+  // `code === 'VALIDATION'` is the minification-safe discriminant; simulate
+  // a mangled class to prove detection still works.
+  test('detects a validation error by code when class names are minified', () => {
+    class MangledClassName extends Error {}
+    const mangled = Object.assign(
+      new MangledClassName('{"found":{"password":"leak-me"}}'),
+      {
+        all: [{ path: '/password' }],
+        code: 'VALIDATION',
+        type: 'body'
+      }
+    )
+
+    const { error: metaError, message } = normalizeLoggedError(mangled, false)
+
+    expect(message).toBe('Validation failed (body): /password')
+    expect(metaError.name).toBe('ValidationError')
+    expect(JSON.stringify(metaError)).not.toContain('leak-me')
+    expect(message).not.toContain('leak-me')
+  })
 })

--- a/packages/logixlysia/__tests__/logger/handle-http-error.test.ts
+++ b/packages/logixlysia/__tests__/logger/handle-http-error.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { Elysia, t } from 'elysia'
+
+import logixlysia from '../../src'
+import { HttpError, type Options } from '../../src/interfaces'
+import { normalizeLoggedError } from '../../src/utils/error'
+
+interface CapturedEvent {
+  level: unknown
+  message: unknown
+  meta: Record<string, unknown>
+}
+
+const VALIDATION_FAILED_BODY_REGEX = /^Validation failed \(body\)/
+
+const createCaptureTransport = () => {
+  const events: CapturedEvent[] = []
+  const transport = mock(
+    (level: unknown, message: unknown, meta?: Record<string, unknown>) => {
+      events.push({ level, message, meta: meta ?? {} })
+    }
+  )
+  return { events, transport }
+}
+
+const SECRET_PASSWORD = 'hunter2-secret-value'
+
+const buildLoginApp = (options: Options) =>
+  new Elysia().use(logixlysia(options)).post('/login', () => 'ok', {
+    body: t.Object({
+      email: t.String(),
+      password: t.String({ minLength: 60 })
+    })
+  })
+
+describe('handleHttpError', () => {
+  test('does not leak the request body when a validation error occurs', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildLoginApp({
+      config: {
+        disableFileLogging: true,
+        disableInternalLogger: true,
+        transports: [{ log: transport }]
+      }
+    })
+
+    const res = await app.handle(
+      new Request('http://localhost/login', {
+        body: JSON.stringify({ email: 'a@b.co', password: SECRET_PASSWORD }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST'
+      })
+    )
+
+    expect(res.status).toBe(422)
+
+    const serialized = JSON.stringify(events)
+    expect(serialized).not.toContain(SECRET_PASSWORD)
+
+    const errorEvent = events.find(
+      event =>
+        typeof event.message === 'string' &&
+        event.message.startsWith('Validation failed')
+    )
+    expect(errorEvent).toBeDefined()
+    expect(errorEvent?.message).toMatch(VALIDATION_FAILED_BODY_REGEX)
+
+    const metaError = errorEvent?.meta.error as Record<string, unknown>
+    expect(metaError.name).toBe('ValidationError')
+    expect(metaError.failedPaths).toContain('/password')
+  })
+
+  test('logs the full payload when logErrorPayload is enabled', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildLoginApp({
+      config: {
+        disableFileLogging: true,
+        disableInternalLogger: true,
+        logErrorPayload: true,
+        transports: [{ log: transport }]
+      }
+    })
+
+    const res = await app.handle(
+      new Request('http://localhost/login', {
+        body: JSON.stringify({ email: 'a@b.co', password: SECRET_PASSWORD }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST'
+      })
+    )
+
+    expect(res.status).toBe(422)
+
+    const serialized = JSON.stringify(events)
+    expect(serialized).toContain(SECRET_PASSWORD)
+  })
+
+  test('normalizes a thrown HttpError into a serializable, minimal shape', async () => {
+    const { events, transport } = createCaptureTransport()
+    const options: Options = {
+      config: {
+        disableFileLogging: true,
+        disableInternalLogger: true,
+        transports: [{ log: transport }]
+      }
+    }
+
+    const app = new Elysia().use(logixlysia(options)).get('/down', () => {
+      throw new HttpError(503, 'downstream')
+    })
+
+    await app.handle(new Request('http://localhost/down'))
+
+    const errorEvent = events.find(event => event.meta.status === 503)
+    expect(errorEvent).toBeDefined()
+    expect(errorEvent?.meta.error).toEqual({
+      message: 'downstream',
+      name: 'HttpError',
+      status: 503
+    })
+    expect(() => JSON.stringify(errorEvent?.meta)).not.toThrow()
+  })
+
+  // Elysia route handlers may only throw Error instances (enforced by lint),
+  // but `onError` can still receive a plain object thrown elsewhere (e.g. by
+  // third-party code). Exercise that branch directly against
+  // `normalizeLoggedError` rather than through a full request.
+  test('preserves structured-error fields (why/fix) from a plain-object error', () => {
+    const thrown = {
+      fix: 'set the config value',
+      message: 'bad config',
+      why: 'config missing'
+    }
+
+    const { error: metaError } = normalizeLoggedError(thrown, false)
+
+    expect(metaError.why).toBe('config missing')
+    expect(metaError.fix).toBe('set the config value')
+    expect(metaError.message).toBe('bad config')
+  })
+})

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -151,6 +151,13 @@ export interface Options {
      */
     redactKeys?: string[]
 
+    /**
+     * Log the offending payload (`found`/`errors`) from validation errors.
+     * Off by default: request bodies routinely contain credentials.
+     * @default false
+     */
+    logErrorPayload?: boolean
+
     // Pino
     pino?: (PinoLoggerOptions & { prettyPrint?: PrettyPrintConfig }) | undefined
 

--- a/packages/logixlysia/src/logger/handle-http-error.ts
+++ b/packages/logixlysia/src/logger/handle-http-error.ts
@@ -5,7 +5,7 @@ import {
 import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
 import { logToTransports } from '../output'
 import { logToFile } from '../output/file'
-import { parseError } from '../utils/error'
+import { normalizeLoggedError } from '../utils/error'
 import { redact, redactRequest } from '../utils/redact'
 import { formatLogOutput } from './create-logger'
 
@@ -45,9 +45,9 @@ export const handleHttpError = (
   const disableInternalLogger = config?.disableInternalLogger === true
   const disableFileLogging = config?.disableFileLogging === true
 
-  const message = parseError(error)
+  const { error: safeError, message } = normalizeLoggedError(error, false)
 
-  const data: Record<string, unknown> = { error, message, status }
+  const data: Record<string, unknown> = { error: safeError, message, status }
   const dataWithContext = contextStore
     ? mergeLogDataContext(data, contextStore.getContext(request))
     : data

--- a/packages/logixlysia/src/logger/handle-http-error.ts
+++ b/packages/logixlysia/src/logger/handle-http-error.ts
@@ -45,7 +45,10 @@ export const handleHttpError = (
   const disableInternalLogger = config?.disableInternalLogger === true
   const disableFileLogging = config?.disableFileLogging === true
 
-  const { error: safeError, message } = normalizeLoggedError(error, false)
+  const { error: safeError, message } = normalizeLoggedError(
+    error,
+    config?.logErrorPayload === true
+  )
 
   const data: Record<string, unknown> = { error: safeError, message, status }
   const dataWithContext = contextStore

--- a/packages/logixlysia/src/utils/error.ts
+++ b/packages/logixlysia/src/utils/error.ts
@@ -33,7 +33,12 @@ const isValidationErrorLike = (
   value: unknown
 ): value is Error & { all?: unknown[]; status?: number; type?: string } =>
   value instanceof Error &&
-  (value.name === 'ValidationError' ||
+  // `code` is Elysia's minification-safe discriminant — `.name` and
+  // `.constructor.name` both degrade to a mangled string under bundler
+  // minification (e.g. `bun build --minify`, esbuild), so `code` must be
+  // checked too or validation bodies silently re-leak in that build mode.
+  ((value as { code?: unknown }).code === 'VALIDATION' ||
+    value.name === 'ValidationError' ||
     value.constructor?.name === 'ValidationError')
 
 const STRUCTURED_ERROR_KEYS = [

--- a/packages/logixlysia/src/utils/error.ts
+++ b/packages/logixlysia/src/utils/error.ts
@@ -21,3 +21,95 @@ export const isStructuredError = (
   typeof value === 'object' &&
   value !== null &&
   ('why' in value || 'fix' in value || 'link' in value || 'internal' in value)
+
+export interface NormalizedLoggedError {
+  /** Safe structured representation for data/transport meta. */
+  error: Record<string, unknown>
+  /** Safe one-line message for the log line. */
+  message: string
+}
+
+const isValidationErrorLike = (
+  value: unknown
+): value is Error & { all?: unknown[]; status?: number; type?: string } =>
+  value instanceof Error &&
+  (value.name === 'ValidationError' ||
+    value.constructor?.name === 'ValidationError')
+
+const STRUCTURED_ERROR_KEYS = [
+  'fix',
+  'internal',
+  'link',
+  'message',
+  'name',
+  'status',
+  'why'
+] as const
+
+const copyStructuredErrorFields = (
+  record: Record<string, unknown>
+): Record<string, unknown> => {
+  const safe: Record<string, unknown> = {}
+  for (const key of STRUCTURED_ERROR_KEYS) {
+    if (record[key] !== undefined) {
+      safe[key] = record[key]
+    }
+  }
+  return safe
+}
+
+export const normalizeLoggedError = (
+  error: unknown,
+  logErrorPayload: boolean
+): NormalizedLoggedError => {
+  if (isValidationErrorLike(error) && !logErrorPayload) {
+    const failures = Array.isArray(error.all) ? error.all : []
+    const paths = failures
+      .map(failure =>
+        typeof failure === 'object' && failure !== null && 'path' in failure
+          ? String((failure as { path: unknown }).path)
+          : ''
+      )
+      .filter(Boolean)
+    const scope = typeof error.type === 'string' ? error.type : 'request'
+    const message =
+      paths.length > 0
+        ? `Validation failed (${scope}): ${paths.join(', ')}`
+        : `Validation failed (${scope})`
+    return {
+      error: { failedPaths: paths, name: 'ValidationError', type: scope },
+      message
+    }
+  }
+
+  if (error instanceof Error) {
+    const record = error as unknown as Record<string, unknown>
+    // Native subclasses (e.g. `class HttpError extends Error`) don't set
+    // `.name` unless the author overrides it, so it reads back as the
+    // generic "Error". Prefer the constructor name in that case.
+    const name =
+      error.name === 'Error'
+        ? (error.constructor?.name ?? error.name)
+        : error.name
+    const safe: Record<string, unknown> = {
+      message: error.message,
+      name
+    }
+    // Preserve structured-error fields the formatter renders.
+    for (const key of ['why', 'fix', 'link', 'internal', 'status'] as const) {
+      if (record[key] !== undefined) {
+        safe[key] = record[key]
+      }
+    }
+    return { error: safe, message: parseError(error) }
+  }
+
+  if (isStructuredError(error)) {
+    return {
+      error: copyStructuredErrorFields(error as Record<string, unknown>),
+      message: parseError(error)
+    }
+  }
+
+  return { error: { value: String(error) }, message: parseError(error) }
+}

--- a/packages/logixlysia/src/utils/error.ts
+++ b/packages/logixlysia/src/utils/error.ts
@@ -88,24 +88,17 @@ export const normalizeLoggedError = (
   }
 
   if (error instanceof Error) {
-    const record = error as unknown as Record<string, unknown>
+    const safe = copyStructuredErrorFields(
+      error as unknown as Record<string, unknown>
+    )
+    safe.message = error.message
     // Native subclasses (e.g. `class HttpError extends Error`) don't set
     // `.name` unless the author overrides it, so it reads back as the
     // generic "Error". Prefer the constructor name in that case.
-    const name =
+    safe.name =
       error.name === 'Error'
         ? (error.constructor?.name ?? error.name)
         : error.name
-    const safe: Record<string, unknown> = {
-      message: error.message,
-      name
-    }
-    // Preserve structured-error fields the formatter renders.
-    for (const key of ['why', 'fix', 'link', 'internal', 'status'] as const) {
-      if (record[key] !== undefined) {
-        safe[key] = record[key]
-      }
-    }
     return { error: safe, message: parseError(error) }
   }
 


### PR DESCRIPTION
## Description

When an Elysia schema validation fails, `ValidationError.message` is a JSON document embedding the **entire request payload** under `found:` — and the error path logged that message verbatim plus the raw `error` object into every transport's meta. Any failed login/signup/payment request copied its body (passwords, tokens, card fields) into log files and third-party transports.

This PR normalizes logged errors to a safe shape:

- **`normalizeLoggedError` (`utils/error.ts`)** — ValidationErrors log `Validation failed (body): /password` + `{ name, type, failedPaths }` instead of the payload. Other `Error`s keep their message but transports now receive a plain serializable record (`name`/`message` + preserved `why`/`fix`/`link`/`internal`/`status`), never a live Error instance. Thrown plain objects with StructuredError fields keep them.
- **Minification-safe detection** — at runtime Elysia's `ValidationError` has `.name === 'Error'` (subclass doesn't override it), and `constructor.name` mangles under `bun build --minify`/esbuild. Detection checks Elysia's data property `code === 'VALIDATION'` first, then both name signals, so body-stripping survives minified production builds. Covered by a dedicated mangled-class test.
- **`config.logErrorPayload`** (default `false`) — explicit opt-in restoring full validation messages; the raw object still never reaches transport meta (serializability).
- Subclass names (e.g. `HttpError`) are recovered via `constructor.name` when `.name` reads back as generic `Error`, so meta reports `name: 'HttpError'`.

~~Stacked on #365~~ — #365 was squash-merged, so this branch was rebased onto `main` (the four plan-007 commits replayed cleanly; all gates re-run green after rebase).

## Related Issues

None — from the improvement-plan backlog (plan 007, security). Built on #365 (merged).

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

N/A — logging library change.

## Additional Notes

Verification gates (re-run independently at review, worktree + repo root):

- `bun test` (packages/logixlysia): **170 pass / 0 fail**, 429 expect() calls (+5 tests: validation-leak negative, `logErrorPayload` opt-in positive, HttpError minimal shape + JSON-serializable meta, plain-object StructuredError preservation, minified-class detection)
- `bun run typecheck`: exit 0 (5/5 packages)
- `bun x ultracite check`: clean, 110 files, no suppressions
- `bun run build --filter logixlysia`: exit 0
- Empirically verified against `elysia@1.4.29`: `ValidationError` instance has `code: 'VALIDATION'`, `status: 422`, `type`, `all[]`, and `.name === 'Error'`

1 REVISE round during review: initial detection relied on `.name`/`constructor.name` only; the `code === 'VALIDATION'` discriminant + mangled-class regression test were added to keep the protection intact under minification.

Changeset: `validation-error-body.md`, **minor** bump (new public config surface `logErrorPayload`; default behavior change is the security fix itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
