### PR TITLE
perf(logger): lazy pino construction; remove dead code

### DIFF
--- a/.changeset/lazy-pino.md
+++ b/.changeset/lazy-pino.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': patch
+---
+
+pino is now constructed lazily on first access to `store.pino`/`logger.pino` (or eagerly when `config.pino` is set), instead of on every plugin instantiation. Dead internal helpers `formatLine`, `logWithPino`, and `renderContextTreeLines` were removed (they were never exported from the package).

--- a/packages/logixlysia/__tests__/logger/create-logger.test.ts
+++ b/packages/logixlysia/__tests__/logger/create-logger.test.ts
@@ -270,6 +270,68 @@ describe('createLogger', () => {
     })
   })
 
+  test('does not call pinoFactory across console-path logging when config.pino is absent', () => {
+    const fakePinoFactory = mock(() => ({}) as Pino)
+
+    const logger = createLogger({}, fakePinoFactory as unknown as typeof pino)
+    const request = createMockRequest('http://localhost/test')
+
+    const { restore } = spyConsole()
+    logger.info(request, 'hello')
+    logger.warn(request, 'careful')
+    logger.error(request, 'oops')
+    logger.debug(request, 'trace')
+    restore()
+
+    expect(fakePinoFactory).not.toHaveBeenCalled()
+  })
+
+  test('constructs pino exactly once on first logger.pino access, not again on subsequent access', () => {
+    const fakePinoInstance = { info: mock(() => undefined) } as unknown as Pino
+    const fakePinoFactory = mock(() => fakePinoInstance)
+
+    const logger = createLogger({}, fakePinoFactory as unknown as typeof pino)
+
+    expect(fakePinoFactory).not.toHaveBeenCalled()
+
+    logger.pino.info({})
+    expect(fakePinoFactory).toHaveBeenCalledTimes(1)
+
+    logger.pino.info({})
+    expect(fakePinoFactory).toHaveBeenCalledTimes(1)
+  })
+
+  test('logger.pino.child returns a working child logger through the lazy proxy', () => {
+    const childInfo = mock(() => undefined)
+    const fakeChildLogger = { info: childInfo }
+    const fakePinoInstance = {
+      child: mock((bindings: Record<string, unknown>) => {
+        expect(bindings).toEqual({ a: 1 })
+        return fakeChildLogger
+      })
+    } as unknown as Pino
+    const fakePinoFactory = mock(() => fakePinoInstance)
+
+    const logger = createLogger({}, fakePinoFactory as unknown as typeof pino)
+
+    const child = logger.pino.child({ a: 1 })
+    child.info({ ok: true })
+
+    expect(fakePinoFactory).toHaveBeenCalledTimes(1)
+    expect(childInfo).toHaveBeenCalledTimes(1)
+  })
+
+  test('config.pino present constructs pino eagerly during createLogger', () => {
+    const fakePinoFactory = mock(() => ({}) as Pino)
+
+    createLogger(
+      { config: { pino: {} } },
+      fakePinoFactory as unknown as typeof pino
+    )
+
+    expect(fakePinoFactory).toHaveBeenCalledTimes(1)
+  })
+
   test('prettyPrint merges with default translateTime from config', () => {
     prettyOptionsCaptured = null
     const captured: { options?: any; stream?: any } = {}

--- a/packages/logixlysia/src/logger/create-logger.ts
+++ b/packages/logixlysia/src/logger/create-logger.ts
@@ -1,13 +1,7 @@
 import { STATUS_CODES } from 'node:http'
 import chalk from 'chalk'
 import { getStatusCode } from '../helpers/status'
-import type {
-  LogLevel,
-  Options,
-  Pino,
-  RequestInfo,
-  StoreData
-} from '../interfaces'
+import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
 import { isStructuredError, parseError } from '../utils/error'
 import { sanitizeLogText } from '../utils/sanitize'
 
@@ -372,20 +366,6 @@ const formatEntriesToTreeLines = (
   return lines
 }
 
-export const renderContextTreeLines = (
-  ctx: Record<string, unknown>,
-  options: Options,
-  useColors: boolean
-): string[] => {
-  const depth = options.config?.contextDepth ?? 1
-  if (depth < 1) {
-    return []
-  }
-
-  const entries = collectContextEntries(ctx, '', depth)
-  return formatEntriesToTreeLines(entries, useColors)
-}
-
 const collectStructuredErrorEntries = (error: unknown): [string, string][] => {
   const entries: [string, string][] = []
   const msg = parseError(error)
@@ -715,43 +695,4 @@ export const formatLogOutput = ({
   const contextLines = buildContextTreeLines(level, data, options, useColors)
 
   return { contextLines, main }
-}
-
-/** @deprecated Prefer {@link formatLogOutput} for multi-line context trees. Returns the main line only. */
-export const formatLine = (input: {
-  level: LogLevel
-  request: RequestInfo
-  data: Record<string, unknown>
-  store: StoreData
-  options: Options
-}): string =>
-  formatLogOutput({
-    ...input,
-    options: {
-      ...input.options,
-      config: {
-        ...input.options.config,
-        showContextTree: false
-      }
-    }
-  }).main
-
-export const logWithPino = (
-  logger: Pino,
-  level: LogLevel,
-  data: Record<string, unknown>
-): void => {
-  if (level === 'ERROR') {
-    logger.error(data)
-    return
-  }
-  if (level === 'WARNING') {
-    logger.warn(data)
-    return
-  }
-  if (level === 'DEBUG') {
-    logger.debug(data)
-    return
-  }
-  logger.info(data)
 }

--- a/packages/logixlysia/src/logger/index.ts
+++ b/packages/logixlysia/src/logger/index.ts
@@ -106,10 +106,13 @@ export const createLogger = (
       : {})
   }
 
-  let pinoLogger: Pino
-
-  if (shouldPrettyPrint) {
-    const prettyStream = pretty({
+  // Pino (and, when configured, its pino-pretty transform stream) is expensive to construct
+  // and is only ever needed when a caller explicitly reads store.pino/logger.pino or configures
+  // config.pino — the plugin's own log path writes via console.* and never touches it. Building
+  // it lazily behind a stable Proxy keeps `store.pino === logger.pino` identity while deferring
+  // the cost until first access.
+  const prettyStream = (): ReturnType<typeof pretty> =>
+    pretty({
       colorize: process.stdout?.isTTY === true,
       translateTime: config?.timestamp?.translateTime,
       ...prettyPrintOptions,
@@ -117,12 +120,37 @@ export const createLogger = (
       messageKey
     } as Record<string, unknown>)
 
-    pinoLogger = pinoFactory(basePinoOptions, prettyStream)
-  } else {
-    pinoLogger = pinoFactory({
-      ...basePinoOptions,
-      transport: pinoOptions.transport
-    })
+  let realPino: Pino | undefined
+
+  const getPino = (): Pino => {
+    if (!realPino) {
+      realPino = shouldPrettyPrint
+        ? pinoFactory(basePinoOptions, prettyStream())
+        : pinoFactory({
+            ...basePinoOptions,
+            transport: pinoOptions.transport
+          })
+    }
+    return realPino
+  }
+
+  const lazyPino = new Proxy({} as Pino, {
+    get(_target, prop) {
+      const target = getPino()
+      const value = (target as unknown as Record<string | symbol, unknown>)[
+        prop
+      ]
+      return typeof value === 'function'
+        ? (value as (...args: unknown[]) => unknown).bind(target)
+        : value
+    },
+    has: (_target, prop) => prop in (getPino() as object)
+  })
+
+  // Explicit config.pino means the user opted in to pino directly: construct eagerly so
+  // invalid options fail fast at plugin setup time, matching pre-lazy behavior.
+  if (config?.pino !== undefined) {
+    getPino()
   }
 
   const shouldLog = (level: LogLevel, logFilter?: LogFilter): boolean => {
@@ -279,7 +307,7 @@ export const createLogger = (
     mergeContext: (request, partial) => {
       contextStore.mergeContext(request, partial)
     },
-    pino: pinoLogger,
+    pino: lazyPino,
     warn: (request, message, context) => {
       logWithContext('WARNING', request, message, context)
     }


### PR DESCRIPTION
## Description

Every `logixlysia()` plugin instance used to construct a full pino logger — plus a pino-pretty transform stream under pretty-print presets — even though the plugin's own log path writes via `console.*` and never routes through pino. Pino only matters when the user explicitly configures `config.pino` or reads `store.pino`/`logger.pino`.

Two changes:

1. **Lazy pino construction** (`src/logger/index.ts`): the construction moves behind a memoized `getPino()` exposed through a stable `Proxy`, so `store.pino === logger.pino` identity holds and `.state('pino', logger.pino)` keeps working untouched. Method reads bind to the real instance (verified through `pino.child()`). The pino-pretty stream is built inside the lazy path only — never on the non-pretty branch. **Eager escape hatch preserved**: an explicit `config.pino` still constructs during `createLogger`, so invalid options fail fast at plugin setup exactly as before.
2. **Dead code removed** (`src/logger/create-logger.ts`): `renderContextTreeLines`, `formatLine` (`@deprecated`), and `logWithPino` had zero callers in `src/`, `__tests__/`, and `apps/` (they were never exported from the package barrel) and misled readers into thinking pino participates in the log path. The live `buildContextTreeLines` and its shared helpers are untouched.

Deliberately deferred (noted per plan): making the `pino`/`pino-pretty` *module imports* dynamic (`await import`) — bundler/exports interactions are riskier than the win; construction laziness captures most of the cost.

## Related Issues

—

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary (no docs change needed — `store.pino`/`logger.pino` behave identically from the user's perspective; docs wording pass is planned separately)

## Screenshots (if applicable)

N/A

## Additional Notes

**Bench — "Logger Creation: logixlysia"** (vitest bench, same machine, clean-rebuilt `dist` at each state):

| | hz | min | p75 |
|---|---|---|---|
| before (main @ 69b83aa) | 48,271 | 0.0134 | 0.0190 |
| after (this branch) | 921,784–955,915 | 0.0008 | 0.0009–0.0010 |

**~17x on `min`, ~19–21x on `p75`** — plugin instantiation no longer pays for pino + pino-pretty. Reviewer independently reproduced (837k hz, min 0.0008, p75 0.0010). The request-path suites (overhead floor / structured sink / file sink) are unchanged, as expected for a startup-only change; a full `bun run bench` completed clean.

Benchmark-methodology note: the executor's first baseline run was invalid (stale `dist/` still contained the lazy build after `git stash`), caught via `grep -c "new Proxy" dist/index.js` and redone with forced clean rebuilds at each state — the numbers above are from the corrected runs.

**Verification gates** (run by executor and re-run independently by reviewer):

- `bun test` (packages/logixlysia): 200 pass / 0 fail — including 4 new tests: no factory call across console-path logging without `config.pino`; construct-exactly-once on first `logger.pino` access; working `pino.child()` through the proxy; eager construction when `config.pino` is present
- `bun run typecheck`: 5/5 green
- `bun x ultracite check`: clean
- `bun run build --filter logixlysia`: clean

One subtle behavioral note: property reads through the proxy return a freshly bound function per access (`logger.pino.info !== logger.pino.info` by reference). No code in the repo or tests compares pino method identity; calling behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Pino logging is now initialized only when first accessed, reducing unnecessary setup for console-only logging.
  * Providing explicit Pino configuration continues to initialize logging immediately.
  * Child logger methods remain available through the deferred logger interface.

* **Cleanup**
  * Removed unused internal logging helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->