### PR TITLE
perf: cut redundant work on the per-request log path

### DIFF
--- a/.changeset/hot-path-optimization.md
+++ b/.changeset/hot-path-optimization.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': patch
+---
+
+Per-request logging is faster: format tokens are computed only when present in the log format, colors/thresholds/service are resolved once per logger, URL parsing and duration sampling happen once per emission, internal context reads no longer clone, WebSocket synthetic requests are memoized per path, and `autoRedact` returns the original object untouched when nothing needs redacting.

--- a/packages/logixlysia/__tests__/context/request-context.test.ts
+++ b/packages/logixlysia/__tests__/context/request-context.test.ts
@@ -34,4 +34,36 @@ describe('request context store', () => {
 
     expect(merged.context).toEqual({ plan: 'pro', userId: 'override' })
   })
+
+  test('peekContext returns the live bag without cloning', () => {
+    const store = createRequestContextStore()
+    const request = new Request('http://localhost/')
+
+    store.mergeContext(request, { userId: 'u1' })
+    const peeked = store.peekContext(request)
+    store.mergeContext(request, { plan: 'pro' })
+
+    // Same reference as the internally stored bag: mutations made via mergeContext
+    // are visible through the reference obtained earlier from peekContext.
+    expect(peeked).toEqual({ plan: 'pro', userId: 'u1' })
+  })
+
+  test('peekContext returns a shared empty object for unknown keys', () => {
+    const store = createRequestContextStore()
+    const request = new Request('http://localhost/')
+
+    expect(store.peekContext(request)).toEqual({})
+  })
+
+  test('getContext still returns a fresh copy each call, unlike peekContext', () => {
+    const store = createRequestContextStore()
+    const request = new Request('http://localhost/')
+    store.mergeContext(request, { userId: 'u1' })
+
+    const first = store.getContext(request)
+    const second = store.getContext(request)
+
+    expect(first).toEqual(second)
+    expect(first).not.toBe(second)
+  })
 })

--- a/packages/logixlysia/__tests__/logger/format-output.test.ts
+++ b/packages/logixlysia/__tests__/logger/format-output.test.ts
@@ -8,6 +8,8 @@ import {
 import { redactRequest } from '../../src/utils/redact'
 import { createMockRequest } from '../_helpers/request'
 
+const DIGITS_ONLY_REGEX = /^\d+$/
+
 describe('formatDuration', () => {
   test('formats sub-second requests as ms', () => {
     expect(formatDuration(0)).toBe('0ms')
@@ -199,6 +201,26 @@ describe('formatLogOutput', () => {
     expect(out.main).not.toContain('test@example.com')
     expect(out.main).toContain('[REDACTED]')
     expect(out.main).not.toContain('192.168.1.1')
+  })
+
+  test('renders tokens skipped by the default format when explicitly requested', () => {
+    const request = createMockRequest('http://localhost/api/hello', {
+      headers: { 'x-forwarded-for': '10.0.0.1' }
+    })
+    const store = { beforeTime: BigInt(0) }
+    const out = formatLogOutput({
+      data: { status: 200 },
+      level: 'INFO',
+      options: baseOptions({
+        config: { customLogFormat: '{epoch} {ip}', ip: true, useColors: false }
+      }),
+      request,
+      store
+    })
+
+    const [epochToken, ipToken] = out.main.split(' ')
+    expect(epochToken).toMatch(DIGITS_ONLY_REGEX)
+    expect(ipToken).toBe('10.0.0.1')
   })
 
   test('speed token appears when duration exceeds verySlowThreshold', () => {

--- a/packages/logixlysia/__tests__/utils/redact.test.ts
+++ b/packages/logixlysia/__tests__/utils/redact.test.ts
@@ -159,6 +159,35 @@ describe('redact', () => {
       custom: '[REDACTED]'
     })
   })
+
+  test('returns the same object reference when nothing needs redacting', () => {
+    const original = { count: 3, message: 'all good', nested: { ok: true } }
+    const result = redact(original)
+    expect(result).toBe(original)
+  })
+
+  test('returns the same array reference when nothing needs redacting', () => {
+    const original = [1, 'safe', { ok: true }]
+    const result = redact(original)
+    expect(result).toBe(original)
+  })
+
+  test('changed objects still return new references and leave the original unmutated', () => {
+    const original = { user: { email: 'test@example.com', name: 'ok' } }
+    const result = redact(original)
+    expect(result).not.toBe(original)
+    expect((result as typeof original).user).not.toBe(original.user)
+    expect(original.user.email).toBe('test@example.com')
+  })
+
+  test('only clones the branch containing a change; sibling branches keep their reference', () => {
+    const unrelated = { safe: true }
+    const original = { a: unrelated, b: { email: 'x@example.com' } }
+    const result = redact(original) as typeof original
+    expect(result).not.toBe(original)
+    expect(result.a).toBe(unrelated)
+    expect(result.b).not.toBe(original.b)
+  })
 })
 
 describe('isSensitiveKey', () => {

--- a/packages/logixlysia/src/context/request-context.ts
+++ b/packages/logixlysia/src/context/request-context.ts
@@ -5,7 +5,16 @@ export interface RequestContextStore {
   clearContext: (key: ContextKey) => void
   getContext: (key: ContextKey) => Readonly<Record<string, unknown>>
   mergeContext: (key: ContextKey, partial: Record<string, unknown>) => void
+  /**
+   * Non-cloning read of the live context bag. Returns the SAME object stored internally (or a
+   * shared frozen empty object) — never hand this to user-facing code, which may retain or
+   * mutate it. Only internal, read-only call sites (that immediately spread the result into a
+   * new object) may use this; everything else must use {@link RequestContextStore.getContext}.
+   */
+  peekContext: (key: ContextKey) => Readonly<Record<string, unknown>>
 }
+
+const EMPTY_CONTEXT: Readonly<Record<string, unknown>> = Object.freeze({})
 
 export const createRequestContextStore = (): RequestContextStore => {
   const bags = new WeakMap<ContextKey, Record<string, unknown>>()
@@ -33,6 +42,9 @@ export const createRequestContextStore = (): RequestContextStore => {
       }
       const bag = getOrCreate(key)
       Object.assign(bag, partial)
+    },
+    peekContext(key) {
+      return bags.get(key) ?? EMPTY_CONTEXT
     }
   }
 }

--- a/packages/logixlysia/src/logger/create-logger.ts
+++ b/packages/logixlysia/src/logger/create-logger.ts
@@ -98,10 +98,10 @@ const getSlowThresholds = (
 const colorDurationText = (
   ms: number,
   useColors: boolean,
-  options: Options
+  slow: number,
+  verySlow: number
 ): { text: string; isVerySlow: boolean } => {
   const raw = formatDuration(ms)
-  const { slow, verySlow } = getSlowThresholds(options)
   const isVerySlow = ms >= verySlow
 
   if (!useColors) {
@@ -261,6 +261,43 @@ const getServiceToken = (options: Options, useColors: boolean): string => {
   return `${chalk.dim(bracketed)} `
 }
 
+export interface FormatContext {
+  format: string
+  serviceToken: string
+  slowThreshold: number
+  /** Format tokens actually present in `format` (see {@link LOG_FORMAT_REGEX}). */
+  tokens: Set<string>
+  useColors: boolean
+  verySlowThreshold: number
+}
+
+/**
+ * Resolves colors/format/thresholds/service once per logger instance instead of per log line.
+ * Safe to hoist: TTY-ness and config don't change across a process's lifetime, so freezing the
+ * colors decision at construction time matches real process lifecycles.
+ *
+ * NOTE: adding a new format token requires adding it both to {@link LOG_FORMAT_REGEX} and to the
+ * token-gating checks in {@link formatLogOutput} below.
+ */
+export const createFormatContext = (options: Options): FormatContext => {
+  const { config } = options
+  const useColors = shouldUseColors(options)
+  const format = config?.customLogFormat ?? DEFAULT_LOG_FORMAT
+  const tokens = new Set(format.match(LOG_FORMAT_REGEX) ?? [])
+  const { slow: slowThreshold, verySlow: verySlowThreshold } =
+    getSlowThresholds(options)
+  const serviceToken = getServiceToken(options, useColors)
+
+  return {
+    format,
+    serviceToken,
+    slowThreshold,
+    tokens,
+    useColors,
+    verySlowThreshold
+  }
+}
+
 const stringifyTreeValue = (value: unknown): string => {
   if (value === null) {
     return 'null'
@@ -375,13 +412,13 @@ const collectStructuredErrorEntries = (error: unknown): [string, string][] => {
 export const buildContextTreeLines = (
   level: LogLevel,
   data: Record<string, unknown>,
-  options: Options
+  options: Options,
+  useColors: boolean = shouldUseColors(options)
 ): string[] => {
   if (options.config?.showContextTree === false) {
     return []
   }
 
-  const useColors = shouldUseColors(options)
   const depth = options.config?.contextDepth ?? 1
 
   const entries: [string, string][] = []
@@ -414,78 +451,241 @@ const getContextString = (value: unknown): string => {
   return ''
 }
 
+/** Raw duration/URL parts computed once per log emission by the caller (see `logger/index.ts`). */
+export interface PrecomputedLogParts {
+  durationMs: number
+  pathname: string
+  search: string
+}
+
+/** `{now}`/`{epoch}` share a single `Date` sample; each is only formatted when requested. */
+const getTimestampTokens = (
+  tokens: Set<string>,
+  translateTime: string | undefined,
+  useColors: boolean
+): { timestamp: string; epoch: string } => {
+  if (!(tokens.has('{now}') || tokens.has('{epoch}'))) {
+    return { epoch: '', timestamp: '' }
+  }
+  const now = new Date()
+  const epoch = tokens.has('{epoch}') ? String(now.getTime()) : ''
+  if (!tokens.has('{now}')) {
+    return { epoch, timestamp: '' }
+  }
+  const rawTimestamp = formatTimestamp(now, translateTime)
+  return { epoch, timestamp: getColoredTimestamp(rawTimestamp, useColors) }
+}
+
+const getMessageToken = (
+  tokens: Set<string>,
+  data: Record<string, unknown>
+): string => {
+  if (!tokens.has('{message}')) {
+    return ''
+  }
+  return typeof data.message === 'string' ? data.message : ''
+}
+
+/** `{pathname}`/`{path}`/`{query}` share a single URL parse (or the precomputed one). */
+const getPathnameTokens = (
+  tokens: Set<string>,
+  request: RequestInfo,
+  config: Options['config'],
+  useColors: boolean,
+  precomputed?: PrecomputedLogParts
+): { coloredPathname: string; query: string } => {
+  const needsPathname = tokens.has('{pathname}') || tokens.has('{path}')
+  const needsQuery = tokens.has('{query}')
+  if (!(needsPathname || needsQuery)) {
+    return { coloredPathname: '', query: '' }
+  }
+
+  let rawPathname: string
+  let search: string
+  if (precomputed) {
+    ;({ pathname: rawPathname, search } = precomputed)
+  } else {
+    try {
+      ;({ pathname: rawPathname, search } = new URL(request.url))
+    } catch {
+      rawPathname = request.url || '/'
+      search = ''
+    }
+  }
+
+  const query = needsQuery ? search : ''
+  if (!needsPathname) {
+    return { coloredPathname: '', query }
+  }
+  const pathname = config?.logQueryParams
+    ? `${rawPathname}${search}`
+    : rawPathname
+  return { coloredPathname: getColoredPathname(pathname, useColors), query }
+}
+
+/** `{status}`/`{statusText}` share a single status-code resolution. */
+const getStatusTokens = (
+  tokens: Set<string>,
+  data: Record<string, unknown>,
+  useColors: boolean
+): { coloredStatus: string; statusText: string } => {
+  const needsStatus = tokens.has('{status}')
+  const needsStatusText = tokens.has('{statusText}')
+  if (!(needsStatus || needsStatusText)) {
+    return { coloredStatus: '', statusText: '' }
+  }
+  const statusValue = data.status
+  const statusCode =
+    statusValue === null || statusValue === undefined
+      ? 200
+      : getStatusCode(statusValue)
+  return {
+    coloredStatus: needsStatus
+      ? getColoredStatus(String(statusCode), useColors)
+      : '',
+    statusText: needsStatusText ? getStatusText(statusCode) : ''
+  }
+}
+
+const getIpToken = (
+  tokens: Set<string>,
+  request: RequestInfo,
+  config: Options['config']
+): string => (config?.ip === true && tokens.has('{ip}') ? getIp(request) : '')
+
+const hasNonEmptyContext = (
+  context: unknown
+): context is Record<string, unknown> =>
+  context !== null &&
+  context !== undefined &&
+  typeof context === 'object' &&
+  !Array.isArray(context) &&
+  Object.keys(context as object).length > 0
+
+const getContextToken = (
+  tokens: Set<string>,
+  data: Record<string, unknown>,
+  config: Options['config']
+): string => {
+  if (!tokens.has('{context}')) {
+    return ''
+  }
+  const showTree = config?.showContextTree !== false
+  if (showTree && hasNonEmptyContext(data.context)) {
+    return ''
+  }
+  return getContextString(data.context)
+}
+
+/** `{duration}`/`{speed}` share a single duration sample and slow-threshold check. */
+const getDurationTokens = (
+  tokens: Set<string>,
+  store: StoreData,
+  useColors: boolean,
+  slowThreshold: number,
+  verySlowThreshold: number,
+  precomputed?: PrecomputedLogParts
+): { coloredDuration: string; speedToken: string } => {
+  const needsDuration = tokens.has('{duration}')
+  const needsSpeed = tokens.has('{speed}')
+  if (!(needsDuration || needsSpeed)) {
+    return { coloredDuration: '', speedToken: '' }
+  }
+  const durationMs =
+    precomputed?.durationMs ??
+    (store.beforeTime === BigInt(0)
+      ? 0
+      : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000)
+  const { text, isVerySlow } = colorDurationText(
+    durationMs,
+    useColors,
+    slowThreshold,
+    verySlowThreshold
+  )
+  return {
+    coloredDuration: needsDuration ? text : '',
+    speedToken: needsSpeed ? getSpeedToken(isVerySlow, useColors) : ''
+  }
+}
+
+const getRequestIdToken = (
+  tokens: Set<string>,
+  data: Record<string, unknown>
+): string => {
+  if (!tokens.has('{requestId}')) {
+    return ''
+  }
+  const ctx = data.context
+  if (typeof ctx !== 'object' || ctx === null || !('requestId' in ctx)) {
+    return ''
+  }
+  return String((ctx as Record<string, unknown>).requestId)
+}
+
 export const formatLogOutput = ({
   level,
   request,
   data,
   store,
-  options
+  options,
+  formatContext,
+  precomputed
 }: {
   level: LogLevel
   request: RequestInfo
   data: Record<string, unknown>
   store: StoreData
   options: Options
+  /** Hoisted per-logger constants; computed on the fly when a direct caller omits it. */
+  formatContext?: FormatContext
+  /** Duration/URL parts already computed by the caller; parsed on the fly when omitted. */
+  precomputed?: PrecomputedLogParts
 }): FormattedLogOutput => {
   const { config } = options
-  const useColors = shouldUseColors(options)
-  const format = config?.customLogFormat ?? DEFAULT_LOG_FORMAT
-
-  const now = new Date()
-  const epoch = String(now.getTime())
-  const rawTimestamp = formatTimestamp(now, config?.timestamp?.translateTime)
-  const timestamp = getColoredTimestamp(rawTimestamp, useColors)
-
-  const message = typeof data.message === 'string' ? data.message : ''
-  const durationMs =
-    store.beforeTime === BigInt(0)
-      ? 0
-      : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000
-
-  let rawPathname: string
-  let search: string
-  try {
-    ;({ pathname: rawPathname, search } = new URL(request.url))
-  } catch {
-    rawPathname = request.url || '/'
-    search = ''
-  }
-  const query = search
-  const pathname = config?.logQueryParams
-    ? `${rawPathname}${query}`
-    : rawPathname
-  const statusValue = data.status
-  const statusCode =
-    statusValue === null || statusValue === undefined
-      ? 200
-      : getStatusCode(statusValue)
-  const status = String(statusCode)
-  const ip = config?.ip === true ? getIp(request) : ''
-
-  const showTree = config?.showContextTree !== false
-  const ctxString =
-    showTree &&
-    data.context &&
-    typeof data.context === 'object' &&
-    !Array.isArray(data.context) &&
-    Object.keys(data.context as object).length > 0
-      ? ''
-      : getContextString(data.context)
-
-  const coloredLevel = getColoredLevel(level, useColors)
-  const methodPadded = request.method.toUpperCase().padEnd(METHOD_PAD)
-  const coloredMethod = getColoredMethod(methodPadded, useColors)
-  const coloredPathname = getColoredPathname(pathname, useColors)
-  const coloredStatus = getColoredStatus(status, useColors)
-  const { text: coloredDuration, isVerySlow } = colorDurationText(
-    durationMs,
+  const {
+    format,
+    serviceToken,
+    slowThreshold,
+    tokens,
     useColors,
-    options
+    verySlowThreshold
+  } = formatContext ?? createFormatContext(options)
+
+  const { timestamp, epoch } = getTimestampTokens(
+    tokens,
+    config?.timestamp?.translateTime,
+    useColors
   )
-  const speedToken = getSpeedToken(isVerySlow, useColors)
-  const icon = getLevelIcon(level, useColors)
-  const statusText = getStatusText(statusCode)
-  const serviceToken = getServiceToken(options, useColors)
+  const message = getMessageToken(tokens, data)
+  const { coloredPathname, query } = getPathnameTokens(
+    tokens,
+    request,
+    config,
+    useColors,
+    precomputed
+  )
+  const { coloredStatus, statusText } = getStatusTokens(tokens, data, useColors)
+  const ip = getIpToken(tokens, request, config)
+  const ctxString = getContextToken(tokens, data, config)
+  const coloredLevel = tokens.has('{level}')
+    ? getColoredLevel(level, useColors)
+    : ''
+  const coloredMethod = tokens.has('{method}')
+    ? getColoredMethod(
+        request.method.toUpperCase().padEnd(METHOD_PAD),
+        useColors
+      )
+    : ''
+  const { coloredDuration, speedToken } = getDurationTokens(
+    tokens,
+    store,
+    useColors,
+    slowThreshold,
+    verySlowThreshold,
+    precomputed
+  )
+  const icon = tokens.has('{icon}') ? getLevelIcon(level, useColors) : ''
+  const requestId = getRequestIdToken(tokens, data)
 
   const tokenMap: Record<string, string> = {
     '{context}': ctxString,
@@ -500,12 +700,7 @@ export const formatLogOutput = ({
     '{path}': coloredPathname,
     '{pathname}': coloredPathname,
     '{query}': query,
-    '{requestId}':
-      typeof data.context === 'object' &&
-      data.context !== null &&
-      'requestId' in data.context
-        ? String((data.context as Record<string, unknown>).requestId)
-        : '',
+    '{requestId}': requestId,
     '{service}': serviceToken,
     '{speed}': speedToken,
     '{status}': coloredStatus,
@@ -517,7 +712,7 @@ export const formatLogOutput = ({
     match => tokenMap[match] ?? match
   )
 
-  const contextLines = buildContextTreeLines(level, data, options)
+  const contextLines = buildContextTreeLines(level, data, options, useColors)
 
   return { contextLines, main }
 }

--- a/packages/logixlysia/src/logger/handle-http-error.ts
+++ b/packages/logixlysia/src/logger/handle-http-error.ts
@@ -52,7 +52,9 @@ export const handleHttpError = (
 
   const data: Record<string, unknown> = { error: safeError, message, status }
   const dataWithContext = contextStore
-    ? mergeLogDataContext(data, contextStore.getContext(request))
+    ? // mergeLogDataContext only reads/spreads this bag into a new object; it never retains
+      // the reference, so a non-cloning peek is safe here.
+      mergeLogDataContext(data, contextStore.peekContext(request))
     : data
   const logData =
     config?.autoRedact === true

--- a/packages/logixlysia/src/logger/index.ts
+++ b/packages/logixlysia/src/logger/index.ts
@@ -17,8 +17,48 @@ import type {
 import { logToTransports } from '../output'
 import { logToFile } from '../output/file'
 import { buildPinoRedactPaths, redact, redactRequest } from '../utils/redact'
-import { formatLogOutput } from './create-logger'
+import {
+  createFormatContext,
+  formatLogOutput,
+  type PrecomputedLogParts
+} from './create-logger'
 import { handleHttpError } from './handle-http-error'
+
+const computeDurationMs = (store: StoreData): number =>
+  store.beforeTime === BigInt(0)
+    ? 0
+    : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000
+
+/** Parses the URL once; only called when at least one active sink reads pathname/search. */
+const parseRequestUrlOnce = (
+  request: RequestInfo
+): { pathname: string; search: string } => {
+  try {
+    const { pathname, search } = new URL(request.url)
+    return { pathname, search }
+  } catch {
+    return { pathname: request.url || '/', search: '' }
+  }
+}
+
+/**
+ * Samples duration and parses the URL once per emission for the sinks that will actually run.
+ * `logToTransports`' meta only reads `durationMs` (not pathname/search), so the URL is parsed
+ * only when file logging or the internal console logger is active — skipping it entirely for
+ * transports-only configs, matching that path's pre-optimization behavior.
+ */
+const computePrecomputedLogParts = (
+  store: StoreData,
+  request: RequestInfo,
+  needsUrlParts: boolean
+): PrecomputedLogParts => {
+  const durationMs = computeDurationMs(store)
+  const { pathname, search } = needsUrlParts
+    ? parseRequestUrlOnce(request)
+    : { pathname: '', search: '' }
+
+  return { durationMs, pathname, search }
+}
 
 export const createLogger = (
   options: Options = {},
@@ -27,6 +67,9 @@ export const createLogger = (
 ): Logger => {
   const contextStore = externalContextStore ?? createRequestContextStore()
   const { config } = options
+  // Hoisted once per logger instance: colors/format/thresholds/service don't change across
+  // requests within a process lifetime (see createFormatContext's doc comment).
+  const formatContext = createFormatContext(options)
 
   const pinoConfig = config?.pino
   const { prettyPrint, ...pinoOptions } = pinoConfig ?? {}
@@ -102,6 +145,9 @@ export const createLogger = (
     hasFileLogging ||
     hasInternalLogger
   )
+  // Only file logging and the internal console formatter read pathname/search; transports'
+  // meta only reads durationMs, so skip the URL parse entirely when they're the only sink.
+  const needsUrlParts = hasFileLogging || hasInternalLogger
 
   const log = (
     level: LogLevel,
@@ -115,7 +161,9 @@ export const createLogger = (
 
     const dataWithContext = mergeLogDataContext(
       data,
-      contextStore.getContext(request)
+      // mergeLogDataContext only reads/spreads this bag into a new object; it never retains
+      // the reference, so a non-cloning peek is safe here.
+      contextStore.peekContext(request)
     )
     const logData =
       config?.autoRedact === true
@@ -126,11 +174,18 @@ export const createLogger = (
         ? redactRequest(request, config?.redactKeys)
         : request
 
+    const precomputed = computePrecomputedLogParts(
+      store,
+      logRequest,
+      needsUrlParts
+    )
+
     if (hasTransports) {
       logToTransports({
         data: logData,
         level,
         options,
+        precomputed,
         request: logRequest,
         store
       })
@@ -144,6 +199,7 @@ export const createLogger = (
           filePath,
           level,
           options,
+          precomputed,
           request: logRequest,
           store
         }).catch(() => {
@@ -158,8 +214,10 @@ export const createLogger = (
 
     const { main, contextLines } = formatLogOutput({
       data: logData,
+      formatContext,
       level,
       options,
+      precomputed,
       request: logRequest,
       store
     })

--- a/packages/logixlysia/src/output/file.ts
+++ b/packages/logixlysia/src/output/file.ts
@@ -7,6 +7,8 @@ interface LogToFileInput {
   filePath: string
   level: LogLevel
   options: Options
+  /** Duration/URL parts already computed by the caller; parsed on the fly when omitted. */
+  precomputed?: { durationMs: number; pathname: string; search: string }
   request: RequestInfo
   store: StoreData
 }
@@ -52,7 +54,7 @@ export const logToFile = async (
         })()
       : args[0]
 
-  const { filePath, level, request, data, store, options } = input
+  const { filePath, level, request, data, store, options, precomputed } = input
   const { config } = options
   const useTransportsOnly = config?.useTransportsOnly === true
   const disableFileLogging = config?.disableFileLogging === true
@@ -62,18 +64,26 @@ export const logToFile = async (
 
   const message = typeof data.message === 'string' ? data.message : ''
   const durationMs =
-    store.beforeTime === BigInt(0)
+    precomputed?.durationMs ??
+    (store.beforeTime === BigInt(0)
       ? 0
-      : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000
+      : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000)
 
-  // Safely parse URL to avoid crashes on malformed URLs
   let pathname = '/'
-  try {
-    const { pathname: rawPathname, search } = new URL(request.url)
+  if (precomputed) {
+    const { pathname: rawPathname, search } = precomputed
     pathname = config?.logQueryParams ? `${rawPathname}${search}` : rawPathname
-  } catch {
-    // Fallback to raw URL if parsing fails
-    pathname = request.url
+  } else {
+    // Safely parse URL to avoid crashes on malformed URLs
+    try {
+      const { pathname: rawPathname, search } = new URL(request.url)
+      pathname = config?.logQueryParams
+        ? `${rawPathname}${search}`
+        : rawPathname
+    } catch {
+      // Fallback to raw URL if parsing fails
+      pathname = request.url
+    }
   }
 
   const line = `${level} ${durationMs.toFixed(2)}ms ${request.method} ${sanitizeLogText(pathname, 1024)} ${sanitizeLogText(message)}\n`

--- a/packages/logixlysia/src/output/index.ts
+++ b/packages/logixlysia/src/output/index.ts
@@ -16,6 +16,8 @@ interface LogToTransportsInput {
   data: Record<string, unknown>
   level: LogLevel
   options: Options
+  /** Duration already computed by the caller; sampled on the fly when omitted. */
+  precomputed?: { durationMs: number; pathname: string; search: string }
   request: RequestInfo
   store: StoreData
 }
@@ -36,7 +38,7 @@ export const logToTransports = (
         }
       : args[0]
 
-  const { level, request, data, store, options } = input
+  const { level, request, data, store, options, precomputed } = input
   const transports = options.config?.transports ?? []
   if (transports.length === 0) {
     return
@@ -50,9 +52,10 @@ export const logToTransports = (
     },
     ...data,
     durationMs:
-      store.beforeTime === BigInt(0)
+      precomputed?.durationMs ??
+      (store.beforeTime === BigInt(0)
         ? 0
-        : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000
+        : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000)
   }
 
   for (const transport of transports) {

--- a/packages/logixlysia/src/utils/redact.ts
+++ b/packages/logixlysia/src/utils/redact.ts
@@ -145,6 +145,7 @@ const redactCreditCardCandidates = (text: string): string =>
     return match
   })
 
+/** Returns `text` unchanged (same value) when nothing matched — callers can compare `=== input`. */
 export const redactString = (text: string): string => {
   let result = text
 
@@ -156,6 +157,9 @@ export const redactString = (text: string): string => {
   return result
 }
 
+// Errors are exempt from the identity fast path below: a redacted Error is always constructed
+// fresh (even when nothing changed) so consumers never receive the original, potentially
+// stack-trace-carrying instance by reference.
 const redactErrorClone = (
   originalError: Error,
   inProgress: WeakSet<object>,
@@ -185,30 +189,58 @@ const redactErrorClone = (
   return newError
 }
 
+/**
+ * Redacts each item; returns the ORIGINAL array reference when no item changed (zero
+ * allocations for the common no-PII case). A new array is materialized lazily, starting from
+ * the first item that changes — items before that point are known-unchanged, so they're copied
+ * from `value` as-is rather than recomputed.
+ */
 const redactArrayItems = (
   value: unknown[],
   inProgress: WeakSet<object>,
   extraKeys?: readonly string[]
 ): unknown[] => {
-  const redactedArray: unknown[] = Array.from({ length: value.length })
-  for (let i = 0; i < value.length; i += 1) {
-    redactedArray[i] = redactInner(value[i], inProgress, extraKeys)
+  let result: unknown[] | undefined
+
+  for (const [index, original] of value.entries()) {
+    const redacted = redactInner(original, inProgress, extraKeys)
+    if (result === undefined && redacted !== original) {
+      result = value.slice(0, index)
+    }
+    result?.push(redacted)
   }
-  return redactedArray
+
+  return result ?? value
 }
 
+/** Same lazy-materialization strategy as {@link redactArrayItems}, for plain objects. */
 const redactRecordEntries = (
   recordValue: Record<string, unknown>,
   inProgress: WeakSet<object>,
   extraKeys?: readonly string[]
 ): Record<string, unknown> => {
-  const redactedRecord: Record<string, unknown> = {}
-  for (const key of Object.keys(recordValue)) {
-    redactedRecord[key] = isSensitiveKey(key, extraKeys)
+  const keys = Object.keys(recordValue)
+  let result: Record<string, unknown> | undefined
+
+  for (const [index, key] of keys.entries()) {
+    const original = recordValue[key]
+    const sensitive = isSensitiveKey(key, extraKeys)
+    const redacted = sensitive
       ? REDACTED_TEXT
-      : redactInner(recordValue[key], inProgress, extraKeys)
+      : redactInner(original, inProgress, extraKeys)
+
+    if (result === undefined && (sensitive || redacted !== original)) {
+      result = {}
+      for (const priorKey of keys.slice(0, index)) {
+        result[priorKey] = recordValue[priorKey]
+      }
+    }
+    if (result !== undefined) {
+      result[key] = redacted
+    }
   }
-  return redactedRecord
+
+  return result ?? recordValue
 }
 
 const withReentrancyGuard = <T>(
@@ -243,7 +275,10 @@ const redactInner = <T>(
   }
 
   if (value instanceof Date) {
-    return new Date(value.getTime()) as unknown as T
+    // Dates carry no redactable string content and are never mutated by this module, so they
+    // pass through by reference (part of the identity fast path) instead of being defensively
+    // cloned as before.
+    return value
   }
 
   const obj = value as object

--- a/packages/logixlysia/src/websocket/wrap-ws.ts
+++ b/packages/logixlysia/src/websocket/wrap-ws.ts
@@ -15,8 +15,18 @@ export interface WsHandlerHooks<
   open?: (ws: TWs) => void
 }
 
-const wsSyntheticRequest = (path: string): Request =>
-  new Request(`http://logixlysia.local${path}`, { method: 'WS' })
+// Synthetic requests are only read (method/url) by the log pipeline, never mutated, so caching
+// one per path avoids allocating a fresh Request on every WS open/message/close log event.
+const wsRequestCache = new Map<string, Request>()
+
+const wsSyntheticRequest = (path: string): Request => {
+  let request = wsRequestCache.get(path)
+  if (!request) {
+    request = new Request(`http://logixlysia.local${path}`, { method: 'WS' })
+    wsRequestCache.set(path, request)
+  }
+  return request
+}
 
 export const createWsHandlerWrapper = (
   options: Options,
@@ -35,7 +45,8 @@ export const createWsHandlerWrapper = (
     const key = ws as object
     const beforeTime = wsTimings.get(key) ?? process.hrtime.bigint()
     const store: StoreData = { beforeTime }
-    const accumulated = contextStore.getContext(key)
+    // Read-only: immediately spread below into a new object, never retained or mutated.
+    const accumulated = contextStore.peekContext(key)
     const context =
       Object.keys(accumulated).length > 0 || extra
         ? { ...accumulated, ...extra, wsId: ws.id }


### PR DESCRIPTION
## Description

Cuts redundant per-request work across the logging hot path — six independent optimizations, one commit each:

1. **Hoisted format context** (`createFormatContext`): colors (TTY check), format string, the set of tokens present in the format, slow/very-slow thresholds, and the service token are resolved once per logger instance instead of on every log line. The TTY decision is frozen at construction — matching real process lifecycles (documented in code).
2. **Token gating**: `formatLogOutput` computes only the tokens the format actually uses. On the default format, `epoch`, `ip`, `statusText`, `query`, `requestId`, `context`, and `level` are skipped entirely. Custom formats still render every requested token (covered by a new test).
3. **Single URL parse + single duration sample per emission**: `log()` computes `durationMs` and parses the URL once and threads the values into the console formatter, file sink, and transport meta (each keeps its own config-gated assembly, so output is unchanged; each also keeps a compute-on-the-fly fallback for direct calls). Transports-only configs skip URL parsing entirely — transport meta never read pathname/search.
4. **`peekContext`** — a non-cloning internal context read (documented as internal-only). The three internal read-only sites (request log, error path, WS log) switch to it; the public `Logger.getContext` still returns a fresh copy each call.
5. **Memoized WS synthetic Requests**: one cached `Request` per WS route path instead of a fresh allocation per open/message/close log event.
6. **`autoRedact` identity fast path**: arrays and records materialize a clone lazily, starting at the first changed child; when nothing needs redacting the ORIGINAL reference is returned — the common no-PII case becomes a zero-allocation read-only walk. Changed branches still get new references and originals are never mutated; sibling branches keep their identity (all covered by new tests).

## Related Issues

—

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary (no docs change needed — no public API surface changed; `peekContext` is internal)

## Screenshots (if applicable)

N/A

## Additional Notes

**Bench — request-path suites** (vitest bench, same machine; read `min`/`p75`, `mean`/`hz` flip run-to-run at sub-µs scale):

| suite | min before → after | p75 before → after |
|---|---|---|
| overhead floor | 0.0034 → 0.0034 | 0.0041 → 0.0040 |
| structured sink (noop transport) | 0.0038 → 0.0036 | 0.0043 → 0.0044 |
| file sink | 0.0071 → 0.0065 | 0.0083 → 0.0077 |

Reproduced across 3 executor runs + 1 independent reviewer run. No suite regressed; a full `bun run bench` (all suites) completed clean. The gains on the default-config suites are deliberately modest — that path was already lean; the larger wins (redact identity fast path, WS Request memoization, token gating) apply to configs these suites don't exercise (`autoRedact: true`, WebSocket logging, custom formats with expensive tokens like `{ip}`).

**Verification gates** (run by executor and re-run independently by reviewer):

- `bun test` (packages/logixlysia): 196 pass / 0 fail (incl. new identity, peekContext, and token-gating tests)
- `bun run typecheck`: 5/5 green
- `bun x ultracite check`: clean
- `bun run build --filter logixlysia`: clean

**Review notes** (three deliberate deviations, all verified):

1. **`Date` values now pass through `autoRedact` by reference** instead of being defensively cloned. Dates carry no redactable content and this module never mutates them; keeping the clone would have marked every ancestor container "changed" and defeated the identity fast path for any payload containing a Date. No test pinned the old clone identity.
2. **Transports-only configs skip URL parsing** via a per-logger `needsUrlParts` gate — the executor caught (via bench) that unconditionally precomputing URL parts would have *added* a `new URL()` call to a path that never had one.
3. **Redacted `Error`s are still always constructed fresh** (exempt from the identity fast path) so consumers never receive the original stack-carrying instance by reference — documented with a comment in `redact.ts`.

Maintenance: adding a new format token now requires updating both `LOG_FORMAT_REGEX` and the token-gating checks — a NOTE comment sits on `createFormatContext`. Plans 013 (lazy pino) and 017 (emit() refactor) touch the same files and are sequenced after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved request logging efficiency by reducing repeated formatting, URL parsing, duration calculations, and context copying.
  * Optimized WebSocket event logging and redaction of unchanged data.

* **Bug Fixes**
  * Improved custom log output for timestamp and client IP fields.
  * Preserved expected object and array references when no redaction is needed.
  * Added safer handling for malformed request URLs.

* **Tests**
  * Expanded coverage for request context behavior, log formatting, and redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->