### PR TITLE
feat(bench): measure real logging work on the request path

### DIFF
--- a/apps/docs/content/comparison.mdx
+++ b/apps/docs/content/comparison.mdx
@@ -37,4 +37,4 @@ Run the monorepo benchmark package:
 bun run bench
 ```
 
-The `Elysia plugin request path` suite compares full `handle()` overhead for Logixlysia, evlog, and elysia-logger. Results vary by machine—use them for regression tracking, not absolute rankings.
+The benchmark package has three request-path suites: an **overhead floor** (all sinks disabled — measures plugin dispatch cost only), a **structured sink** run (no-op transport/drain — measures log assembly and dispatch), and a **file sink** run. Compare like with like: the floor numbers contain no logging work by design. Results vary by machine — use them for regression tracking, not absolute rankings.

--- a/packages/bench/index.bench.ts
+++ b/packages/bench/index.bench.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   logger as bogeychanLogger,
   createPinoLogger as createBogeychan
@@ -181,7 +184,7 @@ const bogeychanApp = new Elysia()
   )
   .get('/', () => 'ok')
 
-describe('Elysia plugin request path', () => {
+describe('Elysia plugin request path — overhead floor (all sinks disabled)', () => {
   bench('logixlysia', async () => {
     await logixlysiaApp.handle(new Request('http://localhost/'))
   })
@@ -192,5 +195,61 @@ describe('Elysia plugin request path', () => {
 
   bench('bogeychan', async () => {
     await bogeychanApp.handle(new Request('http://localhost/'))
+  })
+})
+
+// A no-op transport still exercises data assembly, context merge, meta
+// construction, and dispatch — unlike the floor suite above, this is real
+// work, just with a sink that discards the result instead of writing it
+// anywhere. evlog's noop `drain` (reused from `evlogApp` above) is its
+// equivalent structured sink, so this comparison is apples-to-apples.
+// bogeychan has no comparable noop-sink mode (its `enabled: false` fully
+// short-circuits, same as the floor suite), so it's left out here.
+const noopTransport = {
+  log: () => {
+    /* consume */
+  }
+}
+
+const logixlysiaTransportApp = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        transports: [noopTransport],
+        useTransportsOnly: true
+      }
+    })
+  )
+  .get('/', () => 'ok')
+
+describe('Elysia plugin request path — structured sink (noop consumer)', () => {
+  bench('logixlysia (transport)', async () => {
+    await logixlysiaTransportApp.handle(new Request('http://localhost/'))
+  })
+
+  bench('evlog (drain)', async () => {
+    await evlogApp.handle(new Request('http://localhost/'))
+  })
+})
+
+const benchLogDir = mkdtempSync(join(tmpdir(), 'logixlysia-bench-'))
+
+const logixlysiaFileApp = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        disableInternalLogger: true,
+        logFilePath: join(benchLogDir, 'bench.log')
+      }
+    })
+  )
+  .get('/', () => 'ok')
+
+// `logToFile` is fire-and-forget from `log()` (`.catch(() => {})`), so this
+// suite measures enqueue cost per request plus amortized write cost — not a
+// guarantee that each write has completed by the time `handle()` resolves.
+describe('Elysia plugin request path — file sink', () => {
+  bench('logixlysia (logFilePath)', async () => {
+    await logixlysiaFileApp.handle(new Request('http://localhost/'))
   })
 })

--- a/packages/bench/index.bench.ts
+++ b/packages/bench/index.bench.ts
@@ -7,12 +7,24 @@ import {
 } from '@bogeychan/elysia-logger'
 import { consola } from 'consola'
 import { Elysia } from 'elysia'
-import { createLogger as createEvlog } from 'evlog'
+import { createLogger as createEvlog, initLogger } from 'evlog'
 import { evlog } from 'evlog/elysia'
 import logixlysia, { createLogger } from 'logixlysia'
 import pino from 'pino'
 import { bench, describe } from 'vitest'
 import winston from 'winston'
+
+// evlog prints every wide event to console in addition to draining it —
+// pretty-formatted in dev, or JSON.stringify'd once `pretty` is off (see
+// `emitWideEvent` in evlog's dist: the console branch is gated on
+// `state.silent`, not `state.pretty`; `pretty` only chooses the format).
+// `silent` only suppresses that console branch — the elysia plugin's own
+// `drain` option flows through `options.drain ?? getGlobalDrain()` in its
+// request middleware, independent of `state.drain`/`state.silent` — so this
+// does not disable the drains configured below. Silencing it here makes the
+// drain evlog's only sink, matching logixlysia's noop transport in the
+// structured-sink suite.
+initLogger({ pretty: false, silent: true })
 
 const mockRequest = new Request('http://localhost:3000/')
 
@@ -184,6 +196,10 @@ const bogeychanApp = new Elysia()
   )
   .get('/', () => 'ok')
 
+// evlog has no fully-disabled mode — its "floor" case (evlogApp, below)
+// still assembles and drains a wide event per request, so its number here
+// is not a pure dispatch floor. bogeychan (`enabled: false`) and
+// logixlysia (all sinks disabled) are true floors.
 describe('Elysia plugin request path — overhead floor (all sinks disabled)', () => {
   bench('logixlysia', async () => {
     await logixlysiaApp.handle(new Request('http://localhost/'))


### PR DESCRIPTION
## 📝 Description

Makes the request-path benchmarks measure real logging work (plan 010). The flagship "Elysia plugin request path" suite configured logixlysia with every sink disabled, so `log()` short-circuited in `isEffectivelyDisabled` before doing any work — the suite measured a logger that never logs, and the docs presented that as "full `handle()` overhead". Any future optimization judged against it would be judged against noise.

- **Renamed** the disabled suite to `— overhead floor (all sinks disabled)` — a disabled-logger floor is a legitimate metric when labeled honestly (cases unchanged).
- **Added a structured-sink suite**: logixlysia with a no-op transport (`useTransportsOnly`) vs evlog with its no-op drain — both do real assembly/dispatch work, the sink discards the result. bogeychan is excluded with a comment (its `enabled: false` fully short-circuits; no comparable noop-sink mode).
- **Added a file-sink suite**: logixlysia with `logFilePath` into a temp dir, with a comment that `logToFile` is fire-and-forget so the suite measures enqueue + amortized write cost.
- **Silenced evlog's console reporter** (`initLogger({ pretty: false, silent: true })`): evlog prints every wide event to console *in addition to* draining it (pretty in dev, JSON otherwise) — ~60k console lines per bench run that logixlysia's transport case doesn't pay. With it silenced, the drain is evlog's only sink and the comparison is genuinely apples-to-apples. The elysia plugin's per-instance `drain` is unaffected (`options.drain ?? getGlobalDrain()` in evlog's middleware, independent of `state.silent`) — verified empirically: a counting transport fired exactly 1:1 with requests before and after.
- **Fixed the docs framing** in `comparison.mdx` to describe what each suite actually measures.

## 🔗 Related Issues

None — from the improve-skill audit (plan `plans/010-honest-benchmarks.md`).

## ✅ Checklist

- [x] I have followed the contributing guidelines
- [x] I have verified my changes (bench run below; typecheck + lint clean)
- [x] I have updated the documentation (`comparison.mdx` benchmark section)
- [x] My changes generate no new warnings
- [x] Tests unaffected (no package code touched — bench package is private, no changeset)

## 📸 Screenshots

N/A — benchmark + docs change.

## 📌 Additional Notes

Full `bun run bench` output (WSL2, Bun 1.3.14):

```
 ✓ Logger Creation
   · logixlysia      48,819 hz
   · pino            60,946 hz
   · consola        262,976 hz
   · winston         39,349 hz
   · evlog       12,833,851 hz
   · bogeychan       61,436 hz

 ✓ Simple Log (String)
   · logixlysia  34,234,745 hz   (1.11x pino, 1.16x consola, 5.09x evlog, 7.96x winston)

 ✓ Structured Log (Object)
   · logixlysia  33,362,359 hz   (1.11x pino, 1.40x consola, 14.32x evlog, 21.74x winston)

 ✓ Deep Nested Log
   · logixlysia  34,411,703 hz   (1.11x pino, 1.55x consola, 8.31x evlog, 34.38x winston)

 ✓ Elysia plugin request path — overhead floor (all sinks disabled)
   · logixlysia  183,767 hz  (min 0.0034ms)
   · evlog        62,319 hz  (min 0.0044ms — evlog has no fully-disabled mode; still assembles+drains)
   · bogeychan    80,274 hz  (min 0.0060ms)

 ✓ Elysia plugin request path — structured sink (noop consumer)
   · logixlysia (transport)  203,099 hz  (min 0.0037ms)
   · evlog (drain)            57,651 hz  (min 0.0044ms)

 ✓ Elysia plugin request path — file sink
   · logixlysia (logFilePath)  96,203 hz  (min 0.0063ms)
```

Sanity ordering for the three logixlysia variants — floor < transport ≤ file — holds on the outlier-robust metrics (`min`/`p75`) across repeated runs: floor min ~0.0034ms < transport min ~0.0037ms < file min ~0.0063ms. At sub-microsecond medians, `mean`/`hz` can flip between floor and transport run-to-run from rare GC/scheduler tail outliers — read `min`/`p75` when comparing future runs. A counting transport confirmed the structured-sink suite really dispatches (1 `.log()` call per request, not the `isEffectivelyDisabled` path).

Verification gates:
- `bun run bench` → exit 0, all 7 suites complete, 0 console-spam lines (was ~60k/run)
- `bun run typecheck` → 5/5 turbo tasks pass
- `bun x ultracite check` → 112 files clean
- Diff confined to `packages/bench/index.bench.ts` + `apps/docs/content/comparison.mdx`; no changeset needed (private bench package; docs don't ship in the npm package)

Plans 011/012 (file-sink + hot-path optimization) must quote before/after numbers from these suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark documentation with clearer descriptions of request-path test scenarios.
  * Clarified that overhead-floor results exclude logging work and may vary by machine.

* **Tests**
  * Expanded benchmarks to measure disabled logging overhead, structured sink processing, and file sink processing.
  * Added comparisons using no-op and file-based logging configurations for more comprehensive performance insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->