### PR TITLE
ci: SHA-pin actions, drop npm swap, fix security policy

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛫 Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: ✒️ Dependency Review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🔖 Add Labels
-        uses: actions/labeler@v7
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
       - name: 😵 Check Conflicts
-        uses: mschilde/auto-label-merge-conflicts@master
+        uses: mschilde/auto-label-merge-conflicts@3fdaf1c8b3f8e5b0f88753d9cb3c9c779370b3ef # master
         with:
           CONFLICT_LABEL_NAME: "conflict"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛫 Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 🕺🏻 Prepare Repository
         run: git fetch --unshallow --tags
       - name: 🟢 Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -32,10 +32,10 @@ jobs:
       - name: 🔄️ Update npm
         run: npm install -g npm@latest
       - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - name: 🌵 Cache Bun
         id: bun-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.bun/install/cache
@@ -49,7 +49,7 @@ jobs:
         run: bun run build --filter logixlysia
       - name: 🎟️ Create Release PR or Publish to NPM
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: bun run changeset version
           publish: bun run changeset publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,6 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache-dependency-path: "package.json"
-      - name: 🔄️ Update npm
-        run: npm install -g npm@latest
       - name: 🍞 Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - name: 🌵 Cache Bun

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,14 +16,14 @@ jobs:
     timeout-minutes: 360
     steps:
       - name: 🛫 Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 🔬 Setting up CodeQL
-        uses: github/codeql-action/init@v4.37.4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: javascript-typescript
       - name: 🩻 Auto Build
-        uses: github/codeql-action/autobuild@v4.37.4
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       - name: 🧪 Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: '/languages/javascript-typescript'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,14 +43,14 @@ jobs:
             command: bun run test
     steps:
       - name: 🛫 Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
       - name: 🌵 Cache Bun
         id: bun-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.bun/install/cache
@@ -72,13 +72,13 @@ jobs:
       - code-quality
     steps:
       - name: 🛫 Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
       - name: 🌵 Cache Bun
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.bun/install/cache

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,18 @@
 
 ## Supported Versions
 
-Currently, only the latest on `main` branch is supported with security updates.
+| Version | Supported |
+| ------- | --------- |
+| Latest release (`logixlysia@latest` on npm) | ✅ |
+| Older releases | ❌ — please upgrade |
 
 ## Reporting a Vulnerability
 
-To report a vulnerability, open a new issue on the repository.
+Please do NOT open a public issue for security problems.
+
+Report privately via GitHub's advisory flow:
+https://github.com/PunGrumpy/logixlysia/security/advisories/new
+
+Include reproduction steps and the affected version. You can expect an
+acknowledgement within 7 days. Once a fix ships, we will credit reporters in
+the release notes unless they prefer otherwise.


### PR DESCRIPTION
## 📝 Description

Supply-chain hardening for CI and the security-reporting policy (plan 009):

- **Pin every external GitHub Action to a full commit SHA** (with a `# vX.Y.Z` comment Dependabot keeps updated) across all five workflows. Previously all actions were pinned to mutable tags, and `mschilde/auto-label-merge-conflicts` was pinned to the moving `master` branch — a compromised tag/branch would run arbitrary code in the release job, which holds `id-token: write` and npm publish rights.
- **Drop the `npm install -g npm@latest` step** from the release workflow. Publishing goes through `bun run changeset publish`; node 24 already bundles npm 11.x and `devEngines` now tolerates npm (7dd3bd3), so an unpinned global-tooling swap right before publish serves no purpose.
- **Rewrite `SECURITY.md`** to direct vulnerability reports to GitHub's private advisory flow instead of asking reporters to open a public issue, and add a supported-versions table.

Resolved SHAs (each independently re-verified by the reviewer against the upstream repo via `git ls-remote`):

| Action | Pinned | Tag |
| --- | --- | --- |
| `actions/checkout` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1 |
| `actions/setup-node` | `820762786026740c76f36085b0efc47a31fe5020` | v7.0.0 |
| `oven-sh/setup-bun` | `0c5077e51419868618aeaa5fe8019c62421857d6` | v2.2.0 |
| `actions/cache` | `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` | v6.1.0 |
| `changesets/action` | `a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d` | v1.9.0 |
| `github/codeql-action/*` | `f205ea1c3313d32999d8d6a48b4f6530d4437b38` | v4.37.4 |
| `actions/dependency-review-action` | `a1d282b36b6f3519aa1f3fc636f609c47dddb294` | v5.0.0 |
| `actions/labeler` | `bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13` | v7.0.0 |
| `mschilde/auto-label-merge-conflicts` | `3fdaf1c8b3f8e5b0f88753d9cb3c9c779370b3ef` | master (HEAD) |

## 🔗 Related Issues

None — from the improve-skill audit (plan `plans/009-supply-chain-hardening.md`).

## ✅ Checklist

- [x] I have followed the contributing guidelines
- [x] I have verified my changes (all workflows YAML-lint clean; grep gates below)
- [ ] I have updated the documentation (not needed — no user-facing docs change)
- [x] My changes generate no new warnings
- [x] Tests unaffected (no package code touched — no changeset needed)

## 📸 Screenshots

N/A — CI/policy change only.

## 📌 Additional Notes

**Action required (maintainer):** please enable **Private vulnerability reporting** in *Settings → Code security* so the advisory link in `SECURITY.md` works — the reviewer's `gh api` attempt was blocked by tool permissions.

Notes:
- `github/codeql-action` is pinned at `v4.37.4` — the version the workflow already used. `v4.37.5`/`v4.37.6` exist; Dependabot's monthly `github-actions` run will bump the pin (it understands the `# vX.Y.Z` comment format).
- `mschilde/auto-label-merge-conflicts` has no version tags, so it's pinned to the current `HEAD` of `master`. The action looks unmaintained — worth replacing eventually (deferred; noted in the plan's maintenance section).
- Dependabot already tracks the `github-actions` ecosystem (`.github/dependabot.yml`), so pins will not rot.

Verification gates (run in the executor worktree and independently re-run by the reviewer):
- `grep -rn "uses:" .github/workflows/ | grep -v "\./\.github" | grep -vE "@[0-9a-f]{40}"` → no output (every external action SHA-pinned)
- `grep -rn "@master\|@main" .github/workflows/` → no output
- `grep -n "npm install -g" .github/workflows/release.yml` → no output
- `SECURITY.md` contains the advisories URL; "open a new issue" removed
- `bunx yaml-lint .github/workflows/*.yml` → ✔ YAML Lint successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved workflow security by pinning automation actions to immutable versions.
  * Removed the global npm update step from the release process.
  * Updated the security policy with supported-version guidance and private vulnerability reporting instructions.
  * Added response-time expectations and optional reporter credit in release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->