### PR TITLE
perf(output): stop stat+mkdir+open on every log line

### DIFF
--- a/.changeset/file-sink-performance.md
+++ b/.changeset/file-sink-performance.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': patch
+---
+
+File sink now holds an open file handle, batches same-tick lines into single writes, creates the log directory once, and tracks file size in memory — removing the per-line mkdir/open/stat syscalls. Rotation behavior is unchanged.

--- a/packages/logixlysia/__tests__/output/file.test.ts
+++ b/packages/logixlysia/__tests__/output/file.test.ts
@@ -9,6 +9,8 @@ import { createTempDir, removeTempDir } from '../_helpers/tmp'
 /** Owner/group/other permission bits as a 3-digit octal string, e.g. '600'. */
 const permBits = (mode: number): string => mode.toString(8).slice(-3)
 
+const MESSAGE_ID_REGEX = /msg-(\d+)$/
+
 describe('logToFile', () => {
   test('writes to file and creates directories', async () => {
     const dir = await createTempDir()
@@ -150,6 +152,176 @@ describe('logToFile', () => {
 
       const fileStat = await fs.stat(filePath)
       expect(permBits(fileStat.mode)).toBe('644')
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('coalesces same-tick writes into one file with all lines intact', async () => {
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'logs', 'batch.log')
+      const options: Options = { config: {} }
+      const total = 50
+
+      // No awaits between calls: all 50 land in the same microtask batch.
+      const writes = Array.from({ length: total }, (_, i) =>
+        logToFile({
+          data: { message: `msg-${i}` },
+          filePath,
+          level: 'INFO',
+          options,
+          request: createMockRequest(`http://localhost/test${i}`),
+          store: { beforeTime: BigInt(0) }
+        })
+      )
+
+      // Every caller's own promise must resolve, proving per-caller
+      // resolution semantics survive batching.
+      await Promise.all(writes)
+
+      const content = await fs.readFile(filePath, 'utf-8')
+      const lines = content.split('\n').filter(line => line.length > 0)
+      expect(lines.length).toBe(total)
+
+      const seenIds = new Set<string>()
+      for (const line of lines) {
+        const match = line.match(MESSAGE_ID_REGEX)
+        expect(match).not.toBeNull()
+        if (match) {
+          seenIds.add(match[1])
+        }
+      }
+      expect(seenIds.size).toBe(total)
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('rotates on size and resumes writing into a fresh live file', async () => {
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'logs', 'reopen.log')
+      const options: Options = {
+        config: { logRotation: { maxSize: 100 } }
+      }
+
+      // This single line already exceeds maxSize, so it rotates on its own.
+      await logToFile({
+        data: { message: 'x'.repeat(90) },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/first'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      // Small enough to stay under maxSize: proves the live file was
+      // reopened and writes keep landing in it (not the rotated one).
+      await logToFile({
+        data: { message: 'y' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/second'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      const entries = await fs.readdir(join(dir, 'logs'))
+      const rotated = entries.filter(name => name.startsWith('reopen.log.'))
+      expect(rotated.length).toBe(1)
+
+      const rotatedContent = await fs.readFile(
+        join(dir, 'logs', rotated[0]),
+        'utf-8'
+      )
+      expect(rotatedContent).toContain('x'.repeat(90))
+
+      const liveContent = await fs.readFile(filePath, 'utf-8')
+      expect(liveContent).toContain('/second y')
+      expect(liveContent).not.toContain('x'.repeat(90))
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('does not re-rotate immediately after the byte counter resets', async () => {
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'logs', 'no-leak.log')
+      const options: Options = {
+        config: { logRotation: { maxSize: 100 } }
+      }
+
+      // Triggers rotation on its own.
+      await logToFile({
+        data: { message: 'x'.repeat(90) },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/first'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      // Two small writes after the reset: if bytesWritten leaked across the
+      // rotation instead of resetting to 0, these would spuriously rotate
+      // again.
+      await logToFile({
+        data: { message: 'a' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/second'),
+        store: { beforeTime: BigInt(0) }
+      })
+      await logToFile({
+        data: { message: 'b' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/third'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      const entries = await fs.readdir(join(dir, 'logs'))
+      const rotated = entries.filter(name => name.startsWith('no-leak.log.'))
+      expect(rotated.length).toBe(1)
+
+      const liveContent = await fs.readFile(filePath, 'utf-8')
+      const lines = liveContent.split('\n').filter(line => line.length > 0)
+      expect(lines.length).toBe(2)
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('reopened file after rotation keeps the configured mode', async () => {
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'logs', 'mode-after-rotate.log')
+      const options: Options = {
+        config: { logRotation: { maxSize: 50 } }
+      }
+
+      await logToFile({
+        data: { message: 'x'.repeat(60) },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/first'),
+        store: { beforeTime: BigInt(0) }
+      })
+      await logToFile({
+        data: { message: 'hello' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/second'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      const fileStat = await fs.stat(filePath)
+      expect(permBits(fileStat.mode)).toBe('600')
     } finally {
       await removeTempDir(dir)
     }

--- a/packages/logixlysia/src/output/file-sink.ts
+++ b/packages/logixlysia/src/output/file-sink.ts
@@ -1,0 +1,154 @@
+import type { FileHandle } from 'node:fs/promises'
+import { open } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import type { LogRotationConfig } from '../interfaces'
+import { parseSize } from '../utils/rotation'
+import { ensureDir } from './fs'
+import { performRotation } from './rotation-manager'
+
+export interface FileSinkOptions {
+  logDirMode?: number
+  logFileMode?: number
+  logRotation?: LogRotationConfig
+}
+
+export interface FileSink {
+  /** Resolves after `line` is durably written to disk. */
+  write: (line: string, options: FileSinkOptions) => Promise<void>
+}
+
+interface BatchResolver {
+  reject: (error: unknown) => void
+  resolve: () => void
+}
+
+interface PendingBatch {
+  lines: string[]
+  resolvers: BatchResolver[]
+}
+
+class FileSinkImpl implements FileSink {
+  private readonly filePath: string
+  private handle: FileHandle | null = null
+  private bytesWritten = 0
+  private latestOptions: FileSinkOptions = {}
+  private pendingBatch: PendingBatch | null = null
+  // Serializes flush and rotation work per path: every batch (and the
+  // rotation it may trigger) is chained onto this so at most one holder of
+  // the file handle is doing I/O at a time.
+  private flushChain: Promise<void> = Promise.resolve()
+
+  constructor(filePath: string) {
+    this.filePath = filePath
+  }
+
+  write(line: string, options: FileSinkOptions): Promise<void> {
+    // Always use the latest call's options, in case config differs between
+    // calls to the same path (e.g. in tests).
+    this.latestOptions = options
+
+    return new Promise((resolve, reject) => {
+      if (this.pendingBatch) {
+        this.pendingBatch.lines.push(line)
+        this.pendingBatch.resolvers.push({ reject, resolve })
+        return
+      }
+
+      const batch: PendingBatch = {
+        lines: [line],
+        resolvers: [{ reject, resolve }]
+      }
+      this.pendingBatch = batch
+
+      queueMicrotask(() => {
+        this.pendingBatch = null
+        this.flushChain = this.flushChain.then(
+          () => this.flushBatch(batch),
+          () => this.flushBatch(batch)
+        )
+      })
+    })
+  }
+
+  private async flushBatch(batch: PendingBatch): Promise<void> {
+    const options = this.latestOptions
+    // Lines already carry their own trailing newline; join needs no separator.
+    const text = batch.lines.join('')
+
+    try {
+      await this.ensureOpen(options)
+      const handle = this.handle as FileHandle
+      await handle.write(text)
+      this.bytesWritten += Buffer.byteLength(text)
+    } catch (error) {
+      for (const resolver of batch.resolvers) {
+        resolver.reject(error)
+      }
+      return
+    }
+
+    // Rotation (if triggered) is awaited before resolving so callers observe
+    // a consistent on-disk state: the line's write plus any rotation it
+    // caused. maybeRotate() catches and reports its own errors, so it never
+    // rejects this chain.
+    await this.maybeRotate(options)
+
+    for (const resolver of batch.resolvers) {
+      resolver.resolve()
+    }
+  }
+
+  private async ensureOpen(options: FileSinkOptions): Promise<void> {
+    if (this.handle) {
+      return
+    }
+
+    // The directory only needs creating on first open (or on reopen after a
+    // rotation cleared the handle) — never per line.
+    await ensureDir(dirname(this.filePath), options.logDirMode)
+    const handle = await open(this.filePath, 'a', options.logFileMode ?? 0o600)
+    const stat = await handle.stat()
+    this.handle = handle
+    this.bytesWritten = stat.size
+  }
+
+  private async maybeRotate(options: FileSinkOptions): Promise<void> {
+    const rotation = options.logRotation
+    if (!rotation || rotation.maxSize === undefined) {
+      return
+    }
+
+    try {
+      const maxSize = parseSize(rotation.maxSize)
+      if (this.bytesWritten <= maxSize) {
+        return
+      }
+
+      const { handle } = this
+      this.handle = null
+      this.bytesWritten = 0
+      await handle?.close()
+      await performRotation(this.filePath, rotation)
+    } catch (error) {
+      // Log entries were already durably written and resolved above;
+      // rotation failures must not fail the caller's write.
+      console.error(
+        `[logixlysia] Failed to rotate log file ${this.filePath}:`,
+        error
+      )
+    }
+  }
+
+  // see plans/020: flush()/close() lifecycle would await `flushChain` here.
+}
+
+const sinks = new Map<string, FileSink>()
+
+export const getFileSink = (filePath: string): FileSink => {
+  let sink = sinks.get(filePath)
+  if (!sink) {
+    sink = new FileSinkImpl(filePath)
+    sinks.set(filePath, sink)
+  }
+  return sink
+}

--- a/packages/logixlysia/src/output/file.ts
+++ b/packages/logixlysia/src/output/file.ts
@@ -1,33 +1,6 @@
-import { appendFile } from 'node:fs/promises'
-import { dirname } from 'node:path'
 import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
 import { sanitizeLogText } from '../utils/sanitize'
-import { ensureDir } from './fs'
-import { performRotation, shouldRotate } from './rotation-manager'
-
-// Per-file mutex to prevent race conditions during rotation
-const fileLocks = new Map<string, Promise<void>>()
-
-const acquireLock = async (filePath: string): Promise<() => void> => {
-  const prior = fileLocks.get(filePath) ?? Promise.resolve()
-
-  let resolveLock: () => void
-  const newLock = new Promise<void>(resolve => {
-    resolveLock = resolve
-  })
-
-  // Register before awaiting: same-tick callers must chain onto THIS lock.
-  fileLocks.set(filePath, newLock)
-
-  await prior
-
-  return () => {
-    resolveLock?.()
-    if (fileLocks.get(filePath) === newLock) {
-      fileLocks.delete(filePath)
-    }
-  }
-}
+import { getFileSink } from './file-sink'
 
 interface LogToFileInput {
   data: Record<string, unknown>
@@ -105,44 +78,18 @@ export const logToFile = async (
 
   const line = `${level} ${durationMs.toFixed(2)}ms ${request.method} ${sanitizeLogText(pathname, 1024)} ${sanitizeLogText(message)}\n`
 
-  // Acquire lock before any file operations to prevent race conditions
-  const releaseLock = await acquireLock(filePath)
-
   try {
-    try {
-      await ensureDir(dirname(filePath), config?.logDirMode)
-      await appendFile(filePath, line, {
-        encoding: 'utf-8',
-        mode: config?.logFileMode ?? 0o600
-      })
-    } catch (error) {
-      // Log file write errors to stderr so they're not completely silent
-      console.error(
-        `[logixlysia] Failed to write to log file ${filePath}:`,
-        error
-      )
-      throw error
-    }
-
-    const rotation = config?.logRotation
-    if (!rotation) {
-      return
-    }
-
-    const should = await shouldRotate(filePath, rotation)
-    if (should) {
-      try {
-        await performRotation(filePath, rotation)
-      } catch (error) {
-        // Log rotation errors but don't crash - log entry was already written
-        console.error(
-          `[logixlysia] Failed to rotate log file ${filePath}:`,
-          error
-        )
-      }
-    }
-  } finally {
-    // Release lock
-    releaseLock()
+    await getFileSink(filePath).write(line, {
+      logDirMode: config?.logDirMode,
+      logFileMode: config?.logFileMode,
+      logRotation: config?.logRotation
+    })
+  } catch (error) {
+    // Log file write errors to stderr so they're not completely silent
+    console.error(
+      `[logixlysia] Failed to write to log file ${filePath}:`,
+      error
+    )
+    throw error
   }
 }


### PR DESCRIPTION
## Description

Reworks the file sink so a log line no longer costs 2–3 filesystem syscall clusters. Previously every line did `mkdir -p` of the log directory, a full `appendFile` (open→write→close), and — with rotation configured — a `stat` of the file, all serialized behind a per-path promise chain.

The new `src/output/file-sink.ts` (per-path, held in a module `Map`):

- **holds an open `FileHandle`** instead of open/close per line (opened with `logFileMode ?? 0o600`, dir created once with `logDirMode` — the #368 permission hardening is preserved)
- **batches same-tick lines** into a single `handle.write()` via `queueMicrotask` coalescing; each caller's promise still resolves only after its line (and any rotation it triggered) is durably on disk — the contract the existing tests pin
- **tracks file size in memory** (`bytesWritten`, initialized from `stat` at open) so the rotation check is an integer compare, not a per-line `stat`; boundary semantics identical to `shouldRotateBySize` (`> maxSize`)
- **rotation goes through the sink** (close → `performRotation` → reopen on next batch) so the held handle never keeps writing to a renamed inode
- a `flushChain` promise serializes flushes and rotation per path, replacing the old `acquireLock` mutex with the same max-one-holder guarantee (`race-condition.test.ts` passes byte-identical, 20 consecutive runs)

`logToFile` keeps its exported signature (incl. the dual-signature shim, which plan 017 later removes) and its error contract: write failures `console.error` + reject, rotation failures report but don't reject.

## Related Issues

—

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary (no docs change needed — no public API surface changed)

## Screenshots (if applicable)

N/A

## Additional Notes

**Bench — `Elysia plugin request path — file sink` suite** (vitest bench, same machine, `min`/`p75` are the reliable metrics at this scale; `mean`/`hz` flip run-to-run):

| | hz | min | p75 | rme | samples |
|---|---|---|---|---|---|
| before (main @ dfd8c82) | 54,032 | 0.0066 | 0.0117 | ±16.33% | 27,413 |
| after (this branch) | 82,652 | 0.0069 | 0.0087 | ±8.90% | 41,327 |

p75 improved ~25% and throughput ~52%, consistent across 5 independent after-runs (p75 0.0087–0.0093; reviewer reproduced 0.0088). `min` is flat within noise — expected: the bench awaits `handle()` while `logToFile` is fire-and-forget, so the fastest samples measure enqueue cost in both versions; the eliminated per-line mkdir/open/stat syscalls show up as less event-loop contention (p75/hz) rather than a lower floor. A full `bun run bench` run confirms no other suite regressed.

**Verification gates** (run by executor and re-run independently by reviewer in the worktree):

- `bun test` (packages/logixlysia): 188 pass / 0 fail — `race-condition.test.ts` and `rotation-manager.test.ts` byte-identical to main
- `bun run typecheck`: 5/5 green
- `bun x ultracite check`: clean
- `bun run build --filter logixlysia`: clean

**Review notes** (two deliberate deviations from the plan's literal wording, both verified):

1. The batch resolves **after** any rotation it triggered, not merely after the write — this matches the pre-existing behavior (the old code awaited `performRotation` before `logToFile` resolved); resolving earlier broke two rotation tests via `ENOENT: rename` when test cleanup deleted the dir under an in-flight rotation.
2. No separate `dirEnsured` flag: `ensureOpen()` early-returns when the handle exists, so directory creation still happens once per handle lifetime — restructured to satisfy Biome's `noUnnecessaryConditions` without disabling any rule.

Known tradeoff (documented in the plan): external deletion/rename of the live file is no longer auto-healed per line — the held handle is the point; rotation must go through the sink, which it does. Plan 020's `flush()`/`close()` lifecycle will hook onto the sink's `flushChain` tail (marked with a `// see plans/020` comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved file logging efficiency through batched writes and persistent file handling.
  * Reduced overhead by creating log directories only once and tracking file size in memory.

* **Reliability**
  * Ensured batched log entries complete consistently and file rotation continues to preserve file settings.
  * File-write and rotation errors remain reported appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->