### PR TITLE
feat(rotation): implement lazy-on-write interval rotation

### DIFF
--- a/.changeset/interval-rotation.md
+++ b/.changeset/interval-rotation.md
@@ -1,0 +1,13 @@
+---
+'logixlysia': minor
+---
+
+`logRotation.interval` now actually rotates. The live file's age (from
+filesystem creation time, falling back to open time where the filesystem
+reports none) is checked after every write, and the file rotates on the
+first write after the interval elapses — no timers, so an idle process
+rotates on its next write rather than on a wall-clock schedule. When both
+`maxSize` and `interval` are set, whichever trigger is crossed first
+rotates. Previously `interval` was accepted and format-validated but
+never triggered rotation; configs that already set it will begin rotating
+on upgrade.

--- a/apps/docs/content/configuration.mdx
+++ b/apps/docs/content/configuration.mdx
@@ -332,7 +332,7 @@ maxSize: '10m'
 
 #### `logRotation.interval`
 
-Accepted and format-validated (`'1h'`, `'1d'`, `'1w'`), but not yet functional — it does not trigger rotation. Rotation currently triggers on `maxSize` only. See [Log Rotation](/docs/features/log-rotation) for details.
+Rotate when the live log file's age reaches the given interval. Evaluated on write — an idle process does not rotate until it logs again. See [Log Rotation](/docs/features/log-rotation) for details.
 
 - **Type:** `string`
 - **Format:** `'1h'`, `'1d'`, `'1w'`

--- a/apps/docs/content/features/log-rotation.mdx
+++ b/apps/docs/content/features/log-rotation.mdx
@@ -34,8 +34,20 @@ Supported formats: `'1k'`, `'1m'`, `'1g'` or bytes (number)
 
 ### Time-based Rotation
 
+```ts
+logRotation: {
+  interval: '1d'    // Rotate when the live file is a day old
+}
+```
+
+Supported formats: a number plus a unit — `'1h'` (hours), `'1d'` (days), `'1w'` (weeks). Minutes and bare numbers are not accepted.
+
 > [!NOTE]
-> Interval-based rotation is not currently implemented. `interval` is accepted and format-validated (`/^(\d+)(h|d|w)$/i`, e.g. `'1h'`, `'1d'`, `'1w'`) for forward compatibility, but it does not trigger rotation yet — rotation currently triggers on `maxSize` only. An implementation following the accepted design is planned (see [PR #380](https://github.com/PunGrumpy/logixlysia/pull/380)); no date is set.
+> Interval rotation is evaluated when a log line is written, not on a
+> wall-clock timer. If the process writes nothing for longer than
+> `interval`, the file rotates on the next write — an idle process's
+> file can exceed `interval` in age until traffic resumes. The file's
+> age is read from filesystem creation time, so it survives restarts.
 
 ### Retention Policy
 
@@ -63,7 +75,7 @@ logRotation: {
 
 ## How Rotation Works
 
-Rotation happens when the in-memory byte count for the file exceeds `maxSize`, checked on every write batch. Empty files are not rotated.
+Rotation happens on write, when either configured trigger is crossed: the in-memory byte count exceeds `maxSize`, or the live file's age (from filesystem creation time) has reached `interval`. Both are checked after every write batch — never on a timer. Empty files are not rotated.
 
 When a log file is rotated, it's renamed with a timestamp and a high-resolution counter to guarantee uniqueness:
 
@@ -91,7 +103,8 @@ app.log.2026-07-27-14-30-05-123-45678901234567 → app.log.2026-07-27-14-30-05-1
 logRotation: {
   maxSize: '100m',
   maxFiles: '30d',
-  compress: true
+  compress: true,
+  interval: '1d'
 }
 ```
 
@@ -111,7 +124,8 @@ logRotation: {
 logRotation: {
   maxSize: '1g',
   maxFiles: '7d',
-  compress: true
+  compress: true,
+  interval: '1h'
 }
 ```
 
@@ -121,3 +135,4 @@ logRotation: {
 - Rotation failures don't crash the application
 - Compression runs asynchronously
 - Old files are automatically cleaned up based on `maxFiles`
+- Interval rotation is checked on write only; an idle process rotates on its next write

--- a/packages/logixlysia/CHANGELOG.md
+++ b/packages/logixlysia/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### Correction (2026-08-10)
+
+The 5.3.0 entries "log-rotation: implement complete rotation with
+interval support" (673b800, 9016a51) added the `interval` config field
+and its format validation, but did not wire it to actually trigger
+rotation — `interval` was a no-op from 5.3.0 until the lazy-on-write
+implementation landed on 2026-08-10. See
+`plans/spikes/021-interval-rotation-decision.md` for the investigation.
+
 ## 6.6.1
 
 ### Patch Changes

--- a/packages/logixlysia/__tests__/output/interval-rotation.test.ts
+++ b/packages/logixlysia/__tests__/output/interval-rotation.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, describe, expect, setSystemTime, test } from 'bun:test'
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+import type { Options } from '../../src/interfaces'
+import { logToFile } from '../../src/output/file'
+import { resolveOpenedAt } from '../../src/output/file-sink'
+import { createMockRequest } from '../_helpers/request'
+import { createTempDir, removeTempDir } from '../_helpers/tmp'
+
+const ONE_HOUR_MS = 60 * 60 * 1000
+const TWO_HOURS_MS = 2 * ONE_HOUR_MS
+
+describe('interval rotation', () => {
+  afterEach(() => {
+    // Always reset the faked clock so it never leaks into other test files.
+    setSystemTime()
+  })
+
+  test('rotates on the first write after the interval elapses', async () => {
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'logs', 'interval.log')
+      const options: Options = {
+        config: { logRotation: { interval: '1h' } }
+      }
+
+      await logToFile({
+        data: { message: 'msg-1' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/first'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      setSystemTime(new Date(Date.now() + TWO_HOURS_MS))
+
+      await logToFile({
+        data: { message: 'msg-2' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/second'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      const logsDir = join(dir, 'logs')
+      const entriesAfterSecond = await fs.readdir(logsDir)
+      const rotated = entriesAfterSecond.filter(name =>
+        name.startsWith('interval.log.')
+      )
+      expect(rotated.length).toBe(1)
+
+      const rotatedContent = await fs.readFile(
+        join(logsDir, rotated[0]),
+        'utf-8'
+      )
+      expect(rotatedContent).toContain('msg-1')
+      expect(rotatedContent).toContain('msg-2')
+
+      // Reset to the real clock before the next write: the rotated-away
+      // file's replacement gets a real (post-rotation) birthtime, so this
+      // write must not immediately trip the interval again.
+      setSystemTime()
+
+      await logToFile({
+        data: { message: 'msg-3' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/third'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      const liveContent = await fs.readFile(filePath, 'utf-8')
+      expect(liveContent).toContain('msg-3')
+      expect(liveContent).not.toContain('msg-1')
+      expect(liveContent).not.toContain('msg-2')
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('does not rotate before the interval elapses', async () => {
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'logs', 'no-rotate.log')
+      const options: Options = {
+        config: { logRotation: { interval: '1h' } }
+      }
+
+      await logToFile({
+        data: { message: 'msg-1' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/first'),
+        store: { beforeTime: BigInt(0) }
+      })
+      await logToFile({
+        data: { message: 'msg-2' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/second'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      const logsDir = join(dir, 'logs')
+      const entries = await fs.readdir(logsDir)
+      expect(entries).toEqual(['no-rotate.log'])
+
+      const content = await fs.readFile(filePath, 'utf-8')
+      expect(content).toContain('msg-1')
+      expect(content).toContain('msg-2')
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('maxSize fires first when both triggers are configured', async () => {
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'logs', 'both-size.log')
+      const options: Options = {
+        config: { logRotation: { interval: '1w', maxSize: 50 } }
+      }
+
+      await logToFile({
+        data: { message: 'x'.repeat(60) },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/first'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      const logsDir = join(dir, 'logs')
+      const entries = await fs.readdir(logsDir)
+      const rotated = entries.filter(name => name.startsWith('both-size.log.'))
+      expect(rotated.length).toBe(1)
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('interval fires first when both triggers are configured', async () => {
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'logs', 'both-interval.log')
+      const options: Options = {
+        config: { logRotation: { interval: '1h', maxSize: 10_000_000 } }
+      }
+
+      await logToFile({
+        data: { message: 'msg-1' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/first'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      setSystemTime(new Date(Date.now() + TWO_HOURS_MS))
+
+      await logToFile({
+        data: { message: 'msg-2' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/second'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      const logsDir = join(dir, 'logs')
+      const entries = await fs.readdir(logsDir)
+      const rotated = entries.filter(name =>
+        name.startsWith('both-interval.log.')
+      )
+      expect(rotated.length).toBe(1)
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('restart simulation: birthtime survives, fresh sink rotates immediately', async () => {
+    const dir = await createTempDir()
+    try {
+      const logsDir = join(dir, 'logs')
+      const filePath = join(logsDir, 'restart.log')
+      await fs.mkdir(logsDir, { recursive: true })
+      // Seed the file directly (no sink involved), so its birthtime is the
+      // real filesystem creation time — simulating a file left over from a
+      // previous process.
+      await fs.writeFile(filePath, 'seed\n')
+
+      setSystemTime(new Date(Date.now() + TWO_HOURS_MS))
+
+      const options: Options = {
+        config: { logRotation: { interval: '1h' } }
+      }
+      await logToFile({
+        data: { message: 'after-restart' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/first'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      const entries = await fs.readdir(logsDir)
+      const rotated = entries.filter(name => name.startsWith('restart.log.'))
+      expect(rotated.length).toBe(1)
+
+      const rotatedContent = await fs.readFile(
+        join(logsDir, rotated[0]),
+        'utf-8'
+      )
+      expect(rotatedContent).toContain('seed')
+      expect(rotatedContent).toContain('after-restart')
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('idle process does not rotate until the next write', async () => {
+    // Documents the accepted idle-process tradeoff from
+    // plans/spikes/021-interval-rotation-decision.md: a process that writes
+    // no logs for longer than `interval` does not rotate until the next
+    // write arrives.
+    const dir = await createTempDir()
+    try {
+      const filePath = join(dir, 'logs', 'idle.log')
+      const options: Options = {
+        config: { logRotation: { interval: '1h' } }
+      }
+
+      await logToFile({
+        data: { message: 'msg-1' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/first'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      setSystemTime(new Date(Date.now() + TWO_HOURS_MS))
+
+      // No write happens here — just wait one macrotask so any (nonexistent)
+      // background rotation would have had a chance to run.
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      const logsDir = join(dir, 'logs')
+      const idleEntries = await fs.readdir(logsDir)
+      expect(idleEntries).toEqual(['idle.log'])
+
+      await logToFile({
+        data: { message: 'msg-2' },
+        filePath,
+        level: 'INFO',
+        options,
+        request: createMockRequest('http://localhost/second'),
+        store: { beforeTime: BigInt(0) }
+      })
+
+      const afterWriteEntries = await fs.readdir(logsDir)
+      const rotated = afterWriteEntries.filter(name =>
+        name.startsWith('idle.log.')
+      )
+      expect(rotated.length).toBe(1)
+    } finally {
+      await removeTempDir(dir)
+    }
+  })
+
+  test('resolveOpenedAt falls back to now when birthtimeMs is 0 or absent', () => {
+    expect(resolveOpenedAt(0, 123)).toBe(123)
+    expect(resolveOpenedAt(undefined, 123)).toBe(123)
+    expect(resolveOpenedAt(456, 123)).toBe(456)
+  })
+})

--- a/packages/logixlysia/src/output/file-sink.ts
+++ b/packages/logixlysia/src/output/file-sink.ts
@@ -2,9 +2,20 @@ import type { FileHandle } from 'node:fs/promises'
 import { open } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { LogRotationConfig } from '../interfaces'
-import { parseSize } from '../utils/rotation'
+import { parseInterval, parseSize } from '../utils/rotation'
 import { ensureDir } from './fs'
 import { performRotation } from './rotation-manager'
+
+/**
+ * The live file's creation time when the filesystem reports one;
+ * some filesystems report 0/absent birthtime — fall back to `now`
+ * (losing restart-survival for the interval clock, but never wrong
+ * by more than the process lifetime).
+ */
+export const resolveOpenedAt = (
+  birthtimeMs: number | undefined,
+  now: number
+): number => (birthtimeMs && birthtimeMs > 0 ? birthtimeMs : now)
 
 export interface FileSinkOptions {
   logDirMode?: number
@@ -33,6 +44,7 @@ class FileSinkImpl implements FileSink {
   private readonly filePath: string
   private handle: FileHandle | null = null
   private bytesWritten = 0
+  private openedAt = 0
   private latestOptions: FileSinkOptions = {}
   private pendingBatch: PendingBatch | null = null
   // Serializes flush and rotation work per path: every batch (and the
@@ -112,23 +124,41 @@ class FileSinkImpl implements FileSink {
     const stat = await handle.stat()
     this.handle = handle
     this.bytesWritten = stat.size
+    this.openedAt = resolveOpenedAt(stat.birthtimeMs, Date.now())
+  }
+
+  /** True when either configured trigger (size, interval) has been crossed. */
+  private shouldRotateNow(rotation: LogRotationConfig): boolean {
+    if (
+      rotation.maxSize !== undefined &&
+      this.bytesWritten > parseSize(rotation.maxSize)
+    ) {
+      return true
+    }
+    return (
+      rotation.interval !== undefined &&
+      Date.now() - this.openedAt >= parseInterval(rotation.interval)
+    )
   }
 
   private async maybeRotate(options: FileSinkOptions): Promise<void> {
     const rotation = options.logRotation
-    if (!rotation || rotation.maxSize === undefined) {
+    if (
+      !rotation ||
+      (rotation.maxSize === undefined && rotation.interval === undefined)
+    ) {
       return
     }
 
     try {
-      const maxSize = parseSize(rotation.maxSize)
-      if (this.bytesWritten <= maxSize) {
+      if (!this.shouldRotateNow(rotation)) {
         return
       }
 
       const { handle } = this
       this.handle = null
       this.bytesWritten = 0
+      this.openedAt = Date.now()
       await handle?.close()
       await performRotation(this.filePath, rotation, options.onRotationError)
     } catch (error) {

--- a/packages/logixlysia/src/output/rotation-manager.ts
+++ b/packages/logixlysia/src/output/rotation-manager.ts
@@ -188,7 +188,7 @@ export const performRotation = async (
     await cleanupRotated(filePath, retention, onError)
   }
 
-  // `config.interval` (fixed-interval rotation, e.g. '1d'/'12h') is not
-  // implemented here: rotation is currently only triggered by `maxSize`
-  // (see `FileSinkImpl.maybeRotate` in file-sink.ts).
+  // Interval-based triggering lives in `FileSinkImpl.maybeRotate`
+  // (file-sink.ts); performRotation is trigger-agnostic — it renames,
+  // compresses, and cleans up regardless of why rotation fired.
 }

--- a/packages/logixlysia/src/types/config.ts
+++ b/packages/logixlysia/src/types/config.ts
@@ -13,7 +13,9 @@ export interface LogRotationConfig {
   compress?: boolean
   compression?: 'gzip'
   /**
-   * Rotate at a fixed interval, e.g. '1d', '12h'.
+   * Rotate when the live file's age reaches a fixed interval, evaluated on
+   * write (an idle process rotates on its next write, not on a timer).
+   * Format: number + 'h' | 'd' | 'w', e.g. '12h', '1d', '1w'.
    */
   interval?: string
   /**


### PR DESCRIPTION
## Description

Implements lazy-on-write interval rotation in the file sink, executing the design accepted in the merged decision record `plans/spikes/021-interval-rotation-decision.md` (PR #380). `logRotation.interval` has been typed, format-validated, documented, and CHANGELOG-claimed since 5.3.0 — but nothing at runtime ever read it: rotation triggered on `maxSize` only.

**Implementation** (`FileSinkImpl`, `src/output/file-sink.ts`):
- `ensureOpen` now captures `openedAt` from `stat.birthtimeMs` — the `stat()` call the sink already performs on every open, so this costs zero additional syscalls. Using filesystem birthtime means the interval clock survives process restarts: a sink opened over an already-old file rotates on its first write.
- New exported `resolveOpenedAt(birthtimeMs, now)` helper falls back to `Date.now()` on filesystems that report `birthtimeMs === 0` (pure function, unit-testable without mocking `node:fs`).
- `maybeRotate` gains a `shouldRotateNow` helper: rotates when `bytesWritten > maxSize` (strict `>`, unchanged semantics) **or** `Date.now() - openedAt >= interval` (`>=`, age reached). The guard now passes for interval-only configs (previously `maxSize === undefined` returned early). Both triggers share the existing rotate-and-clear-handle path; the catch block is byte-for-byte unchanged.
- **No timers.** Rotation is evaluated on write only — the idle-process gap (a file can exceed `interval` in age until the next write) is the accepted, documented tradeoff from the decision record. `grep -rn "setInterval\|setTimeout" packages/logixlysia/src` still returns nothing.

**Docs flip** (per the decision record's instruction): the disclaiming callouts added by #381 are replaced with real behavior — `log-rotation.mdx` Time-based Rotation section (working example + format rules + on-write-evaluation caveat), How Rotation Works (both triggers), Production/High-Volume examples regain `interval`, Important Notes bullet; `configuration.mdx` `logRotation.interval` entry now describes working behavior.

**CHANGELOG correction**: dated note under the top heading recording that the 5.3.0 "complete rotation with interval support" entries (673b800, 9016a51) shipped the field and validation without rotation semantics — `interval` was a no-op from 5.3.0 until this change.

**Changeset**: `minor` — delivers a documented feature; configs that already set `interval` will begin rotating on upgrade (called out in the changeset text).

## Related Issues

- Executes the follow-up sketch from `plans/spikes/021-interval-rotation-decision.md` (accepted via #380)
- Completes the docs flip-back that #381 deliberately deferred until the implementation landed
- Context: #138 (the typing-only issue whose fix introduced the field without semantics)

## Checklist

- [x] Code follows the project's style guidelines (Ultracite/Biome strict — zero suppression comments)
- [x] Tests added: 7 new tests in `__tests__/output/interval-rotation.test.ts`
- [x] All tests pass locally (215 = 208 existing + 7 new; zero existing tests modified)
- [x] Documentation updated (`log-rotation.mdx`, `configuration.mdx`, `LogRotationConfig` doc comment)
- [x] Changeset included (`minor`)

## Screenshots

N/A — logging library runtime behavior.

## Additional Notes

**Verification gates (all re-run independently by the reviewer in the executor's worktree):**

- `cd packages/logixlysia && bun test` → exit 0, **215 pass / 0 fail** (7 new interval-rotation tests; re-run 3× — no flakiness)
- `bun run typecheck` → exit 0
- `bun x ultracite check` → exit 0
- `bun run build --filter logixlysia` → exit 0
- `cd apps/docs && bun run build` → exit 0
- `grep -rn "setInterval\|setTimeout" packages/logixlysia/src` → no matches (still zero timers)
- `grep -rn "not currently implemented\|not yet functional" apps/docs/content` → no matches
- CHANGELOG diff is additions-only; `git diff --stat` shows exactly the 8 in-scope files

**Test mechanism**: `setSystemTime` from `bun:test` advances `Date.now()` while `stat.birthtimeMs` stays real (verified on Bun 1.3.14) — tests cross a `'1h'` interval without waiting. The test file resets the clock in `afterEach` so the fake never leaks across files. Coverage: rotate-after-elapse (+ fresh live file reopens), no-rotate-before-elapse, size-first and interval-first when both triggers configured, restart simulation via real birthtime on a pre-seeded file, an explicit idle-process test documenting the accepted tradeoff, and the `resolveOpenedAt` fallback.

**One evidenced executor deviation, reviewer-verified**: the plan's literal script for test 1 wrote a third message while the clock was still faked +2h; the freshly-reopened file gets a *real* birthtime, so the still-faked `Date.now()` correctly tripped the interval again and rotated the third line away (observed `ENOENT`). The test resets to the real clock before the third write — behavior is by-design, the plan's test script was wrong, not the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functional time-based log rotation using configurable hour, day, or week intervals.
  * Logs rotate on the first write after the interval expires.
  * Size and time limits trigger rotation whichever is reached first.
  * Idle processes remain unchanged until their next write.

* **Documentation**
  * Updated configuration guidance and examples for interval-based rotation.
  * Added changelog notes describing the feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->