### PR TITLE
ci: record the playground terminal on pull requests

### DIFF
--- a/.github/workflows/terminal-recording.yml
+++ b/.github/workflows/terminal-recording.yml
@@ -1,0 +1,140 @@
+name: 🎬 Terminal Recording
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'apps/elysia/**'
+      - 'packages/logixlysia/**'
+      - '.github/workflows/terminal-recording.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  record:
+    name: 🎥 Record playground logs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      artifact-url: ${{ steps.upload.outputs.artifact-url }}
+    steps:
+      - name: 🛫 Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: 🍞 Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
+      - name: 🌵 Cache Bun
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.bun/install/cache
+            **/node_modules
+            .turbo
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}-
+            ${{ runner.os }}-bun-
+      - name: 🔽 Install Dependencies
+        run: bun install
+      - name: 🦊 Build Logixlysia
+        run: bun run build --filter logixlysia
+      - name: 📁 Prepare artifacts
+        run: mkdir -p artifacts
+      - name: 🎞️ Render tape
+        # Every `Wait` in the tape is an assertion: vhs exits non-zero if the
+        # playground never logs the expected line, so this step is a smoke test
+        # that happens to produce a video.
+        uses: charmbracelet/vhs-action@f6d7db07a432fcd3b06772628d36a57f96d95dcf # v2.1.1
+        with:
+          path: apps/elysia/demo.tape
+          install-fonts: true
+      - name: 📤 Upload recording
+        id: upload
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: logixlysia-demo-${{ github.event.pull_request.number || github.run_id }}
+          path: |
+            artifacts/logixlysia-demo.gif
+            artifacts/logixlysia-demo.mp4
+            artifacts/logixlysia-demo.png
+          if-no-files-found: error
+          retention-days: 7
+      - name: 📝 Write job summary
+        env:
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+        run: |
+          {
+            echo "## Playground terminal recording"
+            echo
+            echo "VHS drove \`apps/elysia\` in a real PTY and asserted every line below appeared:"
+            echo
+            echo "- start banner on \`localhost:3001\`"
+            echo "- request context tree on \`/checkout\`"
+            echo "- \`[REDACTED]\` on \`/auto-redact\`"
+            echo "- \`WARNING\` on \`/status/404\`"
+            echo "- red \`ERROR\` on \`/boom\`"
+            echo "- AI token metrics on \`POST /chat\`"
+            echo
+            echo "[Download the GIF, MP4 and PNG](${ARTIFACT_URL})"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  comment:
+    name: 💬 Post recording to PR
+    needs: record
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: 🗒️ Upsert recording comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ARTIFACT_URL: ${{ needs.record.outputs.artifact-url }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const marker = '<!-- logixlysia:terminal-recording -->'
+            const body = [
+              marker,
+              '## 🎬 Playground terminal recording',
+              '',
+              `VHS drove \`apps/elysia\` at \`${process.env.COMMIT_SHA.slice(0, 7)}\` in a real PTY and asserted that logixlysia still prints:`,
+              '',
+              '- the start banner, then a plain `200` request line',
+              '- the per-request context tree on `/checkout`',
+              '- `[REDACTED]` for the card, e-mail, IP and JWT on `/auto-redact`',
+              '- `WARNING` on `/status/404` and a red `ERROR` on `/boom`',
+              '- AI token metrics on `POST /chat`',
+              '',
+              `[Download the GIF, MP4 and PNG](${process.env.ARTIFACT_URL})`,
+            ].join('\n')
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.pull_request.number
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            })
+            const existing = comments.find(comment => comment.body?.includes(marker))
+            try {
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number, body })
+              }
+            } catch (error) {
+              core.warning(`Could not upsert the terminal recording comment: ${error.message}`)
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,6 @@ $RECYCLE.BIN/
 
 # npm configuration
 .npmrc
+
+# VHS terminal recordings
+artifacts

--- a/apps/elysia/demo.tape
+++ b/apps/elysia/demo.tape
@@ -1,0 +1,87 @@
+# Logixlysia — recorded terminal demo of the playground in `apps/elysia`.
+#
+# VHS drives a real PTY, so the frames show exactly what a developer sees:
+# colours, the context tree, redaction, and the error formatting that unit
+# tests cannot assert on.
+#
+# Every `Wait` is an assertion — vhs exits non-zero if the pattern never
+# appears, so a green recording is also a passing smoke test.
+#
+# Run locally from the repository root (needs vhs, ttyd and ffmpeg):
+#   bun install && bun run build --filter logixlysia
+#   mkdir -p artifacts && vhs apps/elysia/demo.tape
+
+Require bun
+Require curl
+
+Output artifacts/logixlysia-demo.gif
+Output artifacts/logixlysia-demo.mp4
+
+Set Shell bash
+Set Theme "Catppuccin Mocha"
+# Sized so the whole demo fits on one screen without scrolling: `Wait+Screen`
+# reads buffer rows 0..term.rows-1, so it goes stale as soon as the terminal
+# scrolls and every assertion below would time out. Adding output means adding
+# height.
+Set FontSize 15
+Set Width 1400
+Set Height 940
+Set Padding 24
+Set Margin 24
+Set MarginFill "#11111b"
+Set BorderRadius 12
+Set WindowBar Colorful
+Set TypingSpeed 45ms
+Set WaitTimeout 60s
+
+# Setup is hidden so the recording opens on an empty prompt.
+Hide
+Type "cd apps/elysia" Enter
+Type "export PS1='\n$ ' PORT=3001" Enter
+Type "clear" Enter
+Show
+
+# The playground boots and logixlysia prints the start banner. The trailing
+# `sleep` keeps the prompt from being drawn into the middle of the banner.
+Type "bun run src/index.ts & sleep 2" Enter
+Wait+Screen /localhost:3001/
+# Outlast the `sleep` above: typing while it still holds the foreground would
+# leave the keystrokes buffered and shift every command that follows.
+Sleep 3s
+
+# A plain 200: level, service tag, method, path, status, duration.
+Type "curl -s localhost:3001/" Enter
+Wait+Screen /GET/
+Sleep 1s
+
+# Per-request context rendered as a tree under the request line.
+Type "curl -s localhost:3001/checkout" Enter
+Wait+Screen /usr_demo/
+Sleep 1s
+
+# autoRedact scrubs the card, e-mail, IP and JWT before they reach stdout.
+Type "curl -s localhost:3001/auto-redact" Enter
+Wait+Screen /REDACTED/
+Sleep 1500ms
+
+# 4xx degrades the line to WARNING.
+Type "curl -s localhost:3001/status/404" Enter
+Wait+Screen /"status":404/
+Sleep 1s
+
+# A thrown handler error becomes a red ERROR line with the message attached.
+Type "curl -s localhost:3001/boom" Enter
+Wait+Screen /Boom!/
+Sleep 1500ms
+
+# AI metrics ride along on the request line.
+Type "curl -s -X POST localhost:3001/chat" Enter
+Wait+Screen /inputTokens/
+Sleep 2s
+
+Screenshot artifacts/logixlysia-demo.png
+# Let the screenshot frame land before the next keystroke shows up in it.
+Sleep 1s
+
+Type "kill %1" Enter
+Sleep 1s


### PR DESCRIPTION
## Description

Adds a VHS tape that drives `apps/elysia` in a real PTY, plus a workflow that renders it on every PR touching the plugin or the playground and posts the result back to the PR.

Colours, the context tree, redaction and error formatting are the whole point of the logger, and none of them survive a piped stdout — the unit suite asserts on strings the plugin never renders that way. This closes that gap without weakening anything that already exists.

**`apps/elysia/demo.tape`** — every `Wait` is an assertion. vhs exits non-zero when the pattern never appears, so a green run is a passing smoke test that happens to produce a video:

| Step | Asserts |
| --- | --- |
| startup | banner on `localhost:3001` |
| `GET /checkout` | per-request context tree (`usr_demo`) |
| `GET /auto-redact` | `[REDACTED]` for card, e-mail, IP and JWT |
| `GET /status/404` | `{"status":404}` behind a `WARNING` line |
| `GET /boom` | `Boom!` behind a red `ERROR` line |
| `POST /chat` | `inputTokens` in the AI metrics |

**`.github/workflows/terminal-recording.yml`** — builds the plugin, renders the tape, uploads the GIF/MP4/PNG, and upserts one PR comment keyed by an HTML marker so pushes update it instead of stacking. Skipped for forks (their token cannot write to pull requests) and for `workflow_dispatch` runs (no PR to comment on).

Three things are load-bearing and are commented in the tape, because each one silently breaks the recording rather than failing loudly:

1. `Wait+Screen` reads buffer rows `0..term.rows-1`, not the viewport, so it freezes on the top of the scrollback as soon as the terminal scrolls and every later assertion times out. The terminal is sized to hold the whole demo — **adding output means adding height**.
2. The `Sleep` after boot must outlast the `sleep` pinned to the start command, or the keystrokes queue in the tty and shift every command that follows.
3. `PS1='\n$ '` — curl responses carry no trailing newline, so without it the next prompt glues itself onto the JSON.

## Related Issues

No linked issue. Prior art: the `terminal-recording.yml` workflow in `millionco/react-doctor`, which does the same for an interactive TUI via `termctrl`. VHS fits better here because the playground has nothing to drive interactively.

## Checklist

- [x] I've reviewed my code
- [x] I've written tests — the tape's six `Wait` assertions are the test; it was rendered end to end both locally (vhs 0.11.0, ttyd 1.7.7, ffmpeg 7.0.2) and on CI, with identical layout
- [ ] I've generated a change set file — not applicable, no published package changes
- [ ] I've updated the docs, if necessary — the tape carries its own header comment with local-run instructions

## Screenshots (if applicable)

The final frame is attached to each run as `logixlysia-demo.png`, alongside the GIF and MP4. Rendering locally:

```sh
bun install && bun run build --filter logixlysia
mkdir -p artifacts && vhs apps/elysia/demo.tape
```

## Additional Notes

- GitHub artifacts are served as zips, so the recording cannot be embedded inline — the PR comment links to the download. Hosting the GIF for an inline preview was tried and dropped: it needs a `contents: write` job pushing to a branch of its own, which is more machinery than the preview is worth.
- `GET /pino` is excluded from the tape because it currently 500s: `routers/index.ts` configures no pino instance, so `store.pino.info` is undefined. Pre-existing and unrelated, but worth a follow-up.
- Slow-request highlighting (`slowThreshold: 500`) is not demonstrated — the playground has no route slow enough to trip it.
