### PR TITLE
fix(security): log-injection hardening and restrictive log-file modes

### DIFF
--- a/.changeset/log-output-hardening.md
+++ b/.changeset/log-output-hardening.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Harden log output: file-sink lines, client IPs, and context-tree values are sanitized (control characters escaped/stripped, lengths bounded); malformed inbound request IDs are replaced with generated ones; log files/dirs are created with `0600`/`0700` modes, configurable via `logFileMode`/`logDirMode` (existing files keep their mode).

--- a/packages/logixlysia/__tests__/middleware/request-id.test.ts
+++ b/packages/logixlysia/__tests__/middleware/request-id.test.ts
@@ -124,4 +124,28 @@ describe('getOrCreateRequestId', () => {
     expect(getOrCreateRequestId(req1, config)).toBe('req-1')
     expect(getOrCreateRequestId(req2, config)).toBe('req-2')
   })
+
+  test('preserves a valid inbound id with dots, dashes, and mixed case', () => {
+    const request = new Request('http://localhost/test', {
+      headers: { 'X-Request-Id': 'abc-123.DEF' }
+    })
+    const id = getOrCreateRequestId(request, defaultConfig)
+    expect(id).toBe('abc-123.DEF')
+  })
+
+  test('replaces an inbound id containing disallowed characters', () => {
+    const request = new Request('http://localhost/test', {
+      headers: { 'X-Request-Id': 'bad id $value' }
+    })
+    const id = getOrCreateRequestId(request, defaultConfig)
+    expect(id).toBe('generated-uuid')
+  })
+
+  test('replaces an inbound id that exceeds the max length', () => {
+    const request = new Request('http://localhost/test', {
+      headers: { 'X-Request-Id': 'a'.repeat(200) }
+    })
+    const id = getOrCreateRequestId(request, defaultConfig)
+    expect(id).toBe('generated-uuid')
+  })
 })

--- a/packages/logixlysia/__tests__/output/file.test.ts
+++ b/packages/logixlysia/__tests__/output/file.test.ts
@@ -6,6 +6,9 @@ import { logToFile } from '../../src/output/file'
 import { createMockRequest } from '../_helpers/request'
 import { createTempDir, removeTempDir } from '../_helpers/tmp'
 
+/** Owner/group/other permission bits as a 3-digit octal string, e.g. '600'. */
+const permBits = (mode: number): string => mode.toString(8).slice(-3)
+
 describe('logToFile', () => {
   test('writes to file and creates directories', async () => {
     const dir = await createTempDir()
@@ -123,8 +126,8 @@ describe('logToFile', () => {
 
       const fileStat = await fs.stat(filePath)
       const dirStat = await fs.stat(dirname(filePath))
-      expect(fileStat.mode & 0o777).toBe(0o600)
-      expect(dirStat.mode & 0o777).toBe(0o700)
+      expect(permBits(fileStat.mode)).toBe('600')
+      expect(permBits(dirStat.mode)).toBe('700')
     } finally {
       await removeTempDir(dir)
     }
@@ -146,7 +149,7 @@ describe('logToFile', () => {
       })
 
       const fileStat = await fs.stat(filePath)
-      expect(fileStat.mode & 0o777).toBe(0o644)
+      expect(permBits(fileStat.mode)).toBe('644')
     } finally {
       await removeTempDir(dir)
     }

--- a/packages/logixlysia/__tests__/output/file.test.ts
+++ b/packages/logixlysia/__tests__/output/file.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { promises as fs } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import type { Options } from '../../src/interfaces'
 import { logToFile } from '../../src/output/file'
 import { createMockRequest } from '../_helpers/request'
@@ -77,6 +77,76 @@ describe('logToFile', () => {
 
       const content = await fs.readFile(filePath, 'utf-8')
       expect(content).toContain('/api/test?user=123')
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('sanitizes newlines in message to prevent log-line injection', async () => {
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'logs', 'inject.log')
+      const options: Options = { config: {} }
+
+      await logToFile({
+        data: { message: 'line1\nFAKE INFO line2' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/test'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      const content = await fs.readFile(filePath, 'utf-8')
+      const lines = content.split('\n').filter(line => line.length > 0)
+      expect(lines.length).toBe(1)
+      expect(content).toContain('line1\\nFAKE INFO line2')
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('creates log files with 0600 mode and directories with 0700 mode by default', async () => {
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'logs', 'perms.log')
+      const options: Options = { config: {} }
+
+      await logToFile({
+        data: { message: 'hello' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/test'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      const fileStat = await fs.stat(filePath)
+      const dirStat = await fs.stat(dirname(filePath))
+      expect(fileStat.mode & 0o777).toBe(0o600)
+      expect(dirStat.mode & 0o777).toBe(0o700)
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('honors a configured logFileMode', async () => {
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'logs', 'custom-mode.log')
+      const options: Options = { config: { logFileMode: 0o644 } }
+
+      await logToFile({
+        data: { message: 'hello' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/test'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      const fileStat = await fs.stat(filePath)
+      expect(fileStat.mode & 0o777).toBe(0o644)
     } finally {
       await removeTempDir(dir)
     }

--- a/packages/logixlysia/__tests__/utils/sanitize.test.ts
+++ b/packages/logixlysia/__tests__/utils/sanitize.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+import { sanitizeLogText } from '../../src/utils/sanitize'
+
+describe('sanitizeLogText', () => {
+  test('leaves clean text unchanged', () => {
+    expect(sanitizeLogText('hello world')).toBe('hello world')
+  })
+
+  test('escapes newlines as literal \\n', () => {
+    expect(sanitizeLogText('line1\nline2')).toBe('line1\\nline2')
+  })
+
+  test('escapes carriage returns as literal \\r', () => {
+    expect(sanitizeLogText('line1\rline2')).toBe('line1\\rline2')
+  })
+
+  test('escapes tabs as literal \\t', () => {
+    expect(sanitizeLogText('a\tb')).toBe('a\\tb')
+  })
+
+  test('strips ANSI escape sequences', () => {
+    const esc = String.fromCharCode(27)
+    expect(sanitizeLogText(`${esc}[31mred`)).toBe('[31mred')
+  })
+
+  test('strips NUL bytes', () => {
+    const nul = String.fromCharCode(0)
+    expect(sanitizeLogText(`a${nul}b`)).toBe('ab')
+  })
+
+  test('truncates long strings to maxLength plus ellipsis', () => {
+    const longText = 'x'.repeat(10_000)
+    const result = sanitizeLogText(longText)
+    expect(result.length).toBe(2049)
+    expect(result.startsWith('x'.repeat(2048))).toBe(true)
+    expect(result.endsWith('…')).toBe(true)
+  })
+
+  test('respects a custom maxLength', () => {
+    const result = sanitizeLogText('abcdefghij', 5)
+    expect(result).toBe('abcde…')
+  })
+})

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -135,6 +135,10 @@ export interface Options {
     disableInternalLogger?: boolean
     disableFileLogging?: boolean
     logFilePath?: string
+    /** File mode for created log files. @default 0o600 */
+    logFileMode?: number
+    /** Directory mode for created log directories. @default 0o700 */
+    logDirMode?: number
     logRotation?: LogRotationConfig
 
     /**

--- a/packages/logixlysia/src/logger/create-logger.ts
+++ b/packages/logixlysia/src/logger/create-logger.ts
@@ -9,6 +9,7 @@ import type {
   StoreData
 } from '../interfaces'
 import { isStructuredError, parseError } from '../utils/error'
+import { sanitizeLogText } from '../utils/sanitize'
 
 const pad2 = (value: number): string => String(value).padStart(2, '0')
 const pad3 = (value: number): string => String(value).padStart(3, '0')
@@ -64,9 +65,9 @@ const formatTimestamp = (date: Date, pattern?: string): string => {
 const getIp = (request: RequestInfo): string => {
   const forwarded = request.headers.get('x-forwarded-for')
   if (forwarded) {
-    return forwarded.split(',')[0]?.trim() ?? ''
+    return sanitizeLogText(forwarded.split(',')[0]?.trim() ?? '', 64)
   }
-  return request.headers.get('x-real-ip') ?? ''
+  return sanitizeLogText(request.headers.get('x-real-ip') ?? '', 64)
 }
 
 export const formatDuration = (ms: number): string => {
@@ -268,18 +269,18 @@ const stringifyTreeValue = (value: unknown): string => {
     return 'undefined'
   }
   if (typeof value === 'string') {
-    return value
+    return sanitizeLogText(value)
   }
   if (typeof value === 'number' || typeof value === 'boolean') {
     return String(value)
   }
   if (value instanceof Error) {
-    return value.message
+    return sanitizeLogText(value.message)
   }
   try {
-    return JSON.stringify(value)
+    return sanitizeLogText(JSON.stringify(value))
   } catch {
-    return String(value)
+    return sanitizeLogText(String(value))
   }
 }
 

--- a/packages/logixlysia/src/logger/create-logger.ts
+++ b/packages/logixlysia/src/logger/create-logger.ts
@@ -64,10 +64,10 @@ const formatTimestamp = (date: Date, pattern?: string): string => {
 /** Resolves client IP from x-forwarded-for (first IP) or x-real-ip. Empty when neither header is set (e.g. localhost). */
 const getIp = (request: RequestInfo): string => {
   const forwarded = request.headers.get('x-forwarded-for')
-  if (forwarded) {
-    return sanitizeLogText(forwarded.split(',')[0]?.trim() ?? '', 64)
-  }
-  return sanitizeLogText(request.headers.get('x-real-ip') ?? '', 64)
+  const candidate = forwarded
+    ? (forwarded.split(',')[0]?.trim() ?? '')
+    : (request.headers.get('x-real-ip') ?? '')
+  return sanitizeLogText(candidate, 64)
 }
 
 export const formatDuration = (ms: number): string => {

--- a/packages/logixlysia/src/middleware/request-id.ts
+++ b/packages/logixlysia/src/middleware/request-id.ts
@@ -1,6 +1,7 @@
 import type { RequestIdConfig } from '../interfaces'
 
 const DEFAULT_HEADER = 'X-Request-Id'
+const VALID_REQUEST_ID = /^[A-Za-z0-9._-]{1,128}$/
 
 export interface ResolvedRequestIdConfig {
   enabled: boolean
@@ -45,13 +46,18 @@ export const resolveRequestIdConfig = (
 /**
  * Reads an existing request ID from the incoming request header, or generates a
  * new one using the configured generator.
+ *
+ * Inbound values are validated against `VALID_REQUEST_ID` (alphanumeric plus
+ * `.`, `_`, `-`, 1-128 chars) before being trusted — request IDs flow into log
+ * lines, response headers, and context trees, so malformed or oversized
+ * values are replaced with a freshly generated one rather than echoed back.
  */
 export const getOrCreateRequestId = (
   request: Request,
   config: ResolvedRequestIdConfig
 ): string => {
   const existing = request.headers.get(config.header)
-  if (existing) {
+  if (existing && VALID_REQUEST_ID.test(existing)) {
     return existing
   }
   return config.generator()

--- a/packages/logixlysia/src/output/file.ts
+++ b/packages/logixlysia/src/output/file.ts
@@ -1,6 +1,7 @@
 import { appendFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
+import { sanitizeLogText } from '../utils/sanitize'
 import { ensureDir } from './fs'
 import { performRotation, shouldRotate } from './rotation-manager'
 
@@ -102,15 +103,18 @@ export const logToFile = async (
     pathname = request.url
   }
 
-  const line = `${level} ${durationMs.toFixed(2)}ms ${request.method} ${pathname} ${message}\n`
+  const line = `${level} ${durationMs.toFixed(2)}ms ${request.method} ${sanitizeLogText(pathname, 1024)} ${sanitizeLogText(message)}\n`
 
   // Acquire lock before any file operations to prevent race conditions
   const releaseLock = await acquireLock(filePath)
 
   try {
     try {
-      await ensureDir(dirname(filePath))
-      await appendFile(filePath, line, { encoding: 'utf-8' })
+      await ensureDir(dirname(filePath), config?.logDirMode)
+      await appendFile(filePath, line, {
+        encoding: 'utf-8',
+        mode: config?.logFileMode ?? 0o600
+      })
     } catch (error) {
       // Log file write errors to stderr so they're not completely silent
       console.error(

--- a/packages/logixlysia/src/output/fs.ts
+++ b/packages/logixlysia/src/output/fs.ts
@@ -1,5 +1,8 @@
 import { promises as fs } from 'node:fs'
 
-export const ensureDir = async (dirPath: string): Promise<void> => {
-  await fs.mkdir(dirPath, { recursive: true })
+export const ensureDir = async (
+  dirPath: string,
+  mode = 0o700
+): Promise<void> => {
+  await fs.mkdir(dirPath, { mode, recursive: true })
 }

--- a/packages/logixlysia/src/utils/sanitize.ts
+++ b/packages/logixlysia/src/utils/sanitize.ts
@@ -1,0 +1,29 @@
+/**
+ * True for C0 controls (0x00-0x08, 0x0B-0x1F), DEL (0x7F), and C1 controls
+ * (0x80-0x9F). Tab, LF, and CR are handled separately by the caller before
+ * this check runs, so they are intentionally included here as a safety net
+ * in case a caller skips that step.
+ */
+const isControlCodePoint = (code: number): boolean =>
+  code <= 8 || (code >= 11 && code <= 31) || (code >= 127 && code <= 159)
+
+/** Strips C0/C1 control chars (keeps none -- \n and \r become visible escapes) and bounds length. */
+export const sanitizeLogText = (value: string, maxLength = 2048): string => {
+  const escaped = value
+    .replaceAll('\r', String.raw`\r`)
+    .replaceAll('\n', String.raw`\n`)
+    .replaceAll('\t', String.raw`\t`)
+
+  let out = ''
+  for (const char of escaped) {
+    const code = char.codePointAt(0) ?? 0
+    if (!isControlCodePoint(code)) {
+      out += char
+    }
+  }
+
+  if (out.length > maxLength) {
+    out = `${out.slice(0, maxLength)}…`
+  }
+  return out
+}


### PR DESCRIPTION
## Description

Four related hardening fixes for request-controlled bytes reaching logs (improvement-plan 008, security):

- **`sanitizeLogText` (`utils/sanitize.ts`)** — escapes `\r`/`\n`/`\t` to visible literals, strips remaining C0/C1 control characters (0x00–0x08, 0x0B–0x1F, 0x7F–0x9F — kills ANSI escapes), and bounds length (default 2048 + `…`). Clean input is identity.
- **File-sink injection closed** — the newline-delimited file sink now sanitizes the URL path (1024 cap) and message before interpolation, so a path or message containing `\n` can no longer forge fake log lines; the URL-parse-failure fallback (raw `request.url`) is covered too.
- **Header-controlled fields bounded** — `getIp` output (`x-forwarded-for`/`x-real-ip`) is sanitized and capped at 64 chars; context-tree values (`stringifyTreeValue` string/Error/JSON branches) are sanitized before printing.
- **Inbound request IDs validated** — `X-Request-Id` must match `^[A-Za-z0-9._-]{1,128}$` or a fresh ID is generated instead of echoing arbitrary bytes into logs and response headers.
- **Restrictive modes** — log dirs are created `0o700`, log files `0o600` (previously default umask, typically world-readable), configurable via new `logFileMode`/`logDirMode`; mode applies at creation only, existing files keep theirs.

Deviation from the plan reviewed and accepted: control-char detection is a numeric code-point range check instead of a regex character class (behaviorally identical; keeps the source file free of `\u` escape-mangling risk), and the mode tests compare octal strings instead of using bitwise `& 0o777` (Biome `noBitwiseOperators`; same assertions).

## Related Issues

None — from the improvement-plan backlog (plan 008, security).

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary (config keys carry JSDoc; docs page pass is owned by a later plan)

## Screenshots (if applicable)

N/A — logging library change.

## Additional Notes

Verification gates (re-run independently at review):

- `bun test` (packages/logixlysia): **184 pass / 0 fail**, 447 expect() calls (+14 tests: 8 sanitize unit tests, injection one-physical-line test, 0600/0700 default + 0644 override mode tests, 3 request-id validation tests)
- `bun run typecheck`: exit 0 (5/5 packages)
- `bun x ultracite check`: clean, 112 files, no suppressions
- `bun run build --filter logixlysia`: exit 0
- `src/utils/sanitize.ts` verified plain UTF-8 text (no literal control bytes in source)
- Host umask 022: default 0o700/0o600 land unmasked (no overlapping bits), mode tests assert exact values

Changeset: `log-output-hardening.md`, **minor** bump (new public config surface `logFileMode`/`logDirMode` + default-permission behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable file and directory permission settings for enhanced control over log file security.

* **Bug Fixes**
  * Improved log output sanitization to prevent injection attacks and harmful characters.
  * Stricter request ID validation now rejects malformed identifiers.

* **Tests**
  * Added comprehensive coverage for log sanitization, request ID validation, and file permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->