### PR TITLE
fix(demo): restore Wait+Screen assertions in the tape

### DIFF
--- a/apps/elysia/demo.tape
+++ b/apps/elysia/demo.tape
@@ -5,9 +5,9 @@
 # tests cannot assert on.
 #
 # Every `Wait` is an assertion — vhs exits non-zero if the pattern never
-# appears, so a green recording is also a passing smoke test. Only the boot
-# banner uses `Wait+Screen` (it must be visible); the rest use plain `Wait`
-# so a little scrollback never breaks the run.
+# appears, so a green recording is also a passing smoke test. They all use
+# `Wait+Screen`: bare `Wait` is `Wait+Line`, which only ever sees the last
+# line, and that line is the prompt by the time curl has returned.
 #
 # Pacing notes: typing speed varies per command (config commands are typed
 # slower than muscle-memory curls), there are pauses before Enter, one
@@ -26,6 +26,10 @@ Output artifacts/logixlysia-demo.mp4
 
 Set Shell bash
 Set Theme "Catppuccin Mocha"
+# Sized so the whole demo fits on one screen without scrolling: `Wait+Screen`
+# reads buffer rows 0..term.rows-1, so it goes stale as soon as the terminal
+# scrolls and every assertion below would time out. Adding output means adding
+# height.
 Set FontSize 15
 Set Width 1400
 Set Height 940
@@ -67,35 +71,35 @@ Backspace Backspace Backspace Backspace
 Type@10ms "ckout"
 Sleep 250ms
 Enter
-Wait /usr_demo/
+Wait+Screen /usr_demo/
 Sleep 1100ms
 
 # autoRedact scrubs the card, e-mail, IP and JWT before they reach stdout.
 Type@12ms "curl localhost:3001/auto-redact"
 Sleep 300ms
 Enter
-Wait /REDACTED/
+Wait+Screen /REDACTED/
 Sleep 1300ms
 
 # 4xx degrades the line to WARNING.
 Type@12ms "curl localhost:3001/status/404"
 Sleep 200ms
 Enter
-Wait /"status":404/
+Wait+Screen /"status":404/
 Sleep 900ms
 
 # A thrown handler error becomes a red ERROR line with the message attached.
 Type@12ms "curl localhost:3001/boom"
 Sleep 350ms
 Enter
-Wait /Boom!/
+Wait+Screen /Boom!/
 Sleep 1300ms
 
 # AI metrics ride along on the request line.
 Type@14ms "curl -X POST localhost:3001/chat"
 Sleep 300ms
 Enter
-Wait /inputTokens/
+Wait+Screen /inputTokens/
 Sleep 1600ms
 
 Screenshot artifacts/logixlysia-demo.png


### PR DESCRIPTION
## Description

Fixes the terminal-recording job, which has failed on every run since #389.

`2e13629` swapped the `Wait+Screen /.../` assertions for plain `Wait /.../`, on the assumption that the bare form tolerates scrollback. It does the opposite: in vhs, bare `Wait` is `Wait+Line`, which only ever inspects the **last** line — and by the time curl has returned, that line is the prompt again. Every assertion after the boot banner was guaranteed to time out:

```
failed to execute command: timeout waiting for "Line usr_demo" to match usr_demo;
last value was: apps/elysia git:(main) $
```

- `+Screen` restored on all five assertions (`usr_demo`, `REDACTED`, `"status":404`, `Boom!`, `inputTokens`).
- Restored the sizing comment that the same commit deleted — it documents why the demo must fit on one screen (`Wait+Screen` reads buffer rows `0..term.rows-1`, so it goes stale the moment the terminal scrolls).
- Corrected the header comment that stated the wrong rationale for bare `Wait`.

## Related Issues

Follow-up to #389.

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Screenshots (if applicable)

## Additional Notes

Single-file change to `apps/elysia/demo.tape`; nothing under `packages/logixlysia/` is touched, so no changeset is required. The recording job on this PR is the verification.
