### PR TITLE
ci: render terminal recordings inline in PR comments

### DIFF
--- a/.github/workflows/terminal-recording-cleanup.yml
+++ b/.github/workflows/terminal-recording-cleanup.yml
@@ -1,0 +1,61 @@
+name: 🧹 Terminal Recording Cleanup
+
+# Releases are the public home for recording assets (see terminal-recording.yml).
+# This workflow keeps them from accumulating: delete on PR close, plus a weekly
+# sweep as a safety net for dispatch runs, cancelled jobs, and missed closes.
+
+on:
+  pull_request:
+    types: [closed]
+  schedule:
+    - cron: '0 3 * * 1'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: terminal-recording-cleanup-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  delete-pr-release:
+    name: 🗑️ Delete PR recording release
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: recording-pr-${{ github.event.pull_request.number }}
+    steps:
+      - name: 🗑️ Delete release and tag
+        run: |
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag
+          else
+            echo "No release for $TAG, nothing to clean"
+          fi
+
+  sweep-stale-releases:
+    name: 🧹 Sweep stale recording releases
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: 🧹 Delete recording releases older than 14 days
+        run: |
+          set -euo pipefail
+          cutoff="$(date -u -d '14 days ago' '+%Y-%m-%dT%H:%M:%SZ')"
+          deleted=0
+          while IFS=$'\t' read -r tag created_at; do
+            [[ -z "$tag" ]] && continue
+            # ISO-8601 timestamps compare correctly as strings.
+            if [[ "$created_at" < "$cutoff" ]]; then
+              echo "Deleting stale release $tag (created $created_at)"
+              gh release delete "$tag" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag \
+                && deleted=$((deleted + 1)) || true
+            fi
+          done < <(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" --paginate \
+            --jq '.[] | select(.tag_name | startswith("recording-pr-")) | [.tag_name, .created_at] | @tsv')
+          echo "Deleted $deleted stale recording release(s)"

--- a/.github/workflows/terminal-recording.yml
+++ b/.github/workflows/terminal-recording.yml
@@ -102,6 +102,9 @@ jobs:
       contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # No checkout in this job: point gh at the repo explicitly so it does
+      # not fall back to reading a git remote.
+      GH_REPO: ${{ github.repository }}
       ARTIFACT_NAME: logixlysia-demo-${{ github.event.pull_request.number }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/terminal-recording.yml
+++ b/.github/workflows/terminal-recording.yml
@@ -89,9 +89,56 @@ jobs:
             echo "[Download the GIF, MP4 and PNG](${ARTIFACT_URL})"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  publish:
+    name: 📦 Publish recording to pre-release
+    needs: record
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      # actions:read lets `gh run download` fetch this run's artifact without
+      # a third-party download action; contents:write manages the release.
+      actions: read
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ARTIFACT_NAME: logixlysia-demo-${{ github.event.pull_request.number }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    outputs:
+      gif-url: ${{ steps.release.outputs.gif-url }}
+      mp4-url: ${{ steps.release.outputs.mp4-url }}
+      png-url: ${{ steps.release.outputs.png-url }}
+    steps:
+      - name: ⬇️ Download recording artifact
+        run: gh run download "${GITHUB_RUN_ID}" --name "${ARTIFACT_NAME}" --dir dist
+      - name: 📦 Upload assets to recording pre-release
+        id: release
+        run: |
+          set -euo pipefail
+          tag="recording-pr-${PR_NUMBER}"
+          base_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" \
+              dist/logixlysia-demo.gif dist/logixlysia-demo.mp4 dist/logixlysia-demo.png --clobber
+          else
+            gh release create "$tag" \
+              dist/logixlysia-demo.gif dist/logixlysia-demo.mp4 dist/logixlysia-demo.png \
+              --prerelease \
+              --title "🎬 Terminal recording — PR #${PR_NUMBER}" \
+              --notes "Recording assets for \`${HEAD_SHA:0:7}\`." \
+              || gh release upload "$tag" \
+                dist/logixlysia-demo.gif dist/logixlysia-demo.mp4 dist/logixlysia-demo.png --clobber
+          fi
+          {
+            echo "gif-url=${base_url}/logixlysia-demo.gif"
+            echo "mp4-url=${base_url}/logixlysia-demo.mp4"
+            echo "png-url=${base_url}/logixlysia-demo.png"
+          } >> "$GITHUB_OUTPUT"
+
   comment:
     name: 💬 Post recording to PR
-    needs: record
+    needs: [record, publish]
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -102,7 +149,9 @@ jobs:
       - name: 🗒️ Upsert recording comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          ARTIFACT_URL: ${{ needs.record.outputs.artifact-url }}
+          RECORDING_URL: ${{ needs.publish.outputs.gif-url }}
+          MP4_URL: ${{ needs.publish.outputs.mp4-url }}
+          PNG_URL: ${{ needs.publish.outputs.png-url }}
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           script: |
@@ -111,6 +160,10 @@ jobs:
               marker,
               '## 🎬 Playground terminal recording',
               '',
+              `![terminal recording](${process.env.RECORDING_URL})`,
+              '',
+              `[MP4](${process.env.MP4_URL}) · [PNG](${process.env.PNG_URL})`,
+              '',
               `VHS drove \`apps/elysia\` at \`${process.env.COMMIT_SHA.slice(0, 7)}\` in a real PTY and asserted that logixlysia still prints:`,
               '',
               '- the start banner, then a plain `200` request line',
@@ -118,8 +171,6 @@ jobs:
               '- `[REDACTED]` for the card, e-mail, IP and JWT on `/auto-redact`',
               '- `WARNING` on `/status/404` and a red `ERROR` on `/boom`',
               '- AI token metrics on `POST /chat`',
-              '',
-              `[Download the GIF, MP4 and PNG](${process.env.ARTIFACT_URL})`,
             ].join('\n')
             const { owner, repo } = context.repo
             const issue_number = context.payload.pull_request.number

--- a/apps/elysia/demo.tape
+++ b/apps/elysia/demo.tape
@@ -42,7 +42,7 @@ Set WaitTimeout 60s
 # typed through the PTY proved fragile under ttyd.
 Hide
 Type "cd apps/elysia" Enter
-Type "export PS1='\napps/elysia git:(main) \$ '" Enter
+Type "export PS1='\napps/elysia git:(main) \$ ' PORT=3001" Enter
 Type "clear" Enter
 Show
 

--- a/apps/elysia/demo.tape
+++ b/apps/elysia/demo.tape
@@ -5,7 +5,14 @@
 # tests cannot assert on.
 #
 # Every `Wait` is an assertion — vhs exits non-zero if the pattern never
-# appears, so a green recording is also a passing smoke test.
+# appears, so a green recording is also a passing smoke test. Only the boot
+# banner uses `Wait+Screen` (it must be visible); the rest use plain `Wait`
+# so a little scrollback never breaks the run.
+#
+# Pacing notes: typing speed varies per command (config commands are typed
+# slower than muscle-memory curls), there are pauses before Enter, one
+# typo-and-fix on `/checkout`, and the video ends on a cleared prompt so the
+# GIF loops cleanly.
 #
 # Run locally from the repository root (needs vhs, ttyd and ffmpeg):
 #   bun install && bun run build --filter logixlysia
@@ -19,10 +26,6 @@ Output artifacts/logixlysia-demo.mp4
 
 Set Shell bash
 Set Theme "Catppuccin Mocha"
-# Sized so the whole demo fits on one screen without scrolling: `Wait+Screen`
-# reads buffer rows 0..term.rows-1, so it goes stale as soon as the terminal
-# scrolls and every assertion below would time out. Adding output means adding
-# height.
 Set FontSize 15
 Set Width 1400
 Set Height 940
@@ -31,57 +34,75 @@ Set Margin 24
 Set MarginFill "#11111b"
 Set BorderRadius 12
 Set WindowBar Colorful
-Set TypingSpeed 45ms
+Set TypingSpeed 25ms
 Set WaitTimeout 60s
 
-# Setup is hidden so the recording opens on an empty prompt.
+# Setup is hidden so the recording opens on an empty prompt. The prompt
+# mimics an oh-my-zsh style theme (cwd + git branch) instead of a bare `$`.
 Hide
 Type "cd apps/elysia" Enter
-Type "export PS1='\n$ ' PORT=3001" Enter
+Type "export PS1='\n\[\033[01;34m\]apps/elysia\[\033[00m\] \[\033[01;33m\]git:(\[\033[00;31m\]main\[\033[01;33m\])\[\033[00m\] \$ '" Enter
 Type "clear" Enter
 Show
 
-# The playground boots and logixlysia prints the start banner. The trailing
-# `sleep` keeps the prompt from being drawn into the middle of the banner.
-Type "bun run src/index.ts & sleep 2" Enter
+# The playground boots and logixlysia prints the start banner. Running it
+# backgrounded returns the prompt immediately, like a real session.
+Type@40ms "bun run src/index.ts &" Enter
 Wait+Screen /localhost:3001/
-# Outlast the `sleep` above: typing while it still holds the foreground would
-# leave the keystrokes buffered and shift every command that follows.
-Sleep 3s
+Sleep 800ms
 
 # A plain 200: level, service tag, method, path, status, duration.
-Type "curl -s localhost:3001/" Enter
-Wait+Screen /GET/
-Sleep 1s
+Type@12ms "curl -s localhost:3001/"
+Sleep 250ms
+Enter
+Wait /GET/
+Sleep 900ms
 
-# Per-request context rendered as a tree under the request line.
-Type "curl -s localhost:3001/checkout" Enter
-Wait+Screen /usr_demo/
-Sleep 1s
+# Per-request context rendered as a tree under the request line. A typo gets
+# caught and fixed before Enter, the way a real keyboard slips sometimes.
+Type@12ms "curl -s localhost:3001/chekout"
+Sleep 450ms
+Backspace Backspace Backspace Backspace
+Type@10ms "ckout"
+Sleep 250ms
+Enter
+Wait /usr_demo/
+Sleep 1100ms
 
 # autoRedact scrubs the card, e-mail, IP and JWT before they reach stdout.
-Type "curl -s localhost:3001/auto-redact" Enter
-Wait+Screen /REDACTED/
-Sleep 1500ms
+Type@12ms "curl -s localhost:3001/auto-redact"
+Sleep 300ms
+Enter
+Wait /REDACTED/
+Sleep 1300ms
 
 # 4xx degrades the line to WARNING.
-Type "curl -s localhost:3001/status/404" Enter
-Wait+Screen /"status":404/
-Sleep 1s
+Type@12ms "curl -s localhost:3001/status/404"
+Sleep 200ms
+Enter
+Wait /"status":404/
+Sleep 900ms
 
 # A thrown handler error becomes a red ERROR line with the message attached.
-Type "curl -s localhost:3001/boom" Enter
-Wait+Screen /Boom!/
-Sleep 1500ms
+Type@12ms "curl -s localhost:3001/boom"
+Sleep 350ms
+Enter
+Wait /Boom!/
+Sleep 1300ms
 
 # AI metrics ride along on the request line.
-Type "curl -s -X POST localhost:3001/chat" Enter
-Wait+Screen /inputTokens/
-Sleep 2s
+Type@14ms "curl -s -X POST localhost:3001/chat"
+Sleep 300ms
+Enter
+Wait /inputTokens/
+Sleep 1600ms
 
 Screenshot artifacts/logixlysia-demo.png
-# Let the screenshot frame land before the next keystroke shows up in it.
-Sleep 1s
+Sleep 800ms
 
 Type "kill %1" Enter
-Sleep 1s
+Sleep 700ms
+# Clear before the recording ends so the GIF loops back to the empty prompt
+# it opened on.
+Type "clear" Enter
+Sleep 500ms

--- a/apps/elysia/demo.tape
+++ b/apps/elysia/demo.tape
@@ -55,15 +55,13 @@ Wait+Screen /localhost:3001/
 Sleep 3s
 
 # A plain 200: level, service tag, method, path, status, duration.
-Type@12ms "curl -s localhost:3001/"
-Sleep 250ms
-Enter
-Wait /GET/
+Type "curl localhost:3001/" Enter
+Wait+Screen /GET/
 Sleep 900ms
 
 # Per-request context rendered as a tree under the request line. A typo gets
 # caught and fixed before Enter, the way a real keyboard slips sometimes.
-Type@12ms "curl -s localhost:3001/chekout"
+Type@12ms "curl localhost:3001/chekout"
 Sleep 450ms
 Backspace Backspace Backspace Backspace
 Type@10ms "ckout"
@@ -73,28 +71,28 @@ Wait /usr_demo/
 Sleep 1100ms
 
 # autoRedact scrubs the card, e-mail, IP and JWT before they reach stdout.
-Type@12ms "curl -s localhost:3001/auto-redact"
+Type@12ms "curl localhost:3001/auto-redact"
 Sleep 300ms
 Enter
 Wait /REDACTED/
 Sleep 1300ms
 
 # 4xx degrades the line to WARNING.
-Type@12ms "curl -s localhost:3001/status/404"
+Type@12ms "curl localhost:3001/status/404"
 Sleep 200ms
 Enter
 Wait /"status":404/
 Sleep 900ms
 
 # A thrown handler error becomes a red ERROR line with the message attached.
-Type@12ms "curl -s localhost:3001/boom"
+Type@12ms "curl localhost:3001/boom"
 Sleep 350ms
 Enter
 Wait /Boom!/
 Sleep 1300ms
 
 # AI metrics ride along on the request line.
-Type@14ms "curl -s -X POST localhost:3001/chat"
+Type@14ms "curl -X POST localhost:3001/chat"
 Sleep 300ms
 Enter
 Wait /inputTokens/

--- a/apps/elysia/demo.tape
+++ b/apps/elysia/demo.tape
@@ -37,19 +37,22 @@ Set WindowBar Colorful
 Set TypingSpeed 25ms
 Set WaitTimeout 60s
 
-# Setup is hidden so the recording opens on an empty prompt. The prompt
-# mimics an oh-my-zsh style theme (cwd + git branch) instead of a bare `$`.
+# Setup is hidden so the recording opens on an empty prompt. The prompt shows
+# cwd + branch like an oh-my-zsh theme; kept ASCII-only because ANSI escapes
+# typed through the PTY proved fragile under ttyd.
 Hide
 Type "cd apps/elysia" Enter
-Type "export PS1='\n\[\033[01;34m\]apps/elysia\[\033[00m\] \[\033[01;33m\]git:(\[\033[00;31m\]main\[\033[01;33m\])\[\033[00m\] \$ '" Enter
+Type "export PS1='\napps/elysia git:(main) \$ '" Enter
 Type "clear" Enter
 Show
 
-# The playground boots and logixlysia prints the start banner. Running it
-# backgrounded returns the prompt immediately, like a real session.
-Type@40ms "bun run src/index.ts &" Enter
+# The playground boots and logixlysia prints the start banner. The trailing
+# `sleep` keeps the prompt from being drawn into the middle of the banner.
+Type@40ms "bun run src/index.ts & sleep 2" Enter
 Wait+Screen /localhost:3001/
-Sleep 800ms
+# Outlast the `sleep` above: typing while it still holds the foreground would
+# leave the keystrokes buffered and shift every command that follows.
+Sleep 3s
 
 # A plain 200: level, service tag, method, path, status, duration.
 Type@12ms "curl -s localhost:3001/"


### PR DESCRIPTION
## Description

Recording assets previously lived behind artifact URLs, which require GitHub login — so the recording could never render inline in a PR comment, and fork contributors could not open it at all.

This PR publishes each recording to a public `recording-pr-<n>` GitHub pre-release instead and embeds the GIF directly in the upserted PR comment:

- **`terminal-recording.yml`** — new `publish` job (record → publish → comment) downloads the run's artifact via `gh run download` (no third-party action to pin), uploads GIF/MP4/PNG to the pre-release with `--clobber` for re-pushes, and the comment job now embeds `![terminal recording](gif-url)` plus MP4/PNG links. Release assets live outside git, so repo size is unaffected.
- **`terminal-recording-cleanup.yml`** (new) — deletes the release + tag when its PR closes, with a weekly cron sweep removing `recording-pr-*` releases older than 14 days as a safety net for `workflow_dispatch` runs, cancelled jobs, and missed closes.

### Testing
- Push to a PR → comment should embed the rendered GIF from the release URL
- Re-push → same comment updates in place (marker upsert), assets replaced via `--clobber`
- Close the PR → release and tag disappear; weekly sweep catches anything left

## Related Issues

None

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

N/A — CI-only change; the PR comment on this very PR will demonstrate the result once triggered.

## Additional Notes

The cleanup workflow no-ops safely for fork PRs (no release exists). If a close-event run is cancelled by an in-progress sync run, the weekly sweep still removes the orphaned release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull request terminal recordings are published as GIF, MP4, and PNG assets.
  * Pull request comments display the recording GIF and link to MP4 and PNG versions.
  * Recording releases are automatically removed when pull requests close or after 14 days.

* **Improvements**
  * Cleanup safely handles missing releases and individual deletion failures.
  * Recording publishing works more reliably in automated workflows.
  * Terminal demos now provide clearer pacing, prompts, and interactive output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->