### PR TITLE
refactor(logger): one sink pipeline, shared helpers, onError hook

### DIFF
--- a/.changeset/sink-pipeline-refactor.md
+++ b/.changeset/sink-pipeline-refactor.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Internal log/error pipelines are unified: error-path logs now honor the same sink gates and console-method-by-level as success-path logs (a 4xx warning now prints via `console.warn` instead of `console.error`). New `config.onError` hook surfaces transport/file/rotation sink failures to your code.

--- a/apps/docs/content/configuration.mdx
+++ b/apps/docs/content/configuration.mdx
@@ -276,6 +276,19 @@ Disable file logging.
 disableFileLogging: true
 ```
 
+### `onError`
+
+Called when a sink (transport, file, or rotation) fails. Errors thrown by the hook itself are swallowed. When absent, failures go to stderr (rate-limited for transports).
+
+- **Type:** `(context: { sink: 'transport' | 'file' | 'rotation'; error: unknown }) => void`
+- **Default:** `undefined`
+
+```ts
+onError: ({ sink, error }) => {
+  metrics.increment(`logixlysia.sink_error.${sink}`)
+}
+```
+
 ## File Logging Options
 
 ### `logFilePath`

--- a/packages/logixlysia/__tests__/logger/handle-http-error.test.ts
+++ b/packages/logixlysia/__tests__/logger/handle-http-error.test.ts
@@ -4,6 +4,7 @@ import { Elysia, t } from 'elysia'
 import logixlysia from '../../src'
 import { HttpError, type Options } from '../../src/interfaces'
 import { normalizeLoggedError } from '../../src/utils/error'
+import { spyConsole } from '../_helpers/console'
 
 interface CapturedEvent {
   level: unknown
@@ -160,5 +161,72 @@ describe('handleHttpError', () => {
     expect(metaError.name).toBe('ValidationError')
     expect(JSON.stringify(metaError)).not.toContain('leak-me')
     expect(message).not.toContain('leak-me')
+  })
+
+  // Pins decided drift #2 from plans/017: the error path now honors the same
+  // sink gates as the success path, so `useTransportsOnly` with zero
+  // transports configured is "effectively disabled" end to end — no
+  // transport call (none configured) and no console output either.
+  test('useTransportsOnly with no transports configured emits nothing at all', async () => {
+    const { spies, restore } = spyConsole()
+    try {
+      const app = new Elysia()
+        .use(logixlysia({ config: { useTransportsOnly: true } }))
+        .get('/down', () => {
+          throw new HttpError(503, 'downstream')
+        })
+
+      const res = await app.handle(new Request('http://localhost/down'))
+
+      expect(res.status).toBe(503)
+      expect(spies.debug).not.toHaveBeenCalled()
+      expect(spies.info).not.toHaveBeenCalled()
+      expect(spies.warn).not.toHaveBeenCalled()
+      expect(spies.error).not.toHaveBeenCalled()
+      expect(spies.log).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
+  // Pins decided drift #3 from plans/017: console output is chosen by level
+  // on both paths now, so a 4xx (WARNING) error prints via console.warn
+  // instead of the previously hardcoded console.error.
+  test('a 4xx error prints via console.warn, not console.error', async () => {
+    const { spies, restore } = spyConsole()
+    try {
+      const app = new Elysia()
+        .use(logixlysia({ config: { disableFileLogging: true } }))
+        .get('/missing', () => {
+          throw new HttpError(404, 'not found')
+        })
+
+      const res = await app.handle(new Request('http://localhost/missing'))
+
+      expect(res.status).toBe(404)
+      expect(spies.warn).toHaveBeenCalledTimes(1)
+      expect(spies.error).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
+  test('a 5xx error still prints via console.error', async () => {
+    const { spies, restore } = spyConsole()
+    try {
+      const app = new Elysia()
+        .use(logixlysia({ config: { disableFileLogging: true } }))
+        .get('/down', () => {
+          throw new HttpError(503, 'downstream')
+        })
+
+      const res = await app.handle(new Request('http://localhost/down'))
+
+      expect(res.status).toBe(503)
+      expect(spies.error).toHaveBeenCalledTimes(1)
+      expect(spies.warn).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
   })
 })

--- a/packages/logixlysia/__tests__/output/file.test.ts
+++ b/packages/logixlysia/__tests__/output/file.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, mock, test } from 'bun:test'
 import { promises as fs } from 'node:fs'
 import { dirname, join } from 'node:path'
-import type { Options } from '../../src/interfaces'
+import type { Options, SinkErrorContext } from '../../src/interfaces'
 import { logToFile } from '../../src/output/file'
 import { createMockRequest } from '../_helpers/request'
 import { createTempDir, removeTempDir } from '../_helpers/tmp'
@@ -322,6 +322,43 @@ describe('logToFile', () => {
 
       const fileStat = await fs.stat(filePath)
       expect(permBits(fileStat.mode)).toBe('600')
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('invokes config.onError with sink "file" when the write fails, and swallows a throwing hook', async () => {
+    const dir = await createTempDir()
+    try {
+      // A regular file where a directory is expected: mkdir(..., {recursive:
+      // true}) fails with ENOTDIR, giving a deterministic, permission-model-
+      // independent write failure.
+      const blocker = join(dir, 'not-a-directory')
+      await fs.writeFile(blocker, 'x')
+      const filePath = join(blocker, 'nested', 'app.log')
+
+      const onError = mock((_context: SinkErrorContext) => {
+        throw new Error('hook boom')
+      })
+      const options: Options = { config: { onError } }
+
+      // The hook throwing must not crash the caller; logToFile still
+      // rejects with the original error (callers already .catch() this).
+      await expect(
+        logToFile({
+          data: { message: 'hello' },
+          filePath,
+          level: 'INFO',
+          options,
+          request: createMockRequest('http://localhost/test'),
+          store: { beforeTime: BigInt(0) }
+        })
+      ).rejects.toBeDefined()
+
+      expect(onError).toHaveBeenCalledTimes(1)
+      const [context] = onError.mock.calls[0] ?? [undefined]
+      expect(context?.sink).toBe('file')
+      expect(context?.error).toBeDefined()
     } finally {
       await removeTempDir(dir)
     }

--- a/packages/logixlysia/__tests__/output/keyed-mutex.test.ts
+++ b/packages/logixlysia/__tests__/output/keyed-mutex.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test'
+import { createKeyedMutex } from '../../src/output/keyed-mutex'
+
+describe('createKeyedMutex', () => {
+  test('same-tick acquires for the same key are never held concurrently', async () => {
+    const mutex = createKeyedMutex()
+    let holders = 0
+    let maxHolders = 0
+
+    const run = async (): Promise<void> => {
+      const release = await mutex.acquire('key')
+      holders += 1
+      maxHolders = Math.max(maxHolders, holders)
+      // Hold the lock across a macrotask window: any concurrent holder would
+      // overlap here and push `holders` above 1.
+      await new Promise(resolve => setTimeout(resolve, 5))
+      holders -= 1
+      release()
+    }
+
+    // Fire all three acquires in the same tick (no awaits between calls) so
+    // any implementation that registers its lock *after* awaiting the prior
+    // one would let same-tick callers all read the same (stale) prior lock.
+    await Promise.all([run(), run(), run()])
+
+    expect(maxHolders).toBe(1)
+  })
+
+  test('acquisitions for different keys never block each other', async () => {
+    const mutex = createKeyedMutex()
+
+    // Both resolve immediately (before either releases) because they key on
+    // different strings; a shared/global lock would make the second await hang.
+    const releaseA = await mutex.acquire('a')
+    const releaseB = await mutex.acquire('b')
+
+    releaseA()
+    releaseB()
+  })
+
+  test('release only clears the map entry when the caller is the current tail', async () => {
+    const mutex = createKeyedMutex()
+    const events: string[] = []
+
+    const releaseA = await mutex.acquire('key')
+
+    // B registers itself as the map's "current" lock for `key` synchronously
+    // inside acquire(), before it awaits A's lock.
+    const bAcquirePromise = mutex.acquire('key').then(release => {
+      events.push('B-start')
+      return release
+    })
+
+    // A releases. Because B already overwrote the map entry, A's release
+    // must NOT delete it — the map should still point at B's lock.
+    releaseA()
+    const releaseB = await bAcquirePromise
+
+    // Queue C now. If A's release had incorrectly cleared the map, C would
+    // read an empty map, treat `key` as free, and start immediately instead
+    // of chaining onto B.
+    let cStarted = false
+    const cAcquirePromise = mutex.acquire('key').then(release => {
+      cStarted = true
+      events.push('C-start')
+      return release
+    })
+
+    // Give any wrongly-unblocked C a window to (incorrectly) start.
+    await new Promise(resolve => setTimeout(resolve, 5))
+    expect(cStarted).toBe(false)
+
+    releaseB()
+    const releaseC = await cAcquirePromise
+    expect(cStarted).toBe(true)
+    releaseC()
+
+    expect(events).toEqual(['B-start', 'C-start'])
+  })
+})

--- a/packages/logixlysia/__tests__/output/transports.test.ts
+++ b/packages/logixlysia/__tests__/output/transports.test.ts
@@ -192,4 +192,51 @@ describe('logToTransports', () => {
 
     expect(rejecting).toHaveBeenCalledTimes(1)
   })
+
+  test('invokes config.onError with sink "transport" instead of the rate-limited stderr fallback, and swallows a throwing hook', () => {
+    const throwing = mock<
+      (lvl: unknown, msg: unknown, metaArg?: unknown) => void
+    >(() => {
+      throw new Error('boom')
+    })
+    const onError = mock((_context: unknown) => {
+      throw new Error('hook boom')
+    })
+
+    const options: Options = {
+      config: { onError, transports: [{ log: throwing }] }
+    }
+    const request = createMockRequest('http://localhost/throw')
+    const store = { beforeTime: BigInt(0) }
+
+    expect(() => {
+      logToTransports({
+        data: { message: 'ignored' },
+        level: 'INFO',
+        options,
+        request,
+        store
+      })
+    }).not.toThrow()
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    const [context] = onError.mock.calls[0] ?? [undefined]
+    const { sink, error } = (context ?? {}) as {
+      error?: unknown
+      sink?: unknown
+    }
+    expect(sink).toBe('transport')
+    expect(error).toBeDefined()
+
+    // A second immediate failure still invokes the hook (unlike the stderr
+    // fallback, onError is not rate-limited: the hook owns its own policy).
+    logToTransports({
+      data: { message: 'ignored again' },
+      level: 'INFO',
+      options,
+      request,
+      store
+    })
+    expect(onError).toHaveBeenCalledTimes(2)
+  })
 })

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -65,6 +65,12 @@ export type PrettyPrintConfig = boolean | Record<string, unknown>
 
 export type LogPreset = 'dev' | 'prod' | 'json'
 
+/** Context passed to {@link Options.config.onError} when a sink fails. */
+export interface SinkErrorContext {
+  error: unknown
+  sink: 'file' | 'rotation' | 'transport'
+}
+
 export interface RequestIdConfig {
   /**
    * Enable request ID generation.
@@ -161,6 +167,13 @@ export interface Options {
      * @default false
      */
     logErrorPayload?: boolean
+
+    /**
+     * Called when a sink (transport, file, rotation) fails. Errors thrown by
+     * the hook itself are swallowed. When absent, failures go to stderr
+     * (rate-limited for transports).
+     */
+    onError?: (context: SinkErrorContext) => void
 
     // Pino
     pino?: (PinoLoggerOptions & { prettyPrint?: PrettyPrintConfig }) | undefined

--- a/packages/logixlysia/src/logger/emit.ts
+++ b/packages/logixlysia/src/logger/emit.ts
@@ -1,0 +1,225 @@
+import {
+  mergeLogDataContext,
+  type RequestContextStore
+} from '../context/request-context'
+import type {
+  LogFilter,
+  LogLevel,
+  Options,
+  RequestInfo,
+  StoreData
+} from '../interfaces'
+import { logToTransports } from '../output'
+import { logToFile } from '../output/file'
+import { redact, redactRequest } from '../utils/redact'
+import {
+  type FormatContext,
+  formatLogOutput,
+  type PrecomputedLogParts
+} from './create-logger'
+
+/**
+ * Which sinks are active for a given config, resolved once per logger
+ * instance (see `createLogger`) since none of these depend on per-request
+ * state.
+ */
+export interface Sinks {
+  hasFileLogging: boolean
+  hasInternalLogger: boolean
+  hasTransports: boolean
+  /** True when no sink is active at all: `log()`/`handleHttpError()` can skip all work. */
+  isEffectivelyDisabled: boolean
+  /** True when at least one active sink reads pathname/search (file logging or the console formatter). */
+  needsUrlParts: boolean
+}
+
+export const resolveSinks = (config: Options['config']): Sinks => {
+  const useTransportsOnly = config?.useTransportsOnly === true
+  const disableInternalLogger = config?.disableInternalLogger === true
+  const disableFileLogging = config?.disableFileLogging === true
+
+  const hasTransports = (config?.transports?.length ?? 0) > 0
+  const hasFileLogging =
+    !(useTransportsOnly || disableFileLogging) && !!config?.logFilePath
+  const hasInternalLogger = !(useTransportsOnly || disableInternalLogger)
+  const isEffectivelyDisabled = !(
+    hasTransports ||
+    hasFileLogging ||
+    hasInternalLogger
+  )
+  const needsUrlParts = hasFileLogging || hasInternalLogger
+
+  return {
+    hasFileLogging,
+    hasInternalLogger,
+    hasTransports,
+    isEffectivelyDisabled,
+    needsUrlParts
+  }
+}
+
+export const shouldLog = (level: LogLevel, logFilter?: LogFilter): boolean => {
+  if (!logFilter?.level || logFilter.level.length === 0) {
+    return true
+  }
+  return logFilter.level.includes(level)
+}
+
+const computeDurationMs = (store: StoreData): number =>
+  store.beforeTime === BigInt(0)
+    ? 0
+    : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000
+
+/** Parses the URL once; only called when at least one active sink reads pathname/search. */
+const parseRequestUrlOnce = (
+  request: RequestInfo
+): { pathname: string; search: string } => {
+  try {
+    const { pathname, search } = new URL(request.url)
+    return { pathname, search }
+  } catch {
+    return { pathname: request.url || '/', search: '' }
+  }
+}
+
+/**
+ * Samples duration and parses the URL once per emission for the sinks that will actually run.
+ * `logToTransports`' meta only reads `durationMs` (not pathname/search), so the URL is parsed
+ * only when file logging or the internal console logger is active — skipping it entirely for
+ * transports-only configs, matching that path's pre-optimization behavior.
+ */
+export const computePrecomputedLogParts = (
+  store: StoreData,
+  request: RequestInfo,
+  needsUrlParts: boolean
+): PrecomputedLogParts => {
+  const durationMs = computeDurationMs(store)
+  const { pathname, search } = needsUrlParts
+    ? parseRequestUrlOnce(request)
+    : { pathname: '', search: '' }
+
+  return { durationMs, pathname, search }
+}
+
+const consoleForLevel = (level: LogLevel): typeof console.log => {
+  switch (level) {
+    case 'DEBUG': {
+      return console.debug
+    }
+    case 'INFO': {
+      return console.info
+    }
+    case 'WARNING': {
+      return console.warn
+    }
+    case 'ERROR': {
+      return console.error
+    }
+    default: {
+      return console.log
+    }
+  }
+}
+
+export interface EmitInput {
+  /** Shared per-request context bag (peeked, never cloned/retained). */
+  contextStore: RequestContextStore
+  data: Record<string, unknown>
+  /** Hoisted per-logger constants for `formatLogOutput`; only read when the internal console logger is active. */
+  formatContext: FormatContext
+  level: LogLevel
+  options: Options
+  request: RequestInfo
+  /** Hoisted per-logger sink gates from {@link resolveSinks}. */
+  sinks: Sinks
+  store: StoreData
+}
+
+/**
+ * The single log-emission pipeline shared by the success path (`log()`) and
+ * the error path (`handleHttpError()`): filter check -> context merge ->
+ * redact -> transports -> file -> console, all gated by the same `sinks`.
+ */
+export const emit = ({
+  contextStore,
+  data,
+  formatContext,
+  level,
+  options,
+  request,
+  sinks,
+  store
+}: EmitInput): void => {
+  const { config } = options
+
+  if (sinks.isEffectivelyDisabled || !shouldLog(level, config?.logFilter)) {
+    return
+  }
+
+  const dataWithContext = mergeLogDataContext(
+    data,
+    // mergeLogDataContext only reads/spreads this bag into a new object; it never retains
+    // the reference, so a non-cloning peek is safe here.
+    contextStore.peekContext(request)
+  )
+  const logData =
+    config?.autoRedact === true
+      ? redact(dataWithContext, config?.redactKeys)
+      : dataWithContext
+  const logRequest =
+    config?.autoRedact === true
+      ? redactRequest(request, config?.redactKeys)
+      : request
+
+  const precomputed = computePrecomputedLogParts(
+    store,
+    logRequest,
+    sinks.needsUrlParts
+  )
+
+  if (sinks.hasTransports) {
+    logToTransports({
+      data: logData,
+      level,
+      options,
+      precomputed,
+      request: logRequest,
+      store
+    })
+  }
+
+  if (sinks.hasFileLogging) {
+    const filePath = config?.logFilePath
+    if (filePath) {
+      logToFile({
+        data: logData,
+        filePath,
+        level,
+        options,
+        precomputed,
+        request: logRequest,
+        store
+      }).catch(() => {
+        /* Ignore errors: file.ts already reported them (console.error or config.onError). */
+      })
+    }
+  }
+
+  if (!sinks.hasInternalLogger) {
+    return
+  }
+
+  const { main, contextLines } = formatLogOutput({
+    data: logData,
+    formatContext,
+    level,
+    options,
+    precomputed,
+    request: logRequest,
+    store
+  })
+  const message =
+    contextLines.length > 0 ? `${main}\n${contextLines.join('\n')}` : main
+
+  consoleForLevel(level)(message)
+}

--- a/packages/logixlysia/src/logger/handle-http-error.ts
+++ b/packages/logixlysia/src/logger/handle-http-error.ts
@@ -1,13 +1,8 @@
-import {
-  mergeLogDataContext,
-  type RequestContextStore
-} from '../context/request-context'
+import type { RequestContextStore } from '../context/request-context'
 import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
-import { logToTransports } from '../output'
-import { logToFile } from '../output/file'
 import { normalizeLoggedError } from '../utils/error'
-import { redact, redactRequest } from '../utils/redact'
-import { formatLogOutput } from './create-logger'
+import type { FormatContext } from './create-logger'
+import { emit, type Sinks, shouldLog } from './emit'
 
 const isErrorWithStatus = (
   value: unknown
@@ -22,28 +17,22 @@ export const handleHttpError = (
   error: unknown,
   store: StoreData,
   options: Options,
-  contextStore?: RequestContextStore
+  contextStore: RequestContextStore,
+  sinks: Sinks,
+  formatContext: FormatContext
 ): void => {
   const { config } = options
 
   const status = isErrorWithStatus(error) ? error.status : 500
-  let level: LogLevel = 'ERROR'
-  if (status < 500 && status >= 400) {
-    level = 'WARNING'
-  }
+  const level: LogLevel = status >= 400 && status < 500 ? 'WARNING' : 'ERROR'
 
-  const logFilter = config?.logFilter
-  if (
-    logFilter?.level &&
-    logFilter.level.length > 0 &&
-    !logFilter.level.includes(level)
-  ) {
+  // Mirrors emit()'s own gate check, but performed *before* normalizing the
+  // error so a filtered-out/disabled logger never pays for that work.
+  // emit() re-checks the same gate, which is cheap and keeps this function a
+  // thin, provably-correct wrapper around the shared pipeline.
+  if (sinks.isEffectivelyDisabled || !shouldLog(level, config?.logFilter)) {
     return
   }
-
-  const useTransportsOnly = config?.useTransportsOnly === true
-  const disableInternalLogger = config?.disableInternalLogger === true
-  const disableFileLogging = config?.disableFileLogging === true
 
   const { error: safeError, message } = normalizeLoggedError(
     error,
@@ -51,51 +40,15 @@ export const handleHttpError = (
   )
 
   const data: Record<string, unknown> = { error: safeError, message, status }
-  const dataWithContext = contextStore
-    ? // mergeLogDataContext only reads/spreads this bag into a new object; it never retains
-      // the reference, so a non-cloning peek is safe here.
-      mergeLogDataContext(data, contextStore.peekContext(request))
-    : data
-  const logData =
-    config?.autoRedact === true
-      ? redact(dataWithContext, config?.redactKeys)
-      : dataWithContext
-  const logRequest =
-    config?.autoRedact === true
-      ? redactRequest(request, config?.redactKeys)
-      : request
 
-  logToTransports({ data: logData, level, options, request: logRequest, store })
-
-  if (!(useTransportsOnly || disableFileLogging)) {
-    const filePath = config?.logFilePath
-    if (filePath) {
-      logToFile({
-        data: logData,
-        filePath,
-        level,
-        options,
-        request: logRequest,
-        store
-      }).catch(() => {
-        // Ignore errors
-      })
-    }
-  }
-
-  if (useTransportsOnly || disableInternalLogger) {
-    return
-  }
-
-  const { main, contextLines } = formatLogOutput({
-    data: logData,
+  emit({
+    contextStore,
+    data,
+    formatContext,
     level,
     options,
-    request: logRequest,
+    request,
+    sinks,
     store
   })
-
-  const formattedMessage =
-    contextLines.length > 0 ? `${main}\n${contextLines.join('\n')}` : main
-  console.error(formattedMessage)
 }

--- a/packages/logixlysia/src/logger/index.ts
+++ b/packages/logixlysia/src/logger/index.ts
@@ -2,11 +2,9 @@ import pino from 'pino'
 import pretty from 'pino-pretty'
 import {
   createRequestContextStore,
-  mergeLogDataContext,
   type RequestContextStore
 } from '../context/request-context'
 import type {
-  LogFilter,
   Logger,
   LogLevel,
   Options,
@@ -14,51 +12,10 @@ import type {
   RequestInfo,
   StoreData
 } from '../interfaces'
-import { logToTransports } from '../output'
-import { logToFile } from '../output/file'
-import { buildPinoRedactPaths, redact, redactRequest } from '../utils/redact'
-import {
-  createFormatContext,
-  formatLogOutput,
-  type PrecomputedLogParts
-} from './create-logger'
+import { buildPinoRedactPaths } from '../utils/redact'
+import { createFormatContext } from './create-logger'
+import { emit, resolveSinks, shouldLog } from './emit'
 import { handleHttpError } from './handle-http-error'
-
-const computeDurationMs = (store: StoreData): number =>
-  store.beforeTime === BigInt(0)
-    ? 0
-    : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000
-
-/** Parses the URL once; only called when at least one active sink reads pathname/search. */
-const parseRequestUrlOnce = (
-  request: RequestInfo
-): { pathname: string; search: string } => {
-  try {
-    const { pathname, search } = new URL(request.url)
-    return { pathname, search }
-  } catch {
-    return { pathname: request.url || '/', search: '' }
-  }
-}
-
-/**
- * Samples duration and parses the URL once per emission for the sinks that will actually run.
- * `logToTransports`' meta only reads `durationMs` (not pathname/search), so the URL is parsed
- * only when file logging or the internal console logger is active — skipping it entirely for
- * transports-only configs, matching that path's pre-optimization behavior.
- */
-const computePrecomputedLogParts = (
-  store: StoreData,
-  request: RequestInfo,
-  needsUrlParts: boolean
-): PrecomputedLogParts => {
-  const durationMs = computeDurationMs(store)
-  const { pathname, search } = needsUrlParts
-    ? parseRequestUrlOnce(request)
-    : { pathname: '', search: '' }
-
-  return { durationMs, pathname, search }
-}
 
 export const createLogger = (
   options: Options = {},
@@ -153,29 +110,8 @@ export const createLogger = (
     getPino()
   }
 
-  const shouldLog = (level: LogLevel, logFilter?: LogFilter): boolean => {
-    if (!logFilter?.level || logFilter.level.length === 0) {
-      return true
-    }
-    return logFilter.level.includes(level)
-  }
-
-  const useTransportsOnly = config?.useTransportsOnly === true
-  const disableInternalLogger = config?.disableInternalLogger === true
-  const disableFileLogging = config?.disableFileLogging === true
-
-  const hasTransports = (config?.transports?.length ?? 0) > 0
-  const hasFileLogging =
-    !(useTransportsOnly || disableFileLogging) && !!config?.logFilePath
-  const hasInternalLogger = !(useTransportsOnly || disableInternalLogger)
-  const isEffectivelyDisabled = !(
-    hasTransports ||
-    hasFileLogging ||
-    hasInternalLogger
-  )
-  // Only file logging and the internal console formatter read pathname/search; transports'
-  // meta only reads durationMs, so skip the URL parse entirely when they're the only sink.
-  const needsUrlParts = hasFileLogging || hasInternalLogger
+  // Resolved once per logger instance: none of these depend on per-request state.
+  const sinks = resolveSinks(config)
 
   const log = (
     level: LogLevel,
@@ -183,97 +119,16 @@ export const createLogger = (
     data: Record<string, unknown>,
     store: StoreData
   ): void => {
-    if (isEffectivelyDisabled || !shouldLog(level, config?.logFilter)) {
-      return
-    }
-
-    const dataWithContext = mergeLogDataContext(
+    emit({
+      contextStore,
       data,
-      // mergeLogDataContext only reads/spreads this bag into a new object; it never retains
-      // the reference, so a non-cloning peek is safe here.
-      contextStore.peekContext(request)
-    )
-    const logData =
-      config?.autoRedact === true
-        ? redact(dataWithContext, config?.redactKeys)
-        : dataWithContext
-    const logRequest =
-      config?.autoRedact === true
-        ? redactRequest(request, config?.redactKeys)
-        : request
-
-    const precomputed = computePrecomputedLogParts(
-      store,
-      logRequest,
-      needsUrlParts
-    )
-
-    if (hasTransports) {
-      logToTransports({
-        data: logData,
-        level,
-        options,
-        precomputed,
-        request: logRequest,
-        store
-      })
-    }
-
-    if (hasFileLogging) {
-      const filePath = config?.logFilePath
-      if (filePath) {
-        logToFile({
-          data: logData,
-          filePath,
-          level,
-          options,
-          precomputed,
-          request: logRequest,
-          store
-        }).catch(() => {
-          /* Ignore errors */
-        })
-      }
-    }
-
-    if (!hasInternalLogger) {
-      return
-    }
-
-    const { main, contextLines } = formatLogOutput({
-      data: logData,
       formatContext,
       level,
       options,
-      precomputed,
-      request: logRequest,
+      request,
+      sinks,
       store
     })
-    const message =
-      contextLines.length > 0 ? `${main}\n${contextLines.join('\n')}` : main
-
-    switch (level) {
-      case 'DEBUG': {
-        console.debug(message)
-        break
-      }
-      case 'INFO': {
-        console.info(message)
-        break
-      }
-      case 'WARNING': {
-        console.warn(message)
-        break
-      }
-      case 'ERROR': {
-        console.error(message)
-        break
-      }
-      default: {
-        console.log(message)
-        break
-      }
-    }
   }
 
   const logWithContext = (
@@ -282,7 +137,7 @@ export const createLogger = (
     message: string,
     context?: Record<string, unknown>
   ): void => {
-    if (isEffectivelyDisabled || !shouldLog(level, config?.logFilter)) {
+    if (sinks.isEffectivelyDisabled || !shouldLog(level, config?.logFilter)) {
       return
     }
     const store: StoreData = { beforeTime: process.hrtime.bigint() }
@@ -298,7 +153,15 @@ export const createLogger = (
     },
     getContext: request => contextStore.getContext(request),
     handleHttpError: (request, error, store) => {
-      handleHttpError(request, error, store, options, contextStore)
+      handleHttpError(
+        request,
+        error,
+        store,
+        options,
+        contextStore,
+        sinks,
+        formatContext
+      )
     },
     info: (request, message, context) => {
       logWithContext('INFO', request, message, context)

--- a/packages/logixlysia/src/output/file-sink.ts
+++ b/packages/logixlysia/src/output/file-sink.ts
@@ -10,6 +10,8 @@ export interface FileSinkOptions {
   logDirMode?: number
   logFileMode?: number
   logRotation?: LogRotationConfig
+  /** Reports a rotation-sink failure; falls back to a stderr line when omitted. */
+  onRotationError?: (error: unknown) => void
 }
 
 export interface FileSink {
@@ -128,14 +130,18 @@ class FileSinkImpl implements FileSink {
       this.handle = null
       this.bytesWritten = 0
       await handle?.close()
-      await performRotation(this.filePath, rotation)
+      await performRotation(this.filePath, rotation, options.onRotationError)
     } catch (error) {
       // Log entries were already durably written and resolved above;
       // rotation failures must not fail the caller's write.
-      console.error(
-        `[logixlysia] Failed to rotate log file ${this.filePath}:`,
-        error
-      )
+      if (options.onRotationError) {
+        options.onRotationError(error)
+      } else {
+        console.error(
+          `[logixlysia] Failed to rotate log file ${this.filePath}:`,
+          error
+        )
+      }
     }
   }
 

--- a/packages/logixlysia/src/output/file.ts
+++ b/packages/logixlysia/src/output/file.ts
@@ -1,4 +1,10 @@
-import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
+import type {
+  LogLevel,
+  Options,
+  RequestInfo,
+  SinkErrorContext,
+  StoreData
+} from '../interfaces'
 import { sanitizeLogText } from '../utils/sanitize'
 import { getFileSink } from './file-sink'
 
@@ -13,47 +19,46 @@ interface LogToFileInput {
   store: StoreData
 }
 
-export const logToFile = async (
-  ...args:
-    | [LogToFileInput]
-    | [
-        string,
-        LogLevel,
-        RequestInfo,
-        Record<string, unknown>,
-        StoreData,
-        Options
-      ]
-): Promise<void> => {
-  const input: LogToFileInput =
-    typeof args[0] === 'string'
-      ? (() => {
-          const [
-            filePathArg,
-            levelArg,
-            requestArg,
-            dataArg,
-            storeArg,
-            optionsArg
-          ] = args as [
-            string,
-            LogLevel,
-            RequestInfo,
-            Record<string, unknown>,
-            StoreData,
-            Options
-          ]
-          return {
-            data: dataArg,
-            filePath: filePathArg,
-            level: levelArg,
-            options: optionsArg,
-            request: requestArg,
-            store: storeArg
-          }
-        })()
-      : args[0]
+/** Resolves the logged pathname (with query string when configured) from precomputed parts or a fresh parse. */
+const resolvePathname = (
+  request: RequestInfo,
+  logQueryParams: boolean | undefined,
+  precomputed?: { pathname: string; search: string }
+): string => {
+  if (precomputed) {
+    const { pathname, search } = precomputed
+    return logQueryParams ? `${pathname}${search}` : pathname
+  }
+  try {
+    // Safely parse URL to avoid crashes on malformed URLs
+    const { pathname, search } = new URL(request.url)
+    return logQueryParams ? `${pathname}${search}` : pathname
+  } catch {
+    // Fallback to raw URL if parsing fails
+    return request.url
+  }
+}
 
+/** Reports a sink failure via `config.onError` when set (swallowing hook errors), else stderr. */
+const reportSinkError = (
+  config: Options['config'],
+  sink: SinkErrorContext['sink'],
+  fallbackMessage: string,
+  error: unknown
+): void => {
+  const onError = config?.onError
+  if (!onError) {
+    console.error(fallbackMessage, error)
+    return
+  }
+  try {
+    onError({ error, sink })
+  } catch {
+    // Swallow errors thrown by the hook itself.
+  }
+}
+
+export const logToFile = async (input: LogToFileInput): Promise<void> => {
   const { filePath, level, request, data, store, options, precomputed } = input
   const { config } = options
   const useTransportsOnly = config?.useTransportsOnly === true
@@ -69,34 +74,24 @@ export const logToFile = async (
       ? 0
       : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000)
 
-  let pathname = '/'
-  if (precomputed) {
-    const { pathname: rawPathname, search } = precomputed
-    pathname = config?.logQueryParams ? `${rawPathname}${search}` : rawPathname
-  } else {
-    // Safely parse URL to avoid crashes on malformed URLs
-    try {
-      const { pathname: rawPathname, search } = new URL(request.url)
-      pathname = config?.logQueryParams
-        ? `${rawPathname}${search}`
-        : rawPathname
-    } catch {
-      // Fallback to raw URL if parsing fails
-      pathname = request.url
-    }
-  }
-
+  const pathname = resolvePathname(request, config?.logQueryParams, precomputed)
   const line = `${level} ${durationMs.toFixed(2)}ms ${request.method} ${sanitizeLogText(pathname, 1024)} ${sanitizeLogText(message)}\n`
+
+  const onRotationError = config?.onError
+    ? (error: unknown) => reportSinkError(config, 'rotation', '', error)
+    : undefined
 
   try {
     await getFileSink(filePath).write(line, {
       logDirMode: config?.logDirMode,
       logFileMode: config?.logFileMode,
-      logRotation: config?.logRotation
+      logRotation: config?.logRotation,
+      onRotationError
     })
   } catch (error) {
-    // Log file write errors to stderr so they're not completely silent
-    console.error(
+    reportSinkError(
+      config,
+      'file',
       `[logixlysia] Failed to write to log file ${filePath}:`,
       error
     )

--- a/packages/logixlysia/src/output/index.ts
+++ b/packages/logixlysia/src/output/index.ts
@@ -1,9 +1,26 @@
-import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
+import type {
+  LogLevel,
+  Options,
+  RequestInfo,
+  SinkErrorContext,
+  StoreData
+} from '../interfaces'
 
 let lastTransportErrorAt = 0
 const TRANSPORT_ERROR_INTERVAL_MS = 5000
 
-const reportTransportError = (error: unknown): void => {
+const reportTransportError = (
+  error: unknown,
+  onError?: (context: SinkErrorContext) => void
+): void => {
+  if (onError) {
+    try {
+      onError({ error, sink: 'transport' })
+    } catch {
+      // Swallow errors thrown by the hook itself.
+    }
+    return
+  }
   const now = Date.now()
   if (now - lastTransportErrorAt < TRANSPORT_ERROR_INTERVAL_MS) {
     return
@@ -22,27 +39,13 @@ interface LogToTransportsInput {
   store: StoreData
 }
 
-export const logToTransports = (
-  ...args:
-    | [LogToTransportsInput]
-    | [LogLevel, RequestInfo, Record<string, unknown>, StoreData, Options]
-): void => {
-  const input: LogToTransportsInput =
-    typeof args[0] === 'string'
-      ? {
-          data: args[2],
-          level: args[0],
-          options: args[4],
-          request: args[1],
-          store: args[3]
-        }
-      : args[0]
-
+export const logToTransports = (input: LogToTransportsInput): void => {
   const { level, request, data, store, options, precomputed } = input
   const transports = options.config?.transports ?? []
   if (transports.length === 0) {
     return
   }
+  const onError = options.config?.onError
 
   const message = typeof data.message === 'string' ? data.message : ''
   const meta: Record<string, unknown> = {
@@ -65,10 +68,12 @@ export const logToTransports = (
         result &&
         typeof (result as { catch?: unknown }).catch === 'function'
       ) {
-        ;(result as Promise<void>).catch(reportTransportError)
+        ;(result as Promise<void>).catch(error =>
+          reportTransportError(error, onError)
+        )
       }
     } catch (error) {
-      reportTransportError(error)
+      reportTransportError(error, onError)
     }
   }
 }

--- a/packages/logixlysia/src/output/keyed-mutex.ts
+++ b/packages/logixlysia/src/output/keyed-mutex.ts
@@ -1,0 +1,41 @@
+export interface KeyedMutex {
+  /**
+   * Serializes work for `key`: resolves once any prior holder for the same
+   * key has released, and returns a release function the caller MUST call
+   * exactly once to hand the lock to the next waiter (if any).
+   */
+  acquire: (key: string) => Promise<() => void>
+}
+
+/**
+ * Creates an independent keyed mutex: acquisitions for different keys never
+ * block each other, while acquisitions for the same key are serialized in
+ * FIFO order.
+ */
+export const createKeyedMutex = (): KeyedMutex => {
+  const locks = new Map<string, Promise<void>>()
+
+  const acquire = async (key: string): Promise<() => void> => {
+    const prior = locks.get(key) ?? Promise.resolve()
+
+    let release: () => void
+    const current = new Promise<void>(resolve => {
+      release = resolve
+    })
+
+    // Register before awaiting: same-tick callers must chain onto THIS lock,
+    // not the one that was current when they called acquire().
+    locks.set(key, current)
+
+    await prior
+
+    return () => {
+      release?.()
+      if (locks.get(key) === current) {
+        locks.delete(key)
+      }
+    }
+  }
+
+  return { acquire }
+}

--- a/packages/logixlysia/src/output/rotation-manager.ts
+++ b/packages/logixlysia/src/output/rotation-manager.ts
@@ -188,5 +188,7 @@ export const performRotation = async (
     await cleanupRotated(filePath, retention, onError)
   }
 
-  // Optional interval-based rotation cleanup (create interval directories / naming) is not required by tests.
+  // `config.interval` (fixed-interval rotation, e.g. '1d'/'12h') is not
+  // implemented here: rotation is currently only triggered by `maxSize`
+  // (see `FileSinkImpl.maybeRotate` in file-sink.ts).
 }

--- a/packages/logixlysia/src/output/rotation-manager.ts
+++ b/packages/logixlysia/src/output/rotation-manager.ts
@@ -8,33 +8,26 @@ import {
   parseSize,
   shouldRotateBySize
 } from '../utils/rotation'
+import { createKeyedMutex } from './keyed-mutex'
 
 const gzipAsync = promisify(gzip)
 
-// Compression lock to prevent concurrent compression of the same file
-const compressionLocks = new Map<string, Promise<void>>()
+// Prevents concurrent compression of the same file (keyed by filePath).
+const compressionLock = createKeyedMutex()
 
-const acquireCompressionLock = async (
-  filePath: string
-): Promise<() => void> => {
-  const prior = compressionLocks.get(filePath) ?? Promise.resolve()
+/** Reports a sink failure; when omitted, the caller falls back to stderr. */
+export type RotationErrorReporter = (error: unknown) => void
 
-  let resolveLock: () => void
-  const newLock = new Promise<void>(resolve => {
-    resolveLock = resolve
-  })
-
-  // Register before awaiting: same-tick callers must chain onto THIS lock.
-  compressionLocks.set(filePath, newLock)
-
-  await prior
-
-  return () => {
-    resolveLock?.()
-    if (compressionLocks.get(filePath) === newLock) {
-      compressionLocks.delete(filePath)
-    }
+const reportRotationError = (
+  message: string,
+  error: unknown,
+  onError?: RotationErrorReporter
+): void => {
+  if (onError) {
+    onError(error)
+    return
   }
+  console.error(message, error)
 }
 
 const pad2 = (value: number): string => String(value).padStart(2, '0')
@@ -66,8 +59,11 @@ export const rotateFile = async (filePath: string): Promise<string> => {
   return rotated
 }
 
-export const compressFile = async (filePath: string): Promise<void> => {
-  const release = await acquireCompressionLock(filePath)
+export const compressFile = async (
+  filePath: string,
+  onError?: RotationErrorReporter
+): Promise<void> => {
+  const release = await compressionLock.acquire(filePath)
   try {
     // Check if file still exists (might have been compressed by another process)
     try {
@@ -82,7 +78,11 @@ export const compressFile = async (filePath: string): Promise<void> => {
     await fs.writeFile(`${filePath}.gz`, compressed)
     await fs.rm(filePath, { force: true })
   } catch (error) {
-    console.error(`[logixlysia] Failed to compress file ${filePath}:`, error)
+    reportRotationError(
+      `[logixlysia] Failed to compress file ${filePath}:`,
+      error,
+      onError
+    )
     throw error
   } finally {
     release()
@@ -100,12 +100,31 @@ export const shouldRotate = async (
   return await shouldRotateBySize(filePath, maxSize)
 }
 
-const cleanupByCount = async (
+interface FileStat {
+  path: string
+  stat: import('node:fs').Stats
+}
+
+const isFulfilled = <T>(
+  result: PromiseSettledResult<T>
+): result is PromiseFulfilledResult<T> => result.status === 'fulfilled'
+
+/**
+ * Deletes rotated files beyond `retention`: for `'count'`, keeps the newest
+ * `retention.value` files (by mtime); for `'time'`, deletes files older than
+ * `retention.value` ms. Individual stat/delete failures are tolerated (via
+ * `allSettled`) so one bad file never blocks cleanup of the rest.
+ */
+const cleanupRotated = async (
   filePath: string,
-  maxFiles: number
+  retention: { type: 'count' | 'time'; value: number },
+  onError?: RotationErrorReporter
 ): Promise<void> => {
   const rotated = await getRotatedFiles(filePath)
-  if (rotated.length <= maxFiles) {
+  if (rotated.length === 0) {
+    return
+  }
+  if (retention.type === 'count' && rotated.length <= retention.value) {
     return
   }
 
@@ -115,69 +134,19 @@ const cleanupByCount = async (
   )
 
   // Extract successful stats, ignore files that were deleted concurrently
-  const stats = statsResults
-    .filter(
-      (
-        result
-      ): result is PromiseFulfilledResult<{
-        path: string
-        stat: import('node:fs').Stats
-      }> => result.status === 'fulfilled'
-    )
-    .map(result => result.value)
+  const stats = statsResults.filter(isFulfilled<FileStat>).map(r => r.value)
 
-  if (stats.length <= maxFiles) {
-    return
-  }
-
-  stats.sort((a, b) => b.stat.mtimeMs - a.stat.mtimeMs)
-  const toDelete = stats.slice(maxFiles)
-
-  // Delete files individually, continuing even if some fail
-  const deleteResults = await Promise.allSettled(
-    toDelete.map(({ path }) => fs.rm(path, { force: true }))
-  )
-
-  // Log failures but don't crash
-  deleteResults.forEach((result, idx) => {
-    if (result.status === 'rejected') {
-      console.error(
-        `[logixlysia] Failed to delete rotated log ${toDelete[idx].path}:`,
-        result.reason
-      )
+  let toDelete: FileStat[]
+  if (retention.type === 'count') {
+    if (stats.length <= retention.value) {
+      return
     }
-  })
-}
-
-const cleanupByTime = async (
-  filePath: string,
-  maxAgeMs: number
-): Promise<void> => {
-  const rotated = await getRotatedFiles(filePath)
-  if (rotated.length === 0) {
-    return
+    stats.sort((a, b) => b.stat.mtimeMs - a.stat.mtimeMs)
+    toDelete = stats.slice(retention.value)
+  } else {
+    const now = Date.now()
+    toDelete = stats.filter(({ stat }) => now - stat.mtimeMs > retention.value)
   }
-
-  const now = Date.now()
-
-  // Use Promise.allSettled to handle individual file stat failures gracefully
-  const statsResults = await Promise.allSettled(
-    rotated.map(async p => ({ path: p, stat: await fs.stat(p) }))
-  )
-
-  // Extract successful stats
-  const stats = statsResults
-    .filter(
-      (
-        result
-      ): result is PromiseFulfilledResult<{
-        path: string
-        stat: import('node:fs').Stats
-      }> => result.status === 'fulfilled'
-    )
-    .map(result => result.value)
-
-  const toDelete = stats.filter(({ stat }) => now - stat.mtimeMs > maxAgeMs)
 
   // Delete files individually, continuing even if some fail
   const deleteResults = await Promise.allSettled(
@@ -187,9 +156,10 @@ const cleanupByTime = async (
   // Log failures but don't crash
   deleteResults.forEach((result, idx) => {
     if (result.status === 'rejected') {
-      console.error(
-        `[logixlysia] Failed to delete old log ${toDelete[idx].path}:`,
-        result.reason
+      reportRotationError(
+        `[logixlysia] Failed to delete rotated log ${toDelete[idx].path}:`,
+        result.reason,
+        onError
       )
     }
   })
@@ -197,7 +167,8 @@ const cleanupByTime = async (
 
 export const performRotation = async (
   filePath: string,
-  config: LogRotationConfig
+  config: LogRotationConfig,
+  onError?: RotationErrorReporter
 ): Promise<void> => {
   const rotated = await rotateFile(filePath)
   if (!rotated) {
@@ -208,17 +179,13 @@ export const performRotation = async (
   if (shouldCompress) {
     const algo = config.compression ?? 'gzip'
     if (algo === 'gzip') {
-      await compressFile(rotated)
+      await compressFile(rotated, onError)
     }
   }
 
   if (config.maxFiles !== undefined) {
     const retention = parseRetention(config.maxFiles)
-    if (retention.type === 'count') {
-      await cleanupByCount(filePath, retention.value)
-    } else {
-      await cleanupByTime(filePath, retention.value)
-    }
+    await cleanupRotated(filePath, retention, onError)
   }
 
   // Optional interval-based rotation cleanup (create interval directories / naming) is not required by tests.


### PR DESCRIPTION
## Description

Unifies the drifted success-path (`log()`) and error-path (`handleHttpError`) logging pipelines into a single `emit()`, extracts shared helpers, and adds a `config.onError` hook — per `plans/017-sink-pipeline-refactor.md`.

**The problem**: both paths implemented the same pipeline (filter → context merge → redact → transports → file → console) by copy, and the copies had drifted: the error path called `logToTransports` unconditionally, ignored `isEffectivelyDisabled`, hardcoded `console.error`, and never threaded the precomputed duration/URL parts (paying a second URL parse per error). Every fix on one path had to be made twice.

**What changed** (4 commits):

1. `refactor(output): extract keyed-mutex and unify rotation cleanup` — the register-before-await keyed mutex now lives in `src/output/keyed-mutex.ts` with direct deterministic unit tests (closing a known gap from #350, whose fs-based exclusion test couldn't expose the historical same-tick race — the new test provably does: temporarily reverting the register-before-await ordering makes it fail with `maxHolders = 3`). `cleanupByCount`/`cleanupByTime` (~80 duplicated lines) merged into one `cleanupRotated`.
2. `refactor(logger): unify log and error-path emission into a single emit()` — `src/logger/emit.ts` exports `resolveSinks()` (computed once per logger) and `emit()`; `log()` and `handleHttpError` are now thin wrappers. `handle-http-error.ts` shrank to status/level/normalize + one `emit` call, keeping a cheap pre-check so a filtered-out logger never pays for `normalizeLoggedError`.
3. `feat(logger): add config.onError hook; drop dual-signature sink shims` — `logToFile`/`logToTransports` lose their unused positional-args overloads; new optional `config.onError({sink: 'transport' | 'file' | 'rotation', error})` surfaces sink failures (hook errors swallowed; absent hook keeps the existing stderr behavior). Documented in `configuration.mdx`.
4. `test(logger): pin unified error-path gating and console-method-by-level` — regression tests for the resolved drifts (added in review round 1).

### Deliberate behavior changes (the drift resolutions — closed list from the plan)

- Error-path logs now honor the same sink gates: with `useTransportsOnly` and zero transports, an error emits **nothing** (previously it still printed to console.error). Pinned by a new test.
- Console method is chosen by level on both paths: a 4xx (WARNING) error now prints via `console.warn` instead of `console.error`; 5xx still uses `console.error` (control test pins both). Called out in the changeset.
- The error path now reuses the single-parse `precomputed` optimization from #373.

No public API changes: neither `logToFile` nor `logToTransports` is exported from the package barrel; the internal `handleHttpError` signature change is invisible to the integration-style tests and consumers.

## Related Issues

Implements `plans/017-sink-pipeline-refactor.md` (audit findings D-01/D-02/D-06/D-07/D-08). Builds on #350 (mutex), #351/#373 (timing/precompute), #353 (status ladder), #366 (error normalization), #372 (file sink).

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/PunGrumpy/logixlysia/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A — internal refactor + config hook.

## Additional Notes

Verification gates (executor-run, reviewer re-run independently):

| Gate | Command | Result |
|------|---------|--------|
| Tests | `cd packages/logixlysia && bun test` | ✅ 208 pass, 0 fail (200 pre-existing — zero modified — + 8 new) |
| Typecheck | `bun run typecheck` | ✅ exit 0 |
| Lint | `bun x ultracite check` | ✅ exit 0 |
| Build | `bun run build --filter logixlysia` | ✅ exit 0 |

Bench parity (clean rebuilds both states, min/p75 ms — refactor must be neutral):

| Suite | main (6c26cc2) | this branch |
|---|---|---|
| overhead floor | 0.0034 / 0.0045 | 0.0034 / 0.0041 |
| structured sink | 0.0036 / 0.0044 | 0.0036 / 0.0045 |
| file sink | 0.0051 / 0.0062 | 0.0052 / 0.0061 |

New tests: 3 keyed-mutex (incl. same-tick exclusion + tail-cleanup), 2 `onError` (throwing transport / failing file write; throwing hook never crashes the request), 3 error-path drift pins (gating emits nothing; 4xx→warn; 5xx→error control).

Changeset: `.changeset/sink-pipeline-refactor.md` (**minor** — new `config.onError` surface + the documented 4xx console-method change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional error callback for transport, file-writing, and log-rotation failures.
  - Callback details identify the affected sink and underlying error.
  - Added safer coordination for concurrent log rotation and improved retention cleanup.

- **Bug Fixes**
  - Logging failures are now consistently reported, with stderr fallback when no callback is configured.
  - Errors thrown by the callback no longer interrupt logging.
  - HTTP 4xx and 5xx errors use appropriate warning and error console levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->