### PR TITLE
feat(adapters): built-in transports for nine observability platforms

### DIFF
--- a/.changeset/axiom-adapter.md
+++ b/.changeset/axiom-adapter.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Add the `logixlysia/axiom` adapter. `createAxiomTransport()` ships logs to an Axiom dataset via the ingest API with batching, retries, and env-based credentials (`AXIOM_API_KEY`, `AXIOM_DATASET`, `AXIOM_ORG_ID`, `AXIOM_URL`). Events keep their nested structure so every field is queryable with APL.

--- a/.changeset/better-stack-adapter.md
+++ b/.changeset/better-stack-adapter.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Add the `logixlysia/better-stack` adapter. `createBetterStackTransport()` ships logs to Better Stack Telemetry using `BETTER_STACK_SOURCE_TOKEN`, supporting both the legacy shared endpoint and the dedicated per-source ingesting hosts (`BETTER_STACK_INGESTING_HOST`). Logs post with a `dt` timestamp, `level`, `message`, and the full meta object.

--- a/.changeset/clickhouse-adapter.md
+++ b/.changeset/clickhouse-adapter.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Add the `logixlysia/clickhouse` adapter. `createClickHouseTransport()` inserts logs into a ClickHouse table over the HTTP interface using `JSONEachRow` — rows carry `timestamp`, `level`, `message`, and an `attributes` map of the flattened meta. Database and table names are validated as plain identifiers, and ISO timestamps parse via `date_time_input_format=best_effort`.

--- a/.changeset/datadog-adapter.md
+++ b/.changeset/datadog-adapter.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Add the `logixlysia/datadog` adapter. `createDatadogTransport()` ships logs to Datadog's v2 logs intake (`DD_API_KEY`, `DD_SITE` for regions). The log level lands in the `status` attribute for Datadog's default remapper, the HTTP response status follows the standard `http.status_code` attribute, and the full meta object rides along as searchable attributes.

--- a/.changeset/hyperdx-adapter.md
+++ b/.changeset/hyperdx-adapter.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Add the `logixlysia/hyperdx` adapter. `createHyperDXTransport()` ships logs to HyperDX (cloud or self-hosted collectors) as OTLP JSON over HTTP, authenticated with `HYPERDX_API_KEY`. Meta fields become dot-notation log attributes searchable in the HyperDX UI.

--- a/.changeset/loki-adapter.md
+++ b/.changeset/loki-adapter.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Add the `logixlysia/loki` adapter. `createLokiTransport()` pushes logs to Grafana Loki (self-hosted or Grafana Cloud with basic auth, multi-tenant via `X-Scope-OrgID`). Streams are labeled with low-cardinality `service_name` and `level`; the log line is the message and full meta as JSON, ready for LogQL's `| json`.

--- a/.changeset/otlp-adapter.md
+++ b/.changeset/otlp-adapter.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Add the `logixlysia/otlp` adapter. `createOtlpTransport()` ships logs to any OTLP/HTTP logs endpoint as `ExportLogsServiceRequest` JSON — OpenTelemetry Collectors, Grafana Cloud, New Relic, Honeycomb, SigNoz, and other OTLP-compatible backends. Honors the standard `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, and `OTEL_SERVICE_NAME` variables.

--- a/.changeset/posthog-adapter.md
+++ b/.changeset/posthog-adapter.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Add the `logixlysia/posthog` adapter. `createPostHogTransport()` captures logs as PostHog events via the batch API (`POSTHOG_API_KEY`, `POSTHOG_HOST` for EU/self-hosted). Meta fields become dot-notation event properties, and logs carrying a `userId` in the request context are linked to PostHog persons via `distinct_id`.

--- a/.changeset/sentry-adapter.md
+++ b/.changeset/sentry-adapter.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Add the `logixlysia/sentry` adapter. `createSentryTransport()` ships structured logs to Sentry (Explore > Logs) via the envelope endpoint using `SENTRY_DSN` — no Sentry SDK required. Every meta field becomes a typed, searchable attribute, and `trace_id` from the request context links logs to traces.

--- a/apps/docs/content/adapters/axiom.mdx
+++ b/apps/docs/content/adapters/axiom.mdx
@@ -1,0 +1,91 @@
+---
+title: Axiom
+description: Ship logs to an Axiom dataset via the ingest API
+---
+
+Send logs to [Axiom](https://axiom.co). Axiom indexes every field of an event without a schema, so the nested structure Logixlysia sends — `request.method`, `context.requestId`, your custom context — is queryable as-is with APL.
+
+## Setup
+
+1. Create a dataset in the [Axiom console](https://app.axiom.co).
+2. Generate an API token with **ingest** permission for that dataset.
+3. Set the environment variables:
+
+```bash
+AXIOM_API_KEY=xaat-your-token
+AXIOM_DATASET=your-dataset
+```
+
+4. Wire the transport:
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+import { createAxiomTransport } from 'logixlysia/axiom'
+
+const app = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        transports: [createAxiomTransport()]
+      }
+    })
+  )
+  .get('/', () => 'ok')
+  .listen(3000)
+```
+
+5. Trigger a request and query the dataset in Axiom.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AXIOM_API_KEY` | Yes | API token with ingest permission (`xaat-…`) |
+| `AXIOM_DATASET` | Yes | Target dataset name |
+| `AXIOM_ORG_ID` | For personal access tokens | Organization ID |
+| `AXIOM_URL` | No | API base URL (default `https://api.axiom.co`) |
+
+## Options
+
+Options passed to `createAxiomTransport()` override environment variables:
+
+```ts
+const axiom = createAxiomTransport({
+  dataset: 'production-logs',
+  timeout: 10_000
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `apiKey` | `string` | `AXIOM_API_KEY` | API token with ingest permission |
+| `dataset` | `string` | `AXIOM_DATASET` | Target dataset name |
+| `orgId` | `string` | `AXIOM_ORG_ID` | Required when using a personal access token |
+| `baseUrl` | `string` | `https://api.axiom.co` | API base URL |
+
+Plus the shared batching options: `maxBatchSize`, `flushIntervalMs`, `timeout`, `retries` — see the [overview](/docs/adapters/overview#shared-behavior).
+
+## Payload
+
+Each log becomes one event in `POST /v1/datasets/{dataset}/ingest`:
+
+```json
+{
+  "_time": "2026-08-22T12:00:00.000Z",
+  "level": "INFO",
+  "message": "",
+  "request": { "method": "GET", "url": "http://localhost:3000/users" },
+  "status": 200,
+  "durationMs": 12.4,
+  "context": { "requestId": "0d5e…" }
+}
+```
+
+Query it in Axiom with APL, e.g. `['your-dataset'] | where level == "ERROR" and durationMs > 1000`.
+
+## Troubleshooting
+
+- **`401`** — the token is invalid or expired; generate a new one in Axiom settings.
+- **`403` with a personal access token** — set `AXIOM_ORG_ID` (personal tokens are not scoped to an organization).
+- **Nothing arrives** — logs flush in batches (2 s by default); check that the process lived long enough, or call `flush()` before exit.

--- a/apps/docs/content/adapters/better-stack.mdx
+++ b/apps/docs/content/adapters/better-stack.mdx
@@ -1,0 +1,83 @@
+---
+title: Better Stack
+description: Ship logs to Better Stack Telemetry
+---
+
+Send logs to [Better Stack](https://betterstack.com) (formerly Logtail). Logs arrive with a `dt` timestamp, `level`, `message`, and the full meta object — queryable in Live tail and with SQL.
+
+## Setup
+
+1. In Better Stack, create a **source** (platform: JavaScript / HTTP) and copy its **source token**. Newer sources also show a dedicated **ingesting host**.
+2. Set the environment variables:
+
+```bash
+BETTER_STACK_SOURCE_TOKEN=your-source-token
+BETTER_STACK_INGESTING_HOST=https://s123456.eu-nbg-2.betterstackdata.com # if your source shows one
+```
+
+3. Wire the transport:
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+import { createBetterStackTransport } from 'logixlysia/better-stack'
+
+const app = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        transports: [createBetterStackTransport()]
+      }
+    })
+  )
+  .get('/', () => 'ok')
+  .listen(3000)
+```
+
+4. Trigger a request and watch Live tail.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `BETTER_STACK_SOURCE_TOKEN` | Yes | Source token, sent as a Bearer token |
+| `BETTER_STACK_INGESTING_HOST` | No | Dedicated ingesting URL (default `https://in.logs.betterstack.com`) |
+
+## Options
+
+```ts
+const betterStack = createBetterStackTransport({
+  endpoint: 'https://s123456.eu-nbg-2.betterstackdata.com'
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `sourceToken` | `string` | `BETTER_STACK_SOURCE_TOKEN` | Source token |
+| `endpoint` | `string` | `https://in.logs.betterstack.com` | Ingesting URL |
+
+Plus the shared batching options: `maxBatchSize`, `flushIntervalMs`, `timeout`, `retries` — see the [overview](/docs/adapters/overview#shared-behavior).
+
+## Payload
+
+Each log posts as one JSON object in a batched array:
+
+```json
+{
+  "dt": "2026-08-22T12:00:00.000Z",
+  "level": "INFO",
+  "message": "GET /users",
+  "request": { "method": "GET", "url": "http://localhost:3000/users" },
+  "status": 200,
+  "durationMs": 12.4,
+  "context": { "requestId": "0d5e…" }
+}
+```
+
+Nested fields are queryable directly, e.g. `context.requestId` or `request.method` in SQL and Live tail filters.
+
+## Troubleshooting
+
+- **`401`** — the source token is wrong, or the source was deleted; copy a fresh token from the source settings.
+- **Logs land in the wrong source** — each source has its own token; double-check which one is in the environment.
+- **Newer source, nothing arrives** — sources with a dedicated ingesting host reject the legacy default endpoint; set `BETTER_STACK_INGESTING_HOST`.

--- a/apps/docs/content/adapters/clickhouse.mdx
+++ b/apps/docs/content/adapters/clickhouse.mdx
@@ -1,0 +1,112 @@
+---
+title: ClickHouse
+description: Insert logs into a ClickHouse table over HTTP
+---
+
+Send logs straight into a [ClickHouse](https://clickhouse.com) table via the HTTP interface with `JSONEachRow` — your own log warehouse with SQL, no agent or pipeline in between.
+
+## Setup
+
+1. Create the target table:
+
+```sql
+CREATE TABLE default.logs (
+  timestamp DateTime64(3),
+  level LowCardinality(String),
+  message String,
+  attributes Map(String, String)
+)
+ENGINE = MergeTree
+ORDER BY timestamp
+```
+
+2. Set the environment variables (all optional for a default local instance):
+
+```bash
+CLICKHOUSE_URL=http://localhost:8123
+CLICKHOUSE_DATABASE=default
+CLICKHOUSE_TABLE=logs
+CLICKHOUSE_USERNAME=default
+CLICKHOUSE_PASSWORD=secret
+```
+
+3. Wire the transport:
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+import { createClickHouseTransport } from 'logixlysia/clickhouse'
+
+const app = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        transports: [createClickHouseTransport()]
+      }
+    })
+  )
+  .get('/', () => 'ok')
+  .listen(3000)
+```
+
+4. Query: `SELECT * FROM logs WHERE level = 'ERROR' ORDER BY timestamp DESC`.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `CLICKHOUSE_URL` | No | HTTP interface base URL (default `http://localhost:8123`) |
+| `CLICKHOUSE_DATABASE` | No | Target database (default `default`) |
+| `CLICKHOUSE_TABLE` | No | Target table (default `logs`) |
+| `CLICKHOUSE_USERNAME` | No | Sent as `X-ClickHouse-User` |
+| `CLICKHOUSE_PASSWORD` | No | Sent as `X-ClickHouse-Key` |
+
+## Options
+
+```ts
+const clickhouse = createClickHouseTransport({
+  database: 'observability',
+  table: 'app_logs'
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `url` | `string` | `http://localhost:8123` | HTTP interface base URL |
+| `database` | `string` | `default` | Target database |
+| `table` | `string` | `logs` | Target table |
+| `username` | `string` | `CLICKHOUSE_USERNAME` | Username |
+| `password` | `string` | `CLICKHOUSE_PASSWORD` | Password |
+
+Plus the shared batching options: `maxBatchSize`, `flushIntervalMs`, `timeout`, `retries` — see the [overview](/docs/adapters/overview#shared-behavior).
+
+Database and table names must be plain identifiers (letters, digits, underscores) — anything else throws at startup.
+
+## Payload
+
+Each log becomes one `JSONEachRow` row. Meta flattens into the `attributes` map with values rendered as strings:
+
+```json
+{
+  "timestamp": "2026-08-22T12:00:00.000Z",
+  "level": "INFO",
+  "message": "GET /users",
+  "attributes": {
+    "request.method": "GET",
+    "request.url": "http://localhost:3000/users",
+    "status": "200",
+    "durationMs": "12.4",
+    "context.requestId": "0d5e…"
+  }
+}
+```
+
+Query attributes with map access, e.g. `WHERE attributes['status'] = '500'`. The insert URL includes `date_time_input_format=best_effort` so ISO 8601 timestamps parse into `DateTime64` directly.
+
+ClickHouse loves large batches — for high-volume services, raise `maxBatchSize` (e.g. 500) and `flushIntervalMs` (e.g. 5000) to cut down on tiny inserts.
+
+## Troubleshooting
+
+- **`404` / `UNKNOWN_TABLE`** — create the table first (DDL above), or check `CLICKHOUSE_DATABASE` / `CLICKHOUSE_TABLE`.
+- **`516`** — authentication failed; ClickHouse returns this for bad credentials.
+- **`Cannot parse` errors** — the table schema doesn't match the row shape; align it with the DDL above or adjust column types.

--- a/apps/docs/content/adapters/datadog.mdx
+++ b/apps/docs/content/adapters/datadog.mdx
@@ -1,0 +1,81 @@
+---
+title: Datadog
+description: Ship logs to Datadog via the v2 logs intake API
+---
+
+Send logs to [Datadog](https://www.datadoghq.com) Log Management. Logs arrive with `service` and `source` facets, the level mapped to Datadog's `status`, and the full meta object as searchable attributes.
+
+## Setup
+
+1. Create an API key in **Organization Settings → API Keys**.
+2. Set the environment variables:
+
+```bash
+DD_API_KEY=your-api-key
+DD_SITE=datadoghq.com # or datadoghq.eu, us3.datadoghq.com, us5.datadoghq.com, ap1.datadoghq.com
+DD_SERVICE=my-api
+```
+
+3. Wire the transport:
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+import { createDatadogTransport } from 'logixlysia/datadog'
+
+const app = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        transports: [createDatadogTransport()]
+      }
+    })
+  )
+  .get('/', () => 'ok')
+  .listen(3000)
+```
+
+4. Trigger a request and open **Logs → Explorer** in Datadog.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DD_API_KEY` | Yes | API key, sent as the `DD-API-KEY` header |
+| `DD_SITE` | No | Datadog site (default `datadoghq.com`) |
+| `DD_SERVICE` | No | `service` facet (default `logixlysia`) |
+| `DD_HOSTNAME` | No | `hostname` on each log; omitted when unset |
+
+## Options
+
+```ts
+const datadog = createDatadogTransport({
+  service: 'my-api',
+  tags: { env: 'production', team: 'backend' }
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `apiKey` | `string` | `DD_API_KEY` | Datadog API key |
+| `site` | `string` | `datadoghq.com` | Datadog site / region |
+| `service` | `string` | `logixlysia` | `service` facet |
+| `source` | `string` | `logixlysia` | `ddsource` facet |
+| `hostname` | `string` | `DD_HOSTNAME` | Reported hostname |
+| `tags` | `Record<string, string>` | — | Rendered into `ddtags` as `key:value` pairs |
+
+Plus the shared batching options: `maxBatchSize`, `flushIntervalMs`, `timeout`, `retries` — see the [overview](/docs/adapters/overview#shared-behavior).
+
+## Payload
+
+Logs post to `https://http-intake.logs.{site}/api/v2/logs`:
+
+- **`status`** — the log level lowercased (`info`, `warning`, `error`), which Datadog's default status remapper picks up for severity coloring.
+- **`http.status_code`** — the HTTP response status from access logs, following Datadog's standard attribute so response-code facets work out of the box.
+- **Attributes** — the full meta object rides along nested (`request.method`, `context.requestId`, `durationMs`, …), searchable with `@request.method:GET` style queries.
+
+## Troubleshooting
+
+- **`403`** — the API key is invalid, or it belongs to a different site than `DD_SITE`; keys are region-scoped.
+- **Wrong region** — EU organizations must set `DD_SITE=datadoghq.eu`; a wrong site surfaces as a non-2xx response through the `onError` hook or stderr.
+- **Levels look wrong** — if you customized the status remapper in a log pipeline, map it to the `status` attribute.

--- a/apps/docs/content/adapters/hyperdx.mdx
+++ b/apps/docs/content/adapters/hyperdx.mdx
@@ -1,0 +1,93 @@
+---
+title: HyperDX
+description: Ship logs to HyperDX as OTLP over HTTP
+---
+
+Send logs to [HyperDX](https://hyperdx.io) as standard OTLP JSON (`ExportLogsServiceRequest`). Works with HyperDX cloud and self-hosted collectors alike, and meta fields arrive as searchable log attributes.
+
+## Setup
+
+1. Copy the ingestion API key from your HyperDX team settings.
+2. Set the environment variable:
+
+```bash
+HYPERDX_API_KEY=your-ingestion-key
+```
+
+3. Wire the transport:
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+import { createHyperDXTransport } from 'logixlysia/hyperdx'
+
+const app = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        transports: [createHyperDXTransport({ serviceName: 'my-api' })]
+      }
+    })
+  )
+  .get('/', () => 'ok')
+  .listen(3000)
+```
+
+4. Trigger a request and search the logs in the HyperDX UI.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `HYPERDX_API_KEY` | Yes | Ingestion key, sent as the `authorization` header |
+| `HYPERDX_OTLP_ENDPOINT` | No | OTLP HTTP base URL (default `https://in-otel.hyperdx.io`) |
+| `HYPERDX_SERVICE_NAME` | No | Value of the `service.name` resource attribute |
+| `OTEL_SERVICE_NAME` | No | Fallback for the service name |
+
+## Options
+
+```ts
+const hyperdx = createHyperDXTransport({
+  resourceAttributes: { 'deployment.environment': 'production' },
+  serviceName: 'my-api'
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `apiKey` | `string` | `HYPERDX_API_KEY` | Ingestion API key |
+| `endpoint` | `string` | `https://in-otel.hyperdx.io` | OTLP HTTP base URL — `/v1/logs` is appended |
+| `serviceName` | `string` | `logixlysia` | `service.name` resource attribute |
+| `resourceAttributes` | `Record<string, string>` | — | Extra OTLP resource attributes |
+
+Plus the shared batching options: `maxBatchSize`, `flushIntervalMs`, `timeout`, `retries` — see the [overview](/docs/adapters/overview#shared-behavior).
+
+## Payload
+
+Logs post to `{endpoint}/v1/logs` as OTLP JSON. Levels map to OpenTelemetry severity numbers (`DEBUG` → 5, `INFO` → 9, `WARNING` → 13, `ERROR` → 17), and meta fields flatten into dot-notation attributes:
+
+| Attribute | Example |
+|-----------|---------|
+| `request.method` | `GET` |
+| `request.url` | `http://localhost:3000/users` |
+| `status` | `200` |
+| `durationMs` | `12.4` |
+| `context.requestId` | `0d5e…` |
+
+Pair this with [`logixlysia/otel`](/docs/integrations/otel) to include `context.trace_id` / `context.span_id` and correlate logs with traces.
+
+## Self-Hosted Collectors
+
+Pass the OTLP HTTP **base URL only** (port 4318 by default) — the adapter appends `/v1/logs`:
+
+```ts
+createHyperDXTransport({
+  apiKey: 'local',
+  endpoint: 'http://otel-collector:4318'
+})
+```
+
+## Troubleshooting
+
+- **`401`** — the API key is wrong; use the *ingestion* key, not a personal API key.
+- **Nothing arrives** — logs flush in batches (2 s by default); call `flush()` before short-lived processes exit.

--- a/apps/docs/content/adapters/loki.mdx
+++ b/apps/docs/content/adapters/loki.mdx
@@ -1,0 +1,97 @@
+---
+title: Grafana Loki
+description: Push logs to Grafana Loki or Grafana Cloud
+---
+
+Send logs to [Grafana Loki](https://grafana.com/oss/loki/) — self-hosted or Grafana Cloud. Streams are labeled with `service_name` and `level`; the log line itself is JSON, ready for LogQL's `| json` parser.
+
+## Setup
+
+1. Have a Loki instance (e.g. `http://localhost:3100`) or a Grafana Cloud stack (find the push URL and credentials under **Connections → Loki**).
+2. Set the environment variables:
+
+```bash
+LOKI_URL=http://localhost:3100
+# Grafana Cloud:
+# LOKI_URL=https://logs-prod-012.grafana.net
+# LOKI_USERNAME=123456        # instance ID
+# LOKI_PASSWORD=glc_...       # access token
+```
+
+3. Wire the transport:
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+import { createLokiTransport } from 'logixlysia/loki'
+
+const app = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        transports: [createLokiTransport({ serviceName: 'my-api' })]
+      }
+    })
+  )
+  .get('/', () => 'ok')
+  .listen(3000)
+```
+
+4. Query in Grafana: `{service_name="my-api"} | json`.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `LOKI_URL` | Yes | Loki base URL — `/loki/api/v1/push` is appended |
+| `LOKI_USERNAME` | For Grafana Cloud | Basic-auth username (instance ID) |
+| `LOKI_PASSWORD` | For Grafana Cloud | Basic-auth password / access token |
+| `LOKI_TENANT_ID` | For multi-tenant Loki | Sent as `X-Scope-OrgID` |
+| `LOKI_SERVICE_NAME` | No | `service_name` label (falls back to `OTEL_SERVICE_NAME`) |
+
+## Options
+
+```ts
+const loki = createLokiTransport({
+  labels: { env: 'production' },
+  serviceName: 'my-api'
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `url` | `string` | `LOKI_URL` | Loki base URL |
+| `serviceName` | `string` | `logixlysia` | `service_name` stream label |
+| `labels` | `Record<string, string>` | — | Extra **static** stream labels |
+| `username` | `string` | `LOKI_USERNAME` | Basic-auth username |
+| `password` | `string` | `LOKI_PASSWORD` | Basic-auth password |
+| `tenantId` | `string` | `LOKI_TENANT_ID` | `X-Scope-OrgID` header |
+
+Plus the shared batching options: `maxBatchSize`, `flushIntervalMs`, `timeout`, `retries` — see the [overview](/docs/adapters/overview#shared-behavior).
+
+Keep `labels` low-cardinality (environment, region) — per-request values like request IDs belong in the log line, where LogQL can still filter them, not in labels, where they explode Loki's index.
+
+## Payload
+
+Each batch groups entries by level into streams:
+
+```json
+{
+  "streams": [
+    {
+      "stream": { "service_name": "my-api", "level": "INFO", "env": "production" },
+      "values": [
+        ["1787788800000000000", "{\"message\":\"GET /users\",\"status\":200,\"durationMs\":12.4}"]
+      ]
+    }
+  ]
+}
+```
+
+Query with LogQL, e.g. `{service_name="my-api", level="ERROR"} | json | durationMs > 1000`.
+
+## Troubleshooting
+
+- **`401`** — Grafana Cloud needs both `LOKI_USERNAME` (instance ID) and `LOKI_PASSWORD` (token with `logs:write`).
+- **`400` "entry too far behind"** — Loki rejects out-of-order or too-old timestamps; check the server clock.
+- **`429`** — per-tenant ingestion limits hit; raise `flushIntervalMs`/`maxBatchSize` to send fewer, larger batches, or raise the tenant limits.

--- a/apps/docs/content/adapters/meta.ts
+++ b/apps/docs/content/adapters/meta.ts
@@ -1,0 +1,18 @@
+import { defineMeta } from 'blume'
+
+export default defineMeta({
+  collapsed: false,
+  pages: [
+    'overview',
+    'axiom',
+    'better-stack',
+    'clickhouse',
+    'datadog',
+    'hyperdx',
+    'loki',
+    'otlp',
+    'posthog',
+    'sentry'
+  ],
+  title: 'Adapters'
+})

--- a/apps/docs/content/adapters/otlp.mdx
+++ b/apps/docs/content/adapters/otlp.mdx
@@ -1,0 +1,104 @@
+---
+title: OTLP
+description: Ship logs to any OpenTelemetry-compatible backend
+---
+
+Send logs to any OTLP/HTTP logs endpoint as standard `ExportLogsServiceRequest` JSON — an OpenTelemetry Collector, Grafana Cloud, New Relic, Honeycomb, SigNoz, or any other OTLP-compatible backend. If your platform speaks OTLP and doesn't have a dedicated adapter, this is the one to use.
+
+## Setup
+
+1. Find your backend's OTLP/HTTP endpoint and auth headers (for a local collector this is `http://localhost:4318` and usually no auth).
+2. Set the standard OpenTelemetry environment variables:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_EXPORTER_OTLP_HEADERS=x-api-key=your-key # optional, k=v,k2=v2
+OTEL_SERVICE_NAME=my-api                      # optional
+```
+
+3. Wire the transport:
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+import { createOtlpTransport } from 'logixlysia/otlp'
+
+const app = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        transports: [createOtlpTransport()]
+      }
+    })
+  )
+  .get('/', () => 'ok')
+  .listen(3000)
+```
+
+## Environment Variables
+
+The adapter honors the standard OpenTelemetry exporter variables:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes* | OTLP HTTP base URL — `/v1/logs` is appended |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | Yes* | Signal-specific logs URL, used **as-is**; takes precedence over the generic endpoint |
+| `OTEL_EXPORTER_OTLP_HEADERS` | No | Extra headers in `k=v,k2=v2` format (vendor auth); values may be percent-encoded |
+| `OTEL_EXPORTER_OTLP_LOGS_HEADERS` | No | Signal-specific headers; take precedence over the generic headers |
+| `OTEL_SERVICE_NAME` | No | Value of the `service.name` resource attribute |
+
+\* One of the two endpoint variables (or the `endpoint` option) is required.
+
+## Options
+
+```ts
+const otlp = createOtlpTransport({
+  endpoint: 'https://otlp.example.com',
+  headers: { 'x-api-key': process.env.MY_KEY ?? '' },
+  resourceAttributes: { 'deployment.environment': 'production' },
+  serviceName: 'my-api'
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `endpoint` | `string` | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP HTTP base URL |
+| `headers` | `Record<string, string>` | parsed from env | Extra request headers; overrides env headers per key |
+| `serviceName` | `string` | `logixlysia` | `service.name` resource attribute |
+| `resourceAttributes` | `Record<string, string>` | — | Extra OTLP resource attributes |
+
+Plus the shared batching options: `maxBatchSize`, `flushIntervalMs`, `timeout`, `retries` — see the [overview](/docs/adapters/overview#shared-behavior).
+
+## Payload
+
+Logs post to `{endpoint}/v1/logs`. Levels map to OpenTelemetry severity numbers (`DEBUG` → 5, `INFO` → 9, `WARNING` → 13, `ERROR` → 17), and meta fields flatten into dot-notation attributes (`request.method`, `status`, `durationMs`, `context.requestId`, …).
+
+Pair this with [`logixlysia/otel`](/docs/integrations/otel) to include `context.trace_id` / `context.span_id` and correlate logs with traces in your backend.
+
+## Vendor Examples
+
+**Grafana Cloud** (OTLP gateway):
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-eu-west-2.grafana.net/otlp
+OTEL_EXPORTER_OTLP_HEADERS='Authorization=Basic BASE64_OF_INSTANCE_ID_AND_TOKEN'
+```
+
+**New Relic**:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net
+OTEL_EXPORTER_OTLP_HEADERS=api-key=<license-key>
+```
+
+**Local collector** — point at port 4318 and let the collector fan out:
+
+```ts
+createOtlpTransport({ endpoint: 'http://localhost:4318' })
+```
+
+## Troubleshooting
+
+- **`404`** — the endpoint should be the **base URL only**; the adapter appends `/v1/logs` itself.
+- **`401` / `403`** — check the header format in `OTEL_EXPORTER_OTLP_HEADERS`; values must not be URL-encoded.
+- **Nothing arrives** — logs flush in batches (2 s by default); call `flush()` before short-lived processes exit.

--- a/apps/docs/content/adapters/overview.mdx
+++ b/apps/docs/content/adapters/overview.mdx
@@ -1,0 +1,130 @@
+---
+title: Adapters Overview
+description: Ship logs to observability platforms with built-in adapters
+---
+
+Send your logs to external observability platforms with built-in adapters. Each adapter is a regular [transport](/docs/features/transports) — batched, retried, and non-blocking — so you can mix them with console and file logging or run them exclusively.
+
+## Available Adapters
+
+### Cloud Platforms
+
+| Platform | Import | Best for |
+|----------|--------|----------|
+| [Axiom](/docs/adapters/axiom) | `logixlysia/axiom` | Schema-free log analytics — every field is queryable |
+| [Better Stack](/docs/adapters/better-stack) | `logixlysia/better-stack` | Logs, uptime, and alerting in one place |
+| [Datadog](/docs/adapters/datadog) | `logixlysia/datadog` | Enterprise observability with facets and pipelines |
+| [Sentry](/docs/adapters/sentry) | `logixlysia/sentry` | Structured logs next to your errors and traces |
+| [PostHog](/docs/adapters/posthog) | `logixlysia/posthog` | Product analytics — link logs to persons and funnels |
+
+### Self-Hosted & Open Standards
+
+| Platform | Import | Best for |
+|----------|--------|----------|
+| [OTLP](/docs/adapters/otlp) | `logixlysia/otlp` | Any OpenTelemetry backend — collectors, Grafana Cloud, New Relic, Honeycomb, SigNoz |
+| [HyperDX](/docs/adapters/hyperdx) | `logixlysia/hyperdx` | Open-source observability via OTLP |
+| [Grafana Loki](/docs/adapters/loki) | `logixlysia/loki` | Label-indexed logs for the Grafana stack |
+| [ClickHouse](/docs/adapters/clickhouse) | `logixlysia/clickhouse` | Your own SQL log warehouse, no pipeline in between |
+
+## Quick Start
+
+Set the platform's environment variables, create the transport, and pass it to `transports`:
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+import { createAxiomTransport } from 'logixlysia/axiom'
+
+const app = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        transports: [createAxiomTransport()]
+      }
+    })
+  )
+  .get('/', () => 'ok')
+  .listen(3000)
+```
+
+Trigger a request and the access log appears in your platform's log explorer.
+
+## Shared Behavior
+
+All adapters share the same core:
+
+- **Batching** — entries buffer and flush either when `maxBatchSize` is reached (default 20) or after `flushIntervalMs` (default 2000 ms), whichever comes first.
+- **Retries** — network errors, `429`, and `5xx` responses retry with linear backoff (default 2 retries). Other `4xx` responses fail immediately.
+- **Timeout** — each request aborts after `timeout` ms (default 5000).
+- **Non-blocking** — sends run in the background and never delay your HTTP responses. Failures are reported through [`onError`](/docs/features/transports) (sink `'transport'`) or rate-limited to stderr.
+- **Credentials** — read from environment variables by default; options passed to the factory always win. Missing credentials throw at startup with an actionable message, not silently at runtime.
+
+Every adapter accepts these options on top of its platform-specific ones:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `maxBatchSize` | `number` | `20` | Entries buffered before an immediate flush |
+| `flushIntervalMs` | `number` | `2000` | Max time an entry waits before the buffer is sent |
+| `timeout` | `number` | `5000` | Per-request timeout in milliseconds |
+| `retries` | `number` | `2` | Retry attempts on network errors, 429, and 5xx |
+
+## Multiple Destinations
+
+Adapters compose — fan the same logs out to several platforms:
+
+```ts
+import { createAxiomTransport } from 'logixlysia/axiom'
+import { createSentryTransport } from 'logixlysia/sentry'
+
+app.use(
+  logixlysia({
+    config: {
+      transports: [createAxiomTransport(), createSentryTransport()]
+    }
+  })
+)
+```
+
+## Production-Only External Logging
+
+Use `useTransportsOnly` to disable console and file output and send logs exclusively to your platform:
+
+```ts
+app.use(
+  logixlysia({
+    config: {
+      transports: [createAxiomTransport()],
+      useTransportsOnly: process.env.NODE_ENV === 'production'
+    }
+  })
+)
+```
+
+## Graceful Shutdown
+
+Batching timers never keep the process alive, so flush pending entries before exit. `beforeExit` alone does not fire on `SIGTERM`/`SIGINT`, so handle those too:
+
+```ts
+const axiom = createAxiomTransport()
+const FLUSH_DEADLINE_MS = 3000
+
+const shutdown = async () => {
+  await app.stop()
+  await Promise.race([
+    axiom.flush().catch(() => {
+      /* already reported */
+    }),
+    new Promise(resolve => setTimeout(resolve, FLUSH_DEADLINE_MS))
+  ])
+  process.exit(0)
+}
+
+process.on('SIGTERM', shutdown)
+process.on('SIGINT', shutdown)
+```
+
+## What Gets Sent
+
+Each log carries its level, message, and the full meta object: the request method and URL, the response status, `durationMs`, and everything merged into the [request context](/docs/features/request-context) — request IDs, trace IDs, user IDs, and your own fields. Platforms that prefer flat attributes (HyperDX, Sentry, PostHog) receive dot-notation keys like `request.method` and `context.requestId`; Axiom receives the nested structure as-is.
+
+[Redaction](/docs/configuration) runs before transports, so `autoRedact` and `redactKeys` apply to everything an adapter ships off-box.

--- a/apps/docs/content/adapters/posthog.mdx
+++ b/apps/docs/content/adapters/posthog.mdx
@@ -1,0 +1,97 @@
+---
+title: PostHog
+description: Capture logs as PostHog events linked to persons
+---
+
+Send logs to [PostHog](https://posthog.com) as captured events. Each log becomes an event with dot-notation properties you can use in filters, insights, and cohorts — and logs carrying a user ID link to PostHog persons automatically.
+
+## Setup
+
+1. Copy your project API key (`phc_…`) from **Settings → Project → Project API Key**.
+2. Set the environment variables:
+
+```bash
+POSTHOG_API_KEY=phc_your-project-key
+POSTHOG_HOST=https://us.i.posthog.com # or https://eu.i.posthog.com
+```
+
+3. Wire the transport:
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+import { createPostHogTransport } from 'logixlysia/posthog'
+
+const app = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        transports: [createPostHogTransport()]
+      }
+    })
+  )
+  .get('/', () => 'ok')
+  .listen(3000)
+```
+
+4. Trigger a request and find `logixlysia_log` events in the activity explorer.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `POSTHOG_API_KEY` | Yes | Project API key (`phc_…`) |
+| `POSTHOG_HOST` | No | Instance URL — US cloud (default), EU cloud, or self-hosted |
+
+## Options
+
+```ts
+const posthog = createPostHogTransport({
+  distinctIdField: 'context.accountId',
+  eventName: 'api_log'
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `apiKey` | `string` | `POSTHOG_API_KEY` | Project API key |
+| `host` | `string` | `https://us.i.posthog.com` | PostHog instance URL |
+| `eventName` | `string` | `logixlysia_log` | Name of the captured event |
+| `distinctIdField` | `string` | `context.userId` | Meta path resolved per log to `distinct_id` |
+| `distinctId` | `string` | `logixlysia-server` | Static fallback when the field resolves to nothing |
+
+Plus the shared batching options: `maxBatchSize`, `flushIntervalMs`, `timeout`, `retries` — see the [overview](/docs/adapters/overview#shared-behavior).
+
+## Payload
+
+Logs post to `{host}/batch/`. Each event carries flat, chart-friendly properties:
+
+| Property | Example |
+|----------|---------|
+| `level` | `INFO` |
+| `message` | `GET /users` |
+| `request.method` | `GET` |
+| `status` | `200` |
+| `durationMs` | `12.4` |
+| `context.requestId` | `0d5e…` |
+
+PostHog processes events asynchronously — expect them to appear within about a minute.
+
+## Linking Logs to Persons
+
+Merge a user ID into the request context and the log's `distinct_id` resolves to it:
+
+```ts
+app.get('/profile', ({ log, userId }) => {
+  log.mergeContext({ userId })
+  return getProfile(userId)
+})
+```
+
+Point `distinctIdField` at any other meta path (dot notation) if your identifier lives elsewhere. Without an identifier, events fall back to the static `distinctId` — handy for a backend acting as a single identity.
+
+## Troubleshooting
+
+- **`401`** — the key is not a project API key; it must start with `phc_`.
+- **Events missing** — check the region: EU projects must use `https://eu.i.posthog.com`.
+- **High event volume** — log levels you don't need can be excluded with [`logFilter`](/docs/features/filtering) before they reach the transport.

--- a/apps/docs/content/adapters/sentry.mdx
+++ b/apps/docs/content/adapters/sentry.mdx
@@ -1,0 +1,80 @@
+---
+title: Sentry
+description: Ship structured logs to Sentry next to your errors and traces
+---
+
+Send logs to [Sentry](https://sentry.io)'s structured logs (**Explore → Logs**). Every meta field becomes a typed, searchable attribute, and logs link to traces through `trace_id` — no Sentry SDK required.
+
+## Setup
+
+1. Create (or open) a project in Sentry and copy its DSN from **Settings → Projects → Client Keys (DSN)**.
+2. Set the environment variable:
+
+```bash
+SENTRY_DSN=https://your-public-key@o0.ingest.sentry.io/your-project-id
+```
+
+3. Wire the transport:
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+import { createSentryTransport } from 'logixlysia/sentry'
+
+const app = new Elysia()
+  .use(
+    logixlysia({
+      config: {
+        transports: [createSentryTransport()]
+      }
+    })
+  )
+  .get('/', () => 'ok')
+  .listen(3000)
+```
+
+4. Trigger a request and open **Explore → Logs** in Sentry.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `SENTRY_DSN` | Yes | Project DSN (`https://<public-key>@<host>/<project-id>`) |
+| `SENTRY_ENVIRONMENT` | No | Sets the `sentry.environment` attribute |
+| `SENTRY_RELEASE` | No | Sets the `sentry.release` attribute |
+
+## Options
+
+```ts
+const sentry = createSentryTransport({
+  environment: 'production',
+  release: '1.4.2',
+  tags: { team: 'backend' }
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `dsn` | `string` | `SENTRY_DSN` | Project DSN |
+| `environment` | `string` | `SENTRY_ENVIRONMENT` | `sentry.environment` attribute |
+| `release` | `string` | `SENTRY_RELEASE` | `sentry.release` attribute |
+| `tags` | `Record<string, string>` | — | Extra attributes added to every log |
+
+Plus the shared batching options: `maxBatchSize`, `flushIntervalMs`, `timeout`, `retries` — see the [overview](/docs/adapters/overview#shared-behavior).
+
+## Payload
+
+Logs post to the project's envelope endpoint as Sentry log items:
+
+- **Body** — the log message, or `GET /path` for access logs.
+- **Level** — `DEBUG` → `debug`, `INFO` → `info`, `WARNING` → `warn`, `ERROR` → `error`.
+- **Attributes** — meta fields flattened to typed attributes (`string`, `integer`, `double`, `boolean`): `request.method`, `status`, `durationMs`, `context.requestId`, and anything you merge into the request context.
+- **Trace ID** — reused from `context.trace_id` when [`logixlysia/otel`](/docs/integrations/otel) injected one (linking logs to the trace), otherwise generated.
+
+Filter in Sentry by any attribute, e.g. `status:500` or `context.requestId:0d5e…`.
+
+## Troubleshooting
+
+- **`401` / `403`** — the DSN was revoked or belongs to another project; copy a fresh one from Client Keys.
+- **`invalid DSN` at startup** — the expected shape is `https://<public-key>@<host>/<project-id>`.
+- **Logs don't link to traces** — make sure `trace_id` reaches the request context via [`logixlysia/otel`](/docs/integrations/otel).

--- a/apps/docs/content/docs.json
+++ b/apps/docs/content/docs.json
@@ -56,6 +56,21 @@
         ]
       },
       {
+        "group": "Adapters",
+        "pages": [
+          "adapters/overview",
+          "adapters/axiom",
+          "adapters/better-stack",
+          "adapters/clickhouse",
+          "adapters/datadog",
+          "adapters/hyperdx",
+          "adapters/loki",
+          "adapters/otlp",
+          "adapters/posthog",
+          "adapters/sentry"
+        ]
+      },
+      {
         "group": "Integrations",
         "pages": ["integrations/pino", "integrations/otel", "integrations/ai"]
       }

--- a/apps/docs/content/features/transports.mdx
+++ b/apps/docs/content/features/transports.mdx
@@ -5,6 +5,8 @@ description: Send logs to external services
 
 Send logs to external services using custom transports. Transports work alongside built-in console and file logging.
 
+Looking for Axiom, Better Stack, ClickHouse, Datadog, HyperDX, Loki, OTLP, PostHog, or Sentry? Built-in [adapters](/docs/adapters/overview) cover those — with batching, retries, and credential handling included. Custom transports are for everything else.
+
 ## Output Behavior
 
 Logixlysia supports three types of logging outputs:

--- a/apps/docs/content/meta.ts
+++ b/apps/docs/content/meta.ts
@@ -12,6 +12,7 @@ export default defineMeta({
     'configuration',
     'api-reference',
     'features',
+    'adapters',
     'integrations'
   ],
   title: 'Documentation'

--- a/packages/logixlysia/__tests__/adapters/axiom.test.ts
+++ b/packages/logixlysia/__tests__/adapters/axiom.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createAxiomTransport } from '../../src/axiom'
+import { stubEnv, stubFetch } from './helpers'
+
+const CLEAR_ENV = {
+  AXIOM_API_KEY: undefined,
+  AXIOM_DATASET: undefined,
+  AXIOM_ORG_ID: undefined,
+  AXIOM_URL: undefined
+}
+
+describe('logixlysia/axiom', () => {
+  test('throws without an API token', () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    try {
+      expect(() => createAxiomTransport()).toThrow('AXIOM_API_KEY')
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  test('throws without a dataset', () => {
+    const restoreEnv = stubEnv({ ...CLEAR_ENV, AXIOM_API_KEY: 'xaat-test' })
+    try {
+      expect(() => createAxiomTransport()).toThrow('AXIOM_DATASET')
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  test('reads credentials from the environment', async () => {
+    const restoreEnv = stubEnv({
+      ...CLEAR_ENV,
+      AXIOM_API_KEY: 'xaat-test',
+      AXIOM_DATASET: 'my-logs',
+      AXIOM_ORG_ID: 'my-org'
+    })
+    const stub = stubFetch()
+    try {
+      const transport = createAxiomTransport()
+      transport.log('INFO', 'hello', { status: 200 })
+      await transport.flush()
+
+      expect(stub.calls).toHaveLength(1)
+      const [call] = stub.calls
+      expect(call?.url).toBe('https://api.axiom.co/v1/datasets/my-logs/ingest')
+      expect(call?.headers.authorization).toBe('Bearer xaat-test')
+      expect(call?.headers['x-axiom-org-id']).toBe('my-org')
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('sends events with _time, level, message, and meta', async () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    const stub = stubFetch()
+    try {
+      const transport = createAxiomTransport({
+        apiKey: 'xaat-test',
+        dataset: 'my-logs'
+      })
+      transport.log('ERROR', 'boom', {
+        context: { requestId: 'r1' },
+        status: 500
+      })
+      await transport.flush()
+
+      const events = JSON.parse(stub.calls[0]?.body ?? '[]') as Record<
+        string,
+        unknown
+      >[]
+      expect(events).toHaveLength(1)
+      expect(events[0]).toMatchObject({
+        context: { requestId: 'r1' },
+        level: 'ERROR',
+        message: 'boom',
+        status: 500
+      })
+      expect(typeof events[0]?._time).toBe('string')
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('option overrides beat environment variables', async () => {
+    const restoreEnv = stubEnv({
+      ...CLEAR_ENV,
+      AXIOM_API_KEY: 'xaat-env',
+      AXIOM_DATASET: 'env-logs',
+      AXIOM_URL: 'https://env.example.com'
+    })
+    const stub = stubFetch()
+    try {
+      const transport = createAxiomTransport({
+        baseUrl: 'https://self-hosted.example.com/',
+        dataset: 'override-logs'
+      })
+      transport.log('INFO', 'hi')
+      await transport.flush()
+
+      expect(stub.calls[0]?.url).toBe(
+        'https://self-hosted.example.com/v1/datasets/override-logs/ingest'
+      )
+      expect(stub.calls[0]?.headers.authorization).toBe('Bearer xaat-env')
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('meta cannot overwrite _time, level, or message', async () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    const stub = stubFetch()
+    try {
+      const transport = createAxiomTransport({
+        apiKey: 'xaat-test',
+        dataset: 'my-logs'
+      })
+      transport.log('ERROR', 'real', {
+        _time: 'spoofed',
+        level: 'SPOOFED',
+        message: 'spoofed'
+      })
+      await transport.flush()
+
+      const events = JSON.parse(stub.calls[0]?.body ?? '[]') as Record<
+        string,
+        unknown
+      >[]
+      expect(events[0]?.level).toBe('ERROR')
+      expect(events[0]?.message).toBe('real')
+      expect(events[0]?._time).not.toBe('spoofed')
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+})

--- a/packages/logixlysia/__tests__/adapters/better-stack.test.ts
+++ b/packages/logixlysia/__tests__/adapters/better-stack.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createBetterStackTransport } from '../../src/better-stack'
+import { stubEnv, stubFetch } from './helpers'
+
+const CLEAR_ENV = {
+  BETTER_STACK_INGESTING_HOST: undefined,
+  BETTER_STACK_SOURCE_TOKEN: undefined
+}
+
+describe('logixlysia/better-stack', () => {
+  test('throws without a source token', () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    try {
+      expect(() => createBetterStackTransport()).toThrow(
+        'BETTER_STACK_SOURCE_TOKEN'
+      )
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  test('sends logs with dt, level, message, and meta', async () => {
+    const restoreEnv = stubEnv({
+      ...CLEAR_ENV,
+      BETTER_STACK_SOURCE_TOKEN: 'bs-token'
+    })
+    const stub = stubFetch()
+    try {
+      const transport = createBetterStackTransport()
+      transport.log('INFO', 'hello', { status: 200 })
+      await transport.flush()
+
+      const [call] = stub.calls
+      expect(call?.url).toBe('https://in.logs.betterstack.com')
+      expect(call?.headers.authorization).toBe('Bearer bs-token')
+
+      const logs = JSON.parse(call?.body ?? '[]') as Record<string, unknown>[]
+      expect(logs[0]).toMatchObject({
+        level: 'INFO',
+        message: 'hello',
+        status: 200
+      })
+      expect(typeof logs[0]?.dt).toBe('string')
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('uses a dedicated ingesting host when configured', async () => {
+    const restoreEnv = stubEnv({
+      ...CLEAR_ENV,
+      BETTER_STACK_INGESTING_HOST: 'https://s123.eu-nbg-2.betterstackdata.com/'
+    })
+    const stub = stubFetch()
+    try {
+      const transport = createBetterStackTransport({ sourceToken: 'bs-token' })
+      transport.log('INFO', 'hi')
+      await transport.flush()
+      expect(stub.calls[0]?.url).toBe(
+        'https://s123.eu-nbg-2.betterstackdata.com'
+      )
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('meta cannot overwrite dt, level, or message', async () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    const stub = stubFetch()
+    try {
+      const transport = createBetterStackTransport({ sourceToken: 'bs-token' })
+      transport.log('ERROR', 'real', {
+        dt: 'spoofed',
+        level: 'SPOOFED',
+        message: 'spoofed'
+      })
+      await transport.flush()
+
+      const logs = JSON.parse(stub.calls[0]?.body ?? '[]') as Record<
+        string,
+        unknown
+      >[]
+      expect(logs[0]?.level).toBe('ERROR')
+      expect(logs[0]?.message).toBe('real')
+      expect(logs[0]?.dt).not.toBe('spoofed')
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+})

--- a/packages/logixlysia/__tests__/adapters/clickhouse.test.ts
+++ b/packages/logixlysia/__tests__/adapters/clickhouse.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createClickHouseTransport } from '../../src/clickhouse'
+import { stubEnv, stubFetch } from './helpers'
+
+const CLEAR_ENV = {
+  CLICKHOUSE_DATABASE: undefined,
+  CLICKHOUSE_PASSWORD: undefined,
+  CLICKHOUSE_TABLE: undefined,
+  CLICKHOUSE_URL: undefined,
+  CLICKHOUSE_USERNAME: undefined
+}
+
+describe('logixlysia/clickhouse', () => {
+  test('rejects identifiers that are not plain names', () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    try {
+      expect(() =>
+        createClickHouseTransport({ table: 'logs; DROP TABLE users' })
+      ).toThrow('invalid table')
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  test('inserts JSONEachRow rows with flattened attributes', async () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    const stub = stubFetch()
+    try {
+      const transport = createClickHouseTransport({
+        password: 'secret',
+        username: 'writer'
+      })
+      transport.log('INFO', 'hello', {
+        context: { requestId: 'r1' },
+        status: 200
+      })
+      transport.log('ERROR', 'boom', { status: 500 })
+      await transport.flush()
+
+      const [call] = stub.calls
+      const url = new URL(call?.url ?? '')
+      expect(url.origin).toBe('http://localhost:8123')
+      expect(url.searchParams.get('query')).toBe(
+        'INSERT INTO default.logs FORMAT JSONEachRow'
+      )
+      expect(url.searchParams.get('date_time_input_format')).toBe('best_effort')
+      expect(call?.headers['x-clickhouse-user']).toBe('writer')
+      expect(call?.headers['x-clickhouse-key']).toBe('secret')
+
+      const rows = (call?.body ?? '')
+        .split('\n')
+        .map(line => JSON.parse(line) as Record<string, unknown>)
+      expect(rows).toHaveLength(2)
+      expect(rows[0]).toMatchObject({
+        attributes: { 'context.requestId': 'r1', status: '200' },
+        level: 'INFO',
+        message: 'hello'
+      })
+      expect(rows[1]).toMatchObject({ level: 'ERROR', message: 'boom' })
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('reads connection settings from the environment', async () => {
+    const restoreEnv = stubEnv({
+      ...CLEAR_ENV,
+      CLICKHOUSE_DATABASE: 'observability',
+      CLICKHOUSE_TABLE: 'app_logs',
+      CLICKHOUSE_URL: 'http://clickhouse:8123/'
+    })
+    const stub = stubFetch()
+    try {
+      const transport = createClickHouseTransport()
+      transport.log('INFO', 'hi')
+      await transport.flush()
+
+      const url = new URL(stub.calls[0]?.url ?? '')
+      expect(url.origin).toBe('http://clickhouse:8123')
+      expect(url.searchParams.get('query')).toBe(
+        'INSERT INTO observability.app_logs FORMAT JSONEachRow'
+      )
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+})

--- a/packages/logixlysia/__tests__/adapters/datadog.test.ts
+++ b/packages/logixlysia/__tests__/adapters/datadog.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createDatadogTransport } from '../../src/datadog'
+import { stubEnv, stubFetch } from './helpers'
+
+const CLEAR_ENV = {
+  DD_API_KEY: undefined,
+  DD_HOSTNAME: undefined,
+  DD_SERVICE: undefined,
+  DD_SITE: undefined
+}
+
+describe('logixlysia/datadog', () => {
+  test('throws without an API key', () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    try {
+      expect(() => createDatadogTransport()).toThrow('DD_API_KEY')
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  test('sends logs to the v2 intake with status and meta', async () => {
+    const restoreEnv = stubEnv({
+      ...CLEAR_ENV,
+      DD_API_KEY: 'dd-key',
+      DD_SERVICE: 'my-api'
+    })
+    const stub = stubFetch()
+    try {
+      const transport = createDatadogTransport({ tags: { team: 'backend' } })
+      transport.log('WARNING', 'careful', {
+        request: { method: 'GET', url: 'http://localhost/x' },
+        status: 429
+      })
+      await transport.flush()
+
+      const [call] = stub.calls
+      expect(call?.url).toBe(
+        'https://http-intake.logs.datadoghq.com/api/v2/logs'
+      )
+      expect(call?.headers['dd-api-key']).toBe('dd-key')
+
+      const logs = JSON.parse(call?.body ?? '[]') as Record<string, unknown>[]
+      expect(logs).toHaveLength(1)
+      expect(logs[0]).toMatchObject({
+        ddsource: 'logixlysia',
+        ddtags: 'team:backend',
+        http: { status_code: 429 },
+        message: 'careful',
+        request: { method: 'GET', url: 'http://localhost/x' },
+        service: 'my-api',
+        status: 'warning'
+      })
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('respects the DD_SITE region', async () => {
+    const restoreEnv = stubEnv({ ...CLEAR_ENV, DD_SITE: 'datadoghq.eu' })
+    const stub = stubFetch()
+    try {
+      const transport = createDatadogTransport({ apiKey: 'dd-key' })
+      transport.log('INFO', 'hi')
+      await transport.flush()
+      expect(stub.calls[0]?.url).toBe(
+        'https://http-intake.logs.datadoghq.eu/api/v2/logs'
+      )
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+})

--- a/packages/logixlysia/__tests__/adapters/helpers.ts
+++ b/packages/logixlysia/__tests__/adapters/helpers.ts
@@ -1,0 +1,76 @@
+import { mock } from 'bun:test'
+
+export interface FetchCall {
+  body: string
+  headers: Record<string, string>
+  method: string
+  url: string
+}
+
+export interface FetchStub {
+  calls: FetchCall[]
+  restore: () => void
+}
+
+/**
+ * Replaces `globalThis.fetch` with a stub that records calls and answers with
+ * the queued responses (the last one repeats). Call `restore()` in `finally`.
+ */
+export const stubFetch = (
+  responses: Array<{ body?: string; status: number }> = [{ status: 200 }]
+): FetchStub => {
+  const original = globalThis.fetch
+  const calls: FetchCall[] = []
+  let index = 0
+
+  const fake = mock((input: string | URL | Request, init?: RequestInit) => {
+    const headers: Record<string, string> = {}
+    for (const [key, value] of new Headers(init?.headers).entries()) {
+      headers[key] = value
+    }
+    calls.push({
+      body: typeof init?.body === 'string' ? init.body : '',
+      headers,
+      method: init?.method ?? 'GET',
+      url: String(input)
+    })
+    const response = responses[Math.min(index, responses.length - 1)]
+    index += 1
+    return Promise.resolve(
+      new Response(response?.body ?? '{}', { status: response?.status ?? 200 })
+    )
+  })
+
+  globalThis.fetch = fake as unknown as typeof fetch
+
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original
+    }
+  }
+}
+
+/** Sets env vars for a test, returning a restore function. */
+export const stubEnv = (
+  vars: Record<string, string | undefined>
+): (() => void) => {
+  const previous = new Map<string, string | undefined>()
+  for (const [key, value] of Object.entries(vars)) {
+    previous.set(key, process.env[key])
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+  return () => {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+}

--- a/packages/logixlysia/__tests__/adapters/hyperdx.test.ts
+++ b/packages/logixlysia/__tests__/adapters/hyperdx.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createHyperDXTransport } from '../../src/hyperdx'
+import { stubEnv, stubFetch } from './helpers'
+
+const CLEAR_ENV = {
+  HYPERDX_API_KEY: undefined,
+  HYPERDX_OTLP_ENDPOINT: undefined,
+  HYPERDX_SERVICE_NAME: undefined,
+  OTEL_SERVICE_NAME: undefined
+}
+
+interface OtlpAttribute {
+  key: string
+  value: Record<string, unknown>
+}
+
+interface OtlpPayload {
+  resourceLogs: Array<{
+    resource: { attributes: OtlpAttribute[] }
+    scopeLogs: Array<{
+      logRecords: Array<{
+        attributes: OtlpAttribute[]
+        body: { stringValue: string }
+        severityNumber: number
+        severityText: string
+        timeUnixNano: string
+      }>
+    }>
+  }>
+}
+
+describe('logixlysia/hyperdx', () => {
+  test('throws without an API key', () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    try {
+      expect(() => createHyperDXTransport()).toThrow('HYPERDX_API_KEY')
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  test('sends OTLP logs to the default endpoint', async () => {
+    const restoreEnv = stubEnv({ ...CLEAR_ENV, HYPERDX_API_KEY: 'hdx-key' })
+    const stub = stubFetch()
+    try {
+      const transport = createHyperDXTransport({ serviceName: 'my-api' })
+      transport.log('WARNING', 'careful', {
+        durationMs: 12.5,
+        request: { method: 'GET', url: 'http://localhost/x' }
+      })
+      await transport.flush()
+
+      const [call] = stub.calls
+      expect(call?.url).toBe('https://in-otel.hyperdx.io/v1/logs')
+      expect(call?.headers.authorization).toBe('hdx-key')
+
+      const payload = JSON.parse(call?.body ?? '{}') as OtlpPayload
+      const record = payload.resourceLogs[0]?.scopeLogs[0]?.logRecords[0]
+      expect(record?.body.stringValue).toBe('careful')
+      expect(record?.severityNumber).toBe(13)
+      expect(record?.severityText).toBe('WARNING')
+
+      const serviceName = payload.resourceLogs[0]?.resource.attributes.find(
+        attribute => attribute.key === 'service.name'
+      )
+      expect(serviceName?.value.stringValue).toBe('my-api')
+
+      const method = record?.attributes.find(
+        attribute => attribute.key === 'request.method'
+      )
+      expect(method?.value.stringValue).toBe('GET')
+      const duration = record?.attributes.find(
+        attribute => attribute.key === 'durationMs'
+      )
+      expect(duration?.value.doubleValue).toBe(12.5)
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('appends /v1/logs to a self-hosted endpoint', async () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    const stub = stubFetch()
+    try {
+      const transport = createHyperDXTransport({
+        apiKey: 'hdx-key',
+        endpoint: 'http://collector:4318/'
+      })
+      transport.log('INFO', 'hi')
+      await transport.flush()
+      expect(stub.calls[0]?.url).toBe('http://collector:4318/v1/logs')
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+})

--- a/packages/logixlysia/__tests__/adapters/loki.test.ts
+++ b/packages/logixlysia/__tests__/adapters/loki.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createLokiTransport } from '../../src/loki'
+import { stubEnv, stubFetch } from './helpers'
+
+const CLEAR_ENV = {
+  LOKI_PASSWORD: undefined,
+  LOKI_SERVICE_NAME: undefined,
+  LOKI_TENANT_ID: undefined,
+  LOKI_URL: undefined,
+  LOKI_USERNAME: undefined,
+  OTEL_SERVICE_NAME: undefined
+}
+
+const NANO_TIMESTAMP = /^\d+$/
+
+interface LokiPayload {
+  streams: Array<{
+    stream: Record<string, string>
+    values: [string, string][]
+  }>
+}
+
+describe('logixlysia/loki', () => {
+  test('throws without a URL', () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    try {
+      expect(() => createLokiTransport()).toThrow('LOKI_URL')
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  test('pushes level-grouped streams with JSON lines', async () => {
+    const restoreEnv = stubEnv({ ...CLEAR_ENV, LOKI_URL: 'http://loki:3100/' })
+    const stub = stubFetch()
+    try {
+      const transport = createLokiTransport({
+        labels: { env: 'test' },
+        maxBatchSize: 10,
+        serviceName: 'my-api'
+      })
+      transport.log('INFO', 'first', { status: 200 })
+      transport.log('INFO', 'second', { status: 201 })
+      transport.log('ERROR', 'boom', { status: 500 })
+      await transport.flush()
+
+      const [call] = stub.calls
+      expect(call?.url).toBe('http://loki:3100/loki/api/v1/push')
+
+      const payload = JSON.parse(call?.body ?? '{}') as LokiPayload
+      expect(payload.streams).toHaveLength(2)
+
+      const infoStream = payload.streams.find(
+        stream => stream.stream.level === 'INFO'
+      )
+      expect(infoStream?.stream).toEqual({
+        env: 'test',
+        level: 'INFO',
+        service_name: 'my-api'
+      })
+      expect(infoStream?.values).toHaveLength(2)
+
+      const [timestamp, line] = infoStream?.values[0] ?? ['', '']
+      expect(timestamp).toMatch(NANO_TIMESTAMP)
+      expect(JSON.parse(line)).toMatchObject({ message: 'first', status: 200 })
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('sends basic auth and tenant headers', async () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    const stub = stubFetch()
+    try {
+      const transport = createLokiTransport({
+        password: 'secret',
+        tenantId: 'team-a',
+        url: 'https://logs.grafana.net',
+        username: '12345'
+      })
+      transport.log('INFO', 'hi')
+      await transport.flush()
+
+      const [call] = stub.calls
+      expect(call?.headers.authorization).toBe(
+        `Basic ${Buffer.from('12345:secret').toString('base64')}`
+      )
+      expect(call?.headers['x-scope-orgid']).toBe('team-a')
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('meta cannot overwrite the log line message', async () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    const stub = stubFetch()
+    try {
+      const transport = createLokiTransport({ url: 'http://loki:3100' })
+      transport.log('INFO', 'real', { message: 'spoofed' })
+      await transport.flush()
+
+      const payload = JSON.parse(stub.calls[0]?.body ?? '{}') as LokiPayload
+      const [, line] = payload.streams[0]?.values[0] ?? ['', '']
+      expect(JSON.parse(line)).toMatchObject({ message: 'real' })
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+})

--- a/packages/logixlysia/__tests__/adapters/otlp.test.ts
+++ b/packages/logixlysia/__tests__/adapters/otlp.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createOtlpTransport } from '../../src/otlp'
+import { stubEnv, stubFetch } from './helpers'
+
+const CLEAR_ENV = {
+  OTEL_EXPORTER_OTLP_ENDPOINT: undefined,
+  OTEL_EXPORTER_OTLP_HEADERS: undefined,
+  OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: undefined,
+  OTEL_EXPORTER_OTLP_LOGS_HEADERS: undefined,
+  OTEL_SERVICE_NAME: undefined
+}
+
+interface OtlpAttribute {
+  key: string
+  value: Record<string, unknown>
+}
+
+interface OtlpPayload {
+  resourceLogs: Array<{
+    resource: { attributes: OtlpAttribute[] }
+    scopeLogs: Array<{
+      logRecords: Array<{
+        attributes: OtlpAttribute[]
+        body: { stringValue: string }
+        severityNumber: number
+        severityText: string
+      }>
+    }>
+  }>
+}
+
+describe('logixlysia/otlp', () => {
+  test('throws without an endpoint', () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    try {
+      expect(() => createOtlpTransport()).toThrow('OTEL_EXPORTER_OTLP_ENDPOINT')
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  test('sends OTLP logs and parses headers from the environment', async () => {
+    const restoreEnv = stubEnv({
+      ...CLEAR_ENV,
+      OTEL_EXPORTER_OTLP_ENDPOINT: 'http://collector:4318/',
+      OTEL_EXPORTER_OTLP_HEADERS: 'x-api-key=abc, x-team=core',
+      OTEL_SERVICE_NAME: 'env-service'
+    })
+    const stub = stubFetch()
+    try {
+      const transport = createOtlpTransport()
+      transport.log('ERROR', 'boom', { status: 500 })
+      await transport.flush()
+
+      const [call] = stub.calls
+      expect(call?.url).toBe('http://collector:4318/v1/logs')
+      expect(call?.headers['x-api-key']).toBe('abc')
+      expect(call?.headers['x-team']).toBe('core')
+
+      const payload = JSON.parse(call?.body ?? '{}') as OtlpPayload
+      const record = payload.resourceLogs[0]?.scopeLogs[0]?.logRecords[0]
+      expect(record?.body.stringValue).toBe('boom')
+      expect(record?.severityNumber).toBe(17)
+
+      const serviceName = payload.resourceLogs[0]?.resource.attributes.find(
+        attribute => attribute.key === 'service.name'
+      )
+      expect(serviceName?.value.stringValue).toBe('env-service')
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('option headers override environment headers', async () => {
+    const restoreEnv = stubEnv({
+      ...CLEAR_ENV,
+      OTEL_EXPORTER_OTLP_HEADERS: 'x-api-key=env-value'
+    })
+    const stub = stubFetch()
+    try {
+      const transport = createOtlpTransport({
+        endpoint: 'http://collector:4318',
+        headers: { 'x-api-key': 'option-value' }
+      })
+      transport.log('INFO', 'hi')
+      await transport.flush()
+      expect(stub.calls[0]?.headers['x-api-key']).toBe('option-value')
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('prefers signal-specific endpoint (as-is) and headers', async () => {
+    const restoreEnv = stubEnv({
+      ...CLEAR_ENV,
+      OTEL_EXPORTER_OTLP_ENDPOINT: 'http://generic:4318',
+      OTEL_EXPORTER_OTLP_HEADERS: 'x-api-key=generic',
+      OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: 'http://logs:4318/custom/logs',
+      OTEL_EXPORTER_OTLP_LOGS_HEADERS: 'x-api-key=logs%2Fkey'
+    })
+    const stub = stubFetch()
+    try {
+      const transport = createOtlpTransport()
+      transport.log('INFO', 'hi')
+      await transport.flush()
+
+      const [call] = stub.calls
+      expect(call?.url).toBe('http://logs:4318/custom/logs')
+      expect(call?.headers['x-api-key']).toBe('logs/key')
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+})

--- a/packages/logixlysia/__tests__/adapters/posthog.test.ts
+++ b/packages/logixlysia/__tests__/adapters/posthog.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createPostHogTransport } from '../../src/posthog'
+import { stubEnv, stubFetch } from './helpers'
+
+const CLEAR_ENV = {
+  POSTHOG_API_KEY: undefined,
+  POSTHOG_HOST: undefined
+}
+
+interface CaptureBatch {
+  api_key: string
+  batch: Array<{
+    distinct_id: string
+    event: string
+    properties: Record<string, unknown>
+    timestamp: string
+  }>
+}
+
+describe('logixlysia/posthog', () => {
+  test('throws without an API key', () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    try {
+      expect(() => createPostHogTransport()).toThrow('POSTHOG_API_KEY')
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  test('captures events via the batch API', async () => {
+    const restoreEnv = stubEnv({ ...CLEAR_ENV, POSTHOG_API_KEY: 'phc_test' })
+    const stub = stubFetch()
+    try {
+      const transport = createPostHogTransport()
+      transport.log('INFO', 'hello', {
+        durationMs: 4,
+        request: { method: 'GET', url: 'http://localhost/x' },
+        status: 200
+      })
+      await transport.flush()
+
+      const [call] = stub.calls
+      expect(call?.url).toBe('https://us.i.posthog.com/batch/')
+
+      const payload = JSON.parse(call?.body ?? '{}') as CaptureBatch
+      expect(payload.api_key).toBe('phc_test')
+      expect(payload.batch).toHaveLength(1)
+      expect(payload.batch[0]).toMatchObject({
+        distinct_id: 'logixlysia-server',
+        event: 'logixlysia_log'
+      })
+      expect(payload.batch[0]?.properties).toMatchObject({
+        durationMs: 4,
+        level: 'INFO',
+        message: 'hello',
+        'request.method': 'GET',
+        status: 200
+      })
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('resolves distinct_id from the request context', async () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    const stub = stubFetch()
+    try {
+      const transport = createPostHogTransport({ apiKey: 'phc_test' })
+      transport.log('INFO', 'who', { context: { userId: 'user-42' } })
+      await transport.flush()
+
+      const payload = JSON.parse(stub.calls[0]?.body ?? '{}') as CaptureBatch
+      expect(payload.batch[0]?.distinct_id).toBe('user-42')
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('supports EU host and custom event name and identity field', async () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    const stub = stubFetch()
+    try {
+      const transport = createPostHogTransport({
+        apiKey: 'phc_test',
+        distinctId: 'billing-service',
+        distinctIdField: 'context.accountId',
+        eventName: 'api_log',
+        host: 'https://eu.i.posthog.com/'
+      })
+      transport.log('INFO', 'first', { context: { accountId: 'acct-1' } })
+      transport.log('INFO', 'second', {})
+      await transport.flush()
+
+      const payload = JSON.parse(stub.calls[0]?.body ?? '{}') as CaptureBatch
+      expect(stub.calls[0]?.url).toBe('https://eu.i.posthog.com/batch/')
+      expect(payload.batch[0]).toMatchObject({
+        distinct_id: 'acct-1',
+        event: 'api_log'
+      })
+      expect(payload.batch[1]?.distinct_id).toBe('billing-service')
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('meta cannot overwrite level or message properties', async () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    const stub = stubFetch()
+    try {
+      const transport = createPostHogTransport({ apiKey: 'phc_test' })
+      transport.log('ERROR', 'real', { level: 'SPOOFED', message: 'spoofed' })
+      await transport.flush()
+
+      const payload = JSON.parse(stub.calls[0]?.body ?? '{}') as CaptureBatch
+      expect(payload.batch[0]?.properties).toMatchObject({
+        level: 'ERROR',
+        message: 'real'
+      })
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+})

--- a/packages/logixlysia/__tests__/adapters/sentry.test.ts
+++ b/packages/logixlysia/__tests__/adapters/sentry.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createSentryTransport } from '../../src/sentry'
+import { stubEnv, stubFetch } from './helpers'
+
+const CLEAR_ENV = {
+  SENTRY_DSN: undefined,
+  SENTRY_ENVIRONMENT: undefined,
+  SENTRY_RELEASE: undefined
+}
+
+const DSN = 'https://publickey@o123.ingest.sentry.io/456'
+const TRACE_ID_HEX = /^[0-9a-f]{32}$/
+
+interface SentryLogItem {
+  attributes: Record<string, { type: string; value: unknown }>
+  body: string
+  level: string
+  timestamp: number
+  trace_id: string
+}
+
+const parseEnvelope = (
+  body: string
+): { header: unknown; itemHeader: unknown; items: SentryLogItem[] } => {
+  const [header, itemHeader, payload] = body.split('\n')
+  return {
+    header: JSON.parse(header ?? '{}'),
+    itemHeader: JSON.parse(itemHeader ?? '{}'),
+    items: (JSON.parse(payload ?? '{}') as { items: SentryLogItem[] }).items
+  }
+}
+
+describe('logixlysia/sentry', () => {
+  test('throws without a DSN', () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    try {
+      expect(() => createSentryTransport()).toThrow('SENTRY_DSN')
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  test('throws on a malformed DSN', () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    try {
+      expect(() =>
+        createSentryTransport({ dsn: 'https://sentry.io/' })
+      ).toThrow('invalid DSN')
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  test('sends a log envelope to the project envelope endpoint', async () => {
+    const restoreEnv = stubEnv({ ...CLEAR_ENV, SENTRY_DSN: DSN })
+    const stub = stubFetch()
+    try {
+      const transport = createSentryTransport({
+        environment: 'production',
+        tags: { team: 'backend' }
+      })
+      transport.log('ERROR', 'boom', {
+        durationMs: 3,
+        status: 500
+      })
+      await transport.flush()
+
+      const [call] = stub.calls
+      expect(call?.url).toBe('https://o123.ingest.sentry.io/api/456/envelope/')
+      expect(call?.headers['content-type']).toBe(
+        'application/x-sentry-envelope'
+      )
+      expect(call?.headers['x-sentry-auth']).toContain('sentry_key=publickey')
+
+      const { itemHeader, items } = parseEnvelope(call?.body ?? '')
+      expect(itemHeader).toMatchObject({
+        content_type: 'application/vnd.sentry.items.log+json',
+        item_count: 1,
+        type: 'log'
+      })
+      const [item] = items
+      expect(item?.body).toBe('boom')
+      expect(item?.level).toBe('error')
+      expect(item?.trace_id).toMatch(TRACE_ID_HEX)
+      expect(item?.attributes['sentry.environment']).toEqual({
+        type: 'string',
+        value: 'production'
+      })
+      expect(item?.attributes.team).toEqual({
+        type: 'string',
+        value: 'backend'
+      })
+      expect(item?.attributes.status).toEqual({ type: 'integer', value: 500 })
+      expect(item?.attributes.durationMs).toEqual({
+        type: 'integer',
+        value: 3
+      })
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+
+  test('reuses a trace id from the request context', async () => {
+    const restoreEnv = stubEnv(CLEAR_ENV)
+    const stub = stubFetch()
+    const traceId = 'abcdefabcdefabcdefabcdefabcdef12'
+    try {
+      const transport = createSentryTransport({ dsn: DSN })
+      transport.log('INFO', 'traced', {
+        context: { trace_id: traceId }
+      })
+      await transport.flush()
+
+      const { items } = parseEnvelope(stub.calls[0]?.body ?? '')
+      expect(items[0]?.trace_id).toBe(traceId)
+    } finally {
+      stub.restore()
+      restoreEnv()
+    }
+  })
+})

--- a/packages/logixlysia/__tests__/adapters/shared.test.ts
+++ b/packages/logixlysia/__tests__/adapters/shared.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  createBatchQueue,
+  defaultBody,
+  flattenMeta,
+  getPath,
+  type LogEntry,
+  postWithRetry,
+  stripTrailingSlashes
+} from '../../src/adapters/shared'
+import { stubFetch } from './helpers'
+
+const entry = (overrides: Partial<LogEntry> = {}): LogEntry => ({
+  level: 'INFO',
+  message: 'hello',
+  meta: {},
+  timestamp: new Date('2026-01-01T00:00:00.000Z'),
+  ...overrides
+})
+
+describe('flattenMeta', () => {
+  test('flattens nested objects into dot-notation keys', () => {
+    const flat = flattenMeta({
+      context: { requestId: 'abc', user: { id: 7 } },
+      durationMs: 1.5,
+      request: { method: 'GET', url: 'http://x/y' },
+      status: 200
+    })
+    expect(flat).toEqual({
+      'context.requestId': 'abc',
+      'context.user.id': 7,
+      durationMs: 1.5,
+      'request.method': 'GET',
+      'request.url': 'http://x/y',
+      status: 200
+    })
+  })
+
+  test('stringifies arrays and objects beyond the depth limit', () => {
+    const flat = flattenMeta({
+      a: { b: { c: { d: { e: 1 } } } },
+      tags: ['x', 'y']
+    })
+    expect(flat['a.b.c']).toBe('{"d":{"e":1}}')
+    expect(flat.tags).toBe('["x","y"]')
+  })
+
+  test('skips null and undefined values', () => {
+    expect(flattenMeta({ a: null, b: undefined, c: 0 })).toEqual({ c: 0 })
+  })
+})
+
+describe('getPath', () => {
+  test('resolves dot-notation paths', () => {
+    expect(getPath({ context: { userId: 'u1' } }, 'context.userId')).toBe('u1')
+  })
+
+  test('returns undefined for missing segments', () => {
+    expect(getPath({ context: 'oops' }, 'context.userId')).toBeUndefined()
+  })
+})
+
+describe('defaultBody', () => {
+  test('prefers the log message', () => {
+    expect(defaultBody(entry({ message: 'custom' }))).toBe('custom')
+  })
+
+  test('falls back to method and path for access logs', () => {
+    const accessLog = entry({
+      message: '',
+      meta: { request: { method: 'GET', url: 'http://localhost/users?q=1' } }
+    })
+    expect(defaultBody(accessLog)).toBe('GET /users')
+  })
+
+  test('falls back to the level when nothing else is available', () => {
+    expect(defaultBody(entry({ message: '' }))).toBe('INFO')
+  })
+})
+
+describe('stripTrailingSlashes', () => {
+  test('removes trailing slashes only', () => {
+    expect(stripTrailingSlashes('https://api.example.com///')).toBe(
+      'https://api.example.com'
+    )
+    expect(stripTrailingSlashes('https://api.example.com')).toBe(
+      'https://api.example.com'
+    )
+  })
+})
+
+describe('postWithRetry', () => {
+  test('retries 5xx responses and succeeds', async () => {
+    const stub = stubFetch([{ status: 500 }, { status: 200 }])
+    try {
+      await postWithRetry({
+        body: '{}',
+        headers: {},
+        name: 'Test',
+        retries: 2,
+        timeout: 1000,
+        url: 'https://example.com/ingest'
+      })
+      expect(stub.calls).toHaveLength(2)
+    } finally {
+      stub.restore()
+    }
+  })
+
+  test('does not retry non-retryable 4xx responses', async () => {
+    const stub = stubFetch([{ body: 'bad key', status: 401 }])
+    try {
+      await expect(
+        postWithRetry({
+          body: '{}',
+          headers: {},
+          name: 'Test',
+          retries: 2,
+          timeout: 1000,
+          url: 'https://example.com/ingest'
+        })
+      ).rejects.toThrow('HTTP 401')
+      expect(stub.calls).toHaveLength(1)
+    } finally {
+      stub.restore()
+    }
+  })
+
+  test('throws the last error once retries are exhausted', async () => {
+    const stub = stubFetch([{ status: 503 }])
+    try {
+      await expect(
+        postWithRetry({
+          body: '{}',
+          headers: {},
+          name: 'Test',
+          retries: 1,
+          timeout: 1000,
+          url: 'https://example.com/ingest'
+        })
+      ).rejects.toThrow('HTTP 503')
+      expect(stub.calls).toHaveLength(2)
+    } finally {
+      stub.restore()
+    }
+  })
+})
+
+describe('createBatchQueue', () => {
+  test('flushes immediately when maxBatchSize is reached', async () => {
+    const batches: LogEntry[][] = []
+    const queue = createBatchQueue({
+      flushIntervalMs: 60_000,
+      maxBatchSize: 2,
+      name: 'Test',
+      send: entries => {
+        batches.push(entries)
+        return Promise.resolve()
+      }
+    })
+
+    expect(queue.push(entry())).toBeUndefined()
+    await queue.push(entry())
+    expect(batches).toHaveLength(1)
+    expect(batches[0]).toHaveLength(2)
+  })
+
+  test('flush() sends buffered entries and is a no-op when empty', async () => {
+    const batches: LogEntry[][] = []
+    const queue = createBatchQueue({
+      flushIntervalMs: 60_000,
+      maxBatchSize: 10,
+      name: 'Test',
+      send: entries => {
+        batches.push(entries)
+        return Promise.resolve()
+      }
+    })
+
+    queue.push(entry())
+    await queue.flush()
+    await queue.flush()
+    expect(batches).toHaveLength(1)
+    expect(batches[0]).toHaveLength(1)
+  })
+
+  test('flushes on the interval timer', async () => {
+    const batches: LogEntry[][] = []
+    const queue = createBatchQueue({
+      flushIntervalMs: 10,
+      maxBatchSize: 10,
+      name: 'Test',
+      send: entries => {
+        batches.push(entries)
+        return Promise.resolve()
+      }
+    })
+
+    queue.push(entry())
+    await new Promise(resolve => {
+      setTimeout(resolve, 50)
+    })
+    expect(batches).toHaveLength(1)
+  })
+})

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -8,6 +8,7 @@ const config = defineConfig({
     'src/ai.ts',
     'src/axiom.ts',
     'src/hyperdx.ts',
+    'src/sentry.ts',
     'src/otlp.ts'
   ],
   external: ['elysia', 'chalk', 'pino', 'pino-pretty'],

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -2,7 +2,13 @@ import { defineConfig } from 'bunup'
 
 const config = defineConfig({
   dts: true,
-  entry: ['src/index.ts', 'src/otel.ts', 'src/ai.ts', 'src/axiom.ts'],
+  entry: [
+    'src/index.ts',
+    'src/otel.ts',
+    'src/ai.ts',
+    'src/axiom.ts',
+    'src/otlp.ts'
+  ],
   external: ['elysia', 'chalk', 'pino', 'pino-pretty'],
   format: ['esm'],
   minify: true,

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -10,7 +10,8 @@ const config = defineConfig({
     'src/hyperdx.ts',
     'src/sentry.ts',
     'src/posthog.ts',
-    'src/otlp.ts'
+    'src/otlp.ts',
+    'src/datadog.ts'
   ],
   external: ['elysia', 'chalk', 'pino', 'pino-pretty'],
   format: ['esm'],

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -9,6 +9,7 @@ const config = defineConfig({
     'src/axiom.ts',
     'src/hyperdx.ts',
     'src/sentry.ts',
+    'src/posthog.ts',
     'src/otlp.ts'
   ],
   external: ['elysia', 'chalk', 'pino', 'pino-pretty'],

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -11,7 +11,8 @@ const config = defineConfig({
     'src/sentry.ts',
     'src/posthog.ts',
     'src/otlp.ts',
-    'src/datadog.ts'
+    'src/datadog.ts',
+    'src/better-stack.ts'
   ],
   external: ['elysia', 'chalk', 'pino', 'pino-pretty'],
   format: ['esm'],

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -12,7 +12,8 @@ const config = defineConfig({
     'src/posthog.ts',
     'src/otlp.ts',
     'src/datadog.ts',
-    'src/better-stack.ts'
+    'src/better-stack.ts',
+    'src/loki.ts'
   ],
   external: ['elysia', 'chalk', 'pino', 'pino-pretty'],
   format: ['esm'],

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -13,7 +13,8 @@ const config = defineConfig({
     'src/otlp.ts',
     'src/datadog.ts',
     'src/better-stack.ts',
-    'src/loki.ts'
+    'src/loki.ts',
+    'src/clickhouse.ts'
   ],
   external: ['elysia', 'chalk', 'pino', 'pino-pretty'],
   format: ['esm'],

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -7,6 +7,7 @@ const config = defineConfig({
     'src/otel.ts',
     'src/ai.ts',
     'src/axiom.ts',
+    'src/hyperdx.ts',
     'src/otlp.ts'
   ],
   external: ['elysia', 'chalk', 'pino', 'pino-pretty'],

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -2,12 +2,15 @@ import { defineConfig } from 'bunup'
 
 const config = defineConfig({
   dts: true,
-  entry: ['src/index.ts', 'src/otel.ts', 'src/ai.ts'],
+  entry: ['src/index.ts', 'src/otel.ts', 'src/ai.ts', 'src/axiom.ts'],
   external: ['elysia', 'chalk', 'pino', 'pino-pretty'],
   format: ['esm'],
   minify: true,
   name: 'Logixlysia',
   outDir: 'dist',
+  // Pin the entry root: with 9+ entries Bun.build's inferred common root
+  // nests output under dist/src/, breaking the flat dist/*.js exports paths.
+  sourceBase: './src',
   sourcemap: 'inline'
 })
 

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -44,6 +44,11 @@
       "import": "./dist/hyperdx.js",
       "default": "./dist/hyperdx.js"
     },
+    "./sentry": {
+      "types": "./dist/sentry.d.ts",
+      "import": "./dist/sentry.js",
+      "default": "./dist/sentry.js"
+    },
     "./otlp": {
       "types": "./dist/otlp.d.ts",
       "import": "./dist/otlp.js",

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -39,6 +39,11 @@
       "import": "./dist/axiom.js",
       "default": "./dist/axiom.js"
     },
+    "./hyperdx": {
+      "types": "./dist/hyperdx.d.ts",
+      "import": "./dist/hyperdx.js",
+      "default": "./dist/hyperdx.js"
+    },
     "./otlp": {
       "types": "./dist/otlp.d.ts",
       "import": "./dist/otlp.js",

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -39,6 +39,11 @@
       "import": "./dist/axiom.js",
       "default": "./dist/axiom.js"
     },
+    "./otlp": {
+      "types": "./dist/otlp.d.ts",
+      "import": "./dist/otlp.js",
+      "default": "./dist/otlp.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -49,6 +49,11 @@
       "import": "./dist/sentry.js",
       "default": "./dist/sentry.js"
     },
+    "./posthog": {
+      "types": "./dist/posthog.d.ts",
+      "import": "./dist/posthog.js",
+      "default": "./dist/posthog.js"
+    },
     "./otlp": {
       "types": "./dist/otlp.d.ts",
       "import": "./dist/otlp.js",

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -74,6 +74,11 @@
       "import": "./dist/loki.js",
       "default": "./dist/loki.js"
     },
+    "./clickhouse": {
+      "types": "./dist/clickhouse.d.ts",
+      "import": "./dist/clickhouse.js",
+      "default": "./dist/clickhouse.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -64,6 +64,11 @@
       "import": "./dist/datadog.js",
       "default": "./dist/datadog.js"
     },
+    "./better-stack": {
+      "types": "./dist/better-stack.d.ts",
+      "import": "./dist/better-stack.js",
+      "default": "./dist/better-stack.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -59,6 +59,11 @@
       "import": "./dist/otlp.js",
       "default": "./dist/otlp.js"
     },
+    "./datadog": {
+      "types": "./dist/datadog.d.ts",
+      "import": "./dist/datadog.js",
+      "default": "./dist/datadog.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -34,6 +34,11 @@
       "import": "./dist/ai.js",
       "default": "./dist/ai.js"
     },
+    "./axiom": {
+      "types": "./dist/axiom.d.ts",
+      "import": "./dist/axiom.js",
+      "default": "./dist/axiom.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -69,6 +69,11 @@
       "import": "./dist/better-stack.js",
       "default": "./dist/better-stack.js"
     },
+    "./loki": {
+      "types": "./dist/loki.d.ts",
+      "import": "./dist/loki.js",
+      "default": "./dist/loki.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",

--- a/packages/logixlysia/src/adapters/otlp-core.ts
+++ b/packages/logixlysia/src/adapters/otlp-core.ts
@@ -1,0 +1,93 @@
+import {
+  type AdapterTransport,
+  type BatchTransportOptions,
+  createHttpTransport,
+  defaultBody,
+  type FlatValue,
+  flattenMeta,
+  type LogEntry,
+  OTEL_SEVERITY,
+  toUnixNanos
+} from './shared'
+
+interface OtlpAnyValue {
+  boolValue?: boolean
+  doubleValue?: number
+  intValue?: string
+  stringValue?: string
+}
+
+const toOtlpValue = (value: FlatValue): OtlpAnyValue => {
+  if (typeof value === 'boolean') {
+    return { boolValue: value }
+  }
+  if (typeof value === 'number') {
+    return Number.isInteger(value)
+      ? { intValue: String(value) }
+      : { doubleValue: value }
+  }
+  return { stringValue: value }
+}
+
+const toOtlpAttributes = (
+  flat: Record<string, FlatValue>
+): Array<{ key: string; value: OtlpAnyValue }> =>
+  Object.entries(flat).map(([key, value]) => ({
+    key,
+    value: toOtlpValue(value)
+  }))
+
+export interface OtlpCoreInput {
+  headers: Record<string, string>
+  /** Adapter name used in error messages, e.g. 'OTLP' or 'HyperDX'. */
+  name: string
+  options: BatchTransportOptions
+  resourceAttributes: Record<string, string>
+  serviceName: string
+  /** Full OTLP logs URL, e.g. `https://collector:4318/v1/logs`. */
+  url: string
+}
+
+/**
+ * Shared OTLP-logs transport core: builds an `ExportLogsServiceRequest` JSON
+ * payload and POSTs it to the logs URL. Backs both the generic
+ * `logixlysia/otlp` adapter and vendor wrappers like `logixlysia/hyperdx`.
+ */
+export const createOtlpCore = (input: OtlpCoreInput): AdapterTransport => {
+  const resourceAttributes = toOtlpAttributes({
+    'service.name': input.serviceName,
+    ...input.resourceAttributes
+  })
+
+  const body = (entries: LogEntry[]): string =>
+    JSON.stringify({
+      resourceLogs: [
+        {
+          resource: { attributes: resourceAttributes },
+          scopeLogs: [
+            {
+              logRecords: entries.map(entry => ({
+                attributes: toOtlpAttributes(flattenMeta(entry.meta)),
+                body: { stringValue: defaultBody(entry) },
+                severityNumber: OTEL_SEVERITY[entry.level],
+                severityText: entry.level,
+                timeUnixNano: toUnixNanos(entry.timestamp)
+              })),
+              scope: { name: 'logixlysia' }
+            }
+          ]
+        }
+      ]
+    })
+
+  return createHttpTransport({
+    body,
+    headers: {
+      'Content-Type': 'application/json',
+      ...input.headers
+    },
+    name: input.name,
+    options: input.options,
+    url: input.url
+  })
+}

--- a/packages/logixlysia/src/adapters/shared.ts
+++ b/packages/logixlysia/src/adapters/shared.ts
@@ -1,0 +1,343 @@
+import type { LogLevel, Transport } from '../interfaces'
+
+/** OpenTelemetry severity numbers for each Logixlysia log level. */
+export const OTEL_SEVERITY: Record<LogLevel, number> = {
+  DEBUG: 5,
+  ERROR: 17,
+  INFO: 9,
+  WARNING: 13
+}
+
+const DEFAULT_FLUSH_INTERVAL_MS = 2000
+const DEFAULT_MAX_BATCH_SIZE = 20
+const DEFAULT_RETRIES = 2
+const DEFAULT_TIMEOUT_MS = 5000
+const RETRY_BASE_DELAY_MS = 250
+const HTTP_TOO_MANY_REQUESTS = 429
+const HTTP_SERVER_ERROR_MIN = 500
+const ERROR_BODY_PREVIEW_LENGTH = 200
+const FLATTEN_MAX_DEPTH = 3
+
+export interface BatchTransportOptions {
+  /**
+   * Max time (ms) an entry waits in the buffer before it is sent.
+   * @default 2000
+   */
+  flushIntervalMs?: number
+  /**
+   * Entries buffered before an immediate flush, regardless of the interval.
+   * @default 20
+   */
+  maxBatchSize?: number
+  /**
+   * Retry attempts on network errors, 429, and 5xx responses.
+   * @default 2
+   */
+  retries?: number
+  /**
+   * Per-request timeout in milliseconds.
+   * @default 5000
+   */
+  timeout?: number
+}
+
+/** A {@link Transport} that batches entries and can be flushed on demand. */
+export interface AdapterTransport extends Transport {
+  /** Sends any buffered entries immediately. Call before process exit. */
+  flush: () => Promise<void>
+}
+
+export interface LogEntry {
+  level: LogLevel
+  message: string
+  meta: Record<string, unknown>
+  timestamp: Date
+}
+
+/** Normalizes a base URL by dropping trailing slashes. */
+export const stripTrailingSlashes = (url: string): string => {
+  let end = url.length
+  while (end > 0 && url[end - 1] === '/') {
+    end -= 1
+  }
+  return url.slice(0, end)
+}
+
+/** Reads a non-empty environment variable, or `undefined`. */
+export const envString = (name: string): string | undefined => {
+  const value = process.env[name]
+  return value && value.length > 0 ? value : undefined
+}
+
+/** A configuration error for the named adapter, thrown at creation time. */
+export const transportError = (adapter: string, detail: string): Error =>
+  new Error(`[logixlysia] ${adapter} transport: ${detail}`)
+
+const NANOS_PER_MILLI = 1_000_000n
+
+/** Unix-epoch nanoseconds as a string, the timestamp shape OTLP and Loki expect. */
+export const toUnixNanos = (date: Date): string =>
+  String(BigInt(date.getTime()) * NANOS_PER_MILLI)
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise(resolve => {
+    setTimeout(resolve, ms)
+  })
+
+export interface PostWithRetryInput {
+  body: string
+  headers: Record<string, string>
+  /** Adapter name used in error messages, e.g. 'Axiom'. */
+  name: string
+  retries: number
+  timeout: number
+  url: string
+}
+
+const attemptPost = async (
+  input: PostWithRetryInput,
+  attempt: number
+): Promise<void> => {
+  const retryOrRethrow = async (error: Error): Promise<void> => {
+    if (attempt >= input.retries) {
+      throw error
+    }
+    await sleep(RETRY_BASE_DELAY_MS * (attempt + 1))
+    return attemptPost(input, attempt + 1)
+  }
+
+  let response: Response
+  try {
+    response = await fetch(input.url, {
+      body: input.body,
+      headers: input.headers,
+      method: 'POST',
+      signal: AbortSignal.timeout(input.timeout)
+    })
+  } catch (fetchError) {
+    return retryOrRethrow(
+      fetchError instanceof Error
+        ? fetchError
+        : new Error(`[logixlysia] ${input.name} transport: request failed`, {
+            cause: fetchError
+          })
+    )
+  }
+  if (response.ok) {
+    return
+  }
+  const detail = (await response.text().catch(() => '')).slice(
+    0,
+    ERROR_BODY_PREVIEW_LENGTH
+  )
+  const httpError = new Error(
+    `[logixlysia] ${input.name} transport: HTTP ${response.status}${
+      detail ? ` — ${detail}` : ''
+    }`
+  )
+  const retryable =
+    response.status === HTTP_TOO_MANY_REQUESTS ||
+    response.status >= HTTP_SERVER_ERROR_MIN
+  if (!retryable) {
+    throw httpError
+  }
+  return retryOrRethrow(httpError)
+}
+
+/**
+ * POSTs a payload, retrying on network errors, 429, and 5xx responses with
+ * linear backoff. Non-retryable HTTP errors (4xx except 429) throw immediately.
+ */
+export const postWithRetry = (input: PostWithRetryInput): Promise<void> =>
+  attemptPost(input, 0)
+
+export interface BatchQueue {
+  flush: () => Promise<void>
+  push: (entry: LogEntry) => Promise<void> | undefined
+}
+
+/**
+ * Buffers entries and sends them in batches: immediately once `maxBatchSize`
+ * is reached (the returned promise propagates send errors to the caller), or
+ * after `flushIntervalMs` via an unref'ed timer (errors go to stderr since no
+ * caller is awaiting).
+ */
+export const createBatchQueue = (input: {
+  flushIntervalMs: number
+  maxBatchSize: number
+  name: string
+  send: (entries: LogEntry[]) => Promise<void>
+}): BatchQueue => {
+  let buffer: LogEntry[] = []
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const flush = async (): Promise<void> => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = undefined
+    }
+    if (buffer.length === 0) {
+      return
+    }
+    const entries = buffer
+    buffer = []
+    await input.send(entries)
+  }
+
+  const flushFromTimer = (): void => {
+    flush().catch(error => {
+      console.error(`[logixlysia] ${input.name} transport failed:`, error)
+    })
+  }
+
+  const push = (entry: LogEntry): Promise<void> | undefined => {
+    buffer.push(entry)
+    if (buffer.length >= input.maxBatchSize) {
+      return flush()
+    }
+    if (!timer) {
+      timer = setTimeout(flushFromTimer, input.flushIntervalMs)
+      timer.unref?.()
+    }
+  }
+
+  return { flush, push }
+}
+
+export interface HttpTransportInput {
+  /** Builds the request body for a flushed batch. */
+  body: (entries: LogEntry[]) => string
+  headers: Record<string, string>
+  /** Adapter name used in error messages, e.g. 'Axiom'. */
+  name: string
+  options: BatchTransportOptions
+  url: string
+}
+
+/**
+ * The common adapter shape: a batch queue whose flushes POST to a fixed URL
+ * with retry, exposed as an {@link AdapterTransport}.
+ */
+export const createHttpTransport = (
+  input: HttpTransportInput
+): AdapterTransport => {
+  const retries = input.options.retries ?? DEFAULT_RETRIES
+  const timeout = input.options.timeout ?? DEFAULT_TIMEOUT_MS
+
+  const queue = createBatchQueue({
+    flushIntervalMs: input.options.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS,
+    maxBatchSize: input.options.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE,
+    name: input.name,
+    send: entries =>
+      postWithRetry({
+        body: input.body(entries),
+        headers: input.headers,
+        name: input.name,
+        retries,
+        timeout,
+        url: input.url
+      })
+  })
+
+  return {
+    flush: queue.flush,
+    log: (level, message, meta) =>
+      queue.push({ level, message, meta: meta ?? {}, timestamp: new Date() })
+  }
+}
+
+export type FlatValue = boolean | number | string
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  !(value instanceof Date)
+
+const flattenInto = (
+  out: Record<string, FlatValue>,
+  value: unknown,
+  prefix: string,
+  depth: number
+): void => {
+  if (value === null || value === undefined) {
+    return
+  }
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    out[prefix] = value
+    return
+  }
+  if (value instanceof Date) {
+    out[prefix] = value.toISOString()
+    return
+  }
+  if (isPlainObject(value) && depth < FLATTEN_MAX_DEPTH) {
+    for (const [key, child] of Object.entries(value)) {
+      flattenInto(out, child, prefix ? `${prefix}.${key}` : key, depth + 1)
+    }
+    return
+  }
+  try {
+    out[prefix] = JSON.stringify(value)
+  } catch {
+    out[prefix] = String(value)
+  }
+}
+
+/**
+ * Flattens a transport meta object into dot-notation scalar keys
+ * (`request.method`, `context.requestId`, …). Values nested deeper than three
+ * levels — and arrays — are JSON-stringified.
+ */
+export const flattenMeta = (
+  meta: Record<string, unknown>
+): Record<string, FlatValue> => {
+  const out: Record<string, FlatValue> = {}
+  flattenInto(out, meta, '', 0)
+  return out
+}
+
+/** Reads a dot-notation path (e.g. `context.userId`) from a meta object. */
+export const getPath = (
+  meta: Record<string, unknown>,
+  path: string
+): unknown => {
+  let current: unknown = meta
+  for (const segment of path.split('.')) {
+    if (!isPlainObject(current)) {
+      return
+    }
+    current = current[segment]
+  }
+  return current
+}
+
+/**
+ * Fallback log body for access logs, whose `message` is empty:
+ * `GET /path` derived from the request meta.
+ */
+export const defaultBody = (entry: LogEntry): string => {
+  if (entry.message) {
+    return entry.message
+  }
+  const { request } = entry.meta
+  if (isPlainObject(request)) {
+    const method = typeof request.method === 'string' ? request.method : ''
+    const url = typeof request.url === 'string' ? request.url : ''
+    let path = url
+    try {
+      path = new URL(url).pathname
+    } catch {
+      // Keep the raw URL when it does not parse.
+    }
+    const body = `${method} ${path}`.trim()
+    if (body) {
+      return body
+    }
+  }
+  return entry.level
+}

--- a/packages/logixlysia/src/axiom.ts
+++ b/packages/logixlysia/src/axiom.ts
@@ -1,0 +1,91 @@
+import {
+  type AdapterTransport,
+  type BatchTransportOptions,
+  createHttpTransport,
+  envString,
+  stripTrailingSlashes,
+  transportError
+} from './adapters/shared'
+
+const DEFAULT_BASE_URL = 'https://api.axiom.co'
+
+export interface AxiomTransportOptions extends BatchTransportOptions {
+  /**
+   * Axiom API token with ingest permission (`xaat-…`).
+   * Falls back to the `AXIOM_API_KEY` environment variable.
+   */
+  apiKey?: string
+  /**
+   * API base URL.
+   * Falls back to `AXIOM_URL`.
+   * @default 'https://api.axiom.co'
+   */
+  baseUrl?: string
+  /**
+   * Target dataset name.
+   * Falls back to `AXIOM_DATASET`.
+   */
+  dataset?: string
+  /**
+   * Organization ID — required when using a personal access token.
+   * Falls back to `AXIOM_ORG_ID`.
+   */
+  orgId?: string
+}
+
+/**
+ * Creates a transport that ships logs to an Axiom dataset via the ingest API.
+ * Events keep their nested structure — Axiom indexes every field without a
+ * schema, so `request.method`, `context.requestId`, etc. are all queryable.
+ *
+ * @throws When no API token or dataset is configured.
+ */
+export const createAxiomTransport = (
+  options: AxiomTransportOptions = {}
+): AdapterTransport => {
+  const apiKey = options.apiKey ?? envString('AXIOM_API_KEY')
+  if (!apiKey) {
+    throw transportError(
+      'Axiom',
+      'missing API token. Set AXIOM_API_KEY or pass apiKey to createAxiomTransport()'
+    )
+  }
+  const dataset = options.dataset ?? envString('AXIOM_DATASET')
+  if (!dataset) {
+    throw transportError(
+      'Axiom',
+      'missing dataset. Set AXIOM_DATASET or pass dataset to createAxiomTransport()'
+    )
+  }
+  const baseUrl = stripTrailingSlashes(
+    options.baseUrl ?? envString('AXIOM_URL') ?? DEFAULT_BASE_URL
+  )
+  const orgId = options.orgId ?? envString('AXIOM_ORG_ID')
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${apiKey}`,
+    'Content-Type': 'application/json'
+  }
+  if (orgId) {
+    headers['X-Axiom-Org-Id'] = orgId
+  }
+
+  return createHttpTransport({
+    body: entries =>
+      JSON.stringify(
+        // Meta first so the adapter-owned fields below always win on collision.
+        entries.map(entry => ({
+          ...entry.meta,
+          _time: entry.timestamp.toISOString(),
+          level: entry.level,
+          message: entry.message
+        }))
+      ),
+    headers,
+    name: 'Axiom',
+    options,
+    url: `${baseUrl}/v1/datasets/${encodeURIComponent(dataset)}/ingest`
+  })
+}
+
+export type { AdapterTransport } from './adapters/shared'

--- a/packages/logixlysia/src/better-stack.ts
+++ b/packages/logixlysia/src/better-stack.ts
@@ -1,0 +1,72 @@
+import {
+  type AdapterTransport,
+  type BatchTransportOptions,
+  createHttpTransport,
+  defaultBody,
+  envString,
+  stripTrailingSlashes,
+  transportError
+} from './adapters/shared'
+
+const DEFAULT_ENDPOINT = 'https://in.logs.betterstack.com'
+
+export interface BetterStackTransportOptions extends BatchTransportOptions {
+  /**
+   * Ingesting URL shown next to the source token — newer sources get a
+   * dedicated host like `https://s123456.eu-nbg-2.betterstackdata.com`.
+   * Falls back to `BETTER_STACK_INGESTING_HOST`.
+   * @default 'https://in.logs.betterstack.com'
+   */
+  endpoint?: string
+  /**
+   * Source token from the Better Stack source settings, sent as a Bearer
+   * token. Falls back to the `BETTER_STACK_SOURCE_TOKEN` environment variable.
+   */
+  sourceToken?: string
+}
+
+/**
+ * Creates a transport that ships logs to Better Stack (Telemetry / Logs).
+ * Each log posts as JSON with a `dt` timestamp, `level`, `message`, and the
+ * full meta object — all queryable in Live tail and SQL.
+ *
+ * @throws When no source token is configured.
+ */
+export const createBetterStackTransport = (
+  options: BetterStackTransportOptions = {}
+): AdapterTransport => {
+  const sourceToken =
+    options.sourceToken ?? envString('BETTER_STACK_SOURCE_TOKEN')
+  if (!sourceToken) {
+    throw transportError(
+      'Better Stack',
+      'missing source token. Set BETTER_STACK_SOURCE_TOKEN or pass sourceToken to createBetterStackTransport()'
+    )
+  }
+
+  return createHttpTransport({
+    body: entries =>
+      JSON.stringify(
+        // Meta first so the adapter-owned fields below always win on collision.
+        entries.map(entry => ({
+          ...entry.meta,
+          dt: entry.timestamp.toISOString(),
+          level: entry.level,
+          message: defaultBody(entry)
+        }))
+      ),
+    headers: {
+      Authorization: `Bearer ${sourceToken}`,
+      'Content-Type': 'application/json'
+    },
+    name: 'Better Stack',
+    options,
+    url: stripTrailingSlashes(
+      options.endpoint ??
+        envString('BETTER_STACK_INGESTING_HOST') ??
+        DEFAULT_ENDPOINT
+    )
+  })
+}
+
+export type { AdapterTransport } from './adapters/shared'

--- a/packages/logixlysia/src/clickhouse.ts
+++ b/packages/logixlysia/src/clickhouse.ts
@@ -1,0 +1,123 @@
+import {
+  type AdapterTransport,
+  type BatchTransportOptions,
+  createHttpTransport,
+  defaultBody,
+  envString,
+  flattenMeta,
+  type LogEntry,
+  stripTrailingSlashes,
+  transportError
+} from './adapters/shared'
+
+const DEFAULT_URL = 'http://localhost:8123'
+const DEFAULT_DATABASE = 'default'
+const DEFAULT_TABLE = 'logs'
+const IDENTIFIER = /^[A-Za-z0-9_]+$/
+
+export interface ClickHouseTransportOptions extends BatchTransportOptions {
+  /**
+   * Target database.
+   * Falls back to `CLICKHOUSE_DATABASE`.
+   * @default 'default'
+   */
+  database?: string
+  /**
+   * Password, sent as the `X-ClickHouse-Key` header.
+   * Falls back to `CLICKHOUSE_PASSWORD`.
+   */
+  password?: string
+  /**
+   * Target table. Expected columns: `timestamp DateTime64(3)`,
+   * `level LowCardinality(String)`, `message String`,
+   * `attributes Map(String, String)`.
+   * Falls back to `CLICKHOUSE_TABLE`.
+   * @default 'logs'
+   */
+  table?: string
+  /**
+   * ClickHouse HTTP interface base URL.
+   * Falls back to `CLICKHOUSE_URL`.
+   * @default 'http://localhost:8123'
+   */
+  url?: string
+  /**
+   * Username, sent as the `X-ClickHouse-User` header.
+   * Falls back to `CLICKHOUSE_USERNAME`.
+   */
+  username?: string
+}
+
+const validIdentifier = (value: string, kind: string): string => {
+  if (!IDENTIFIER.test(value)) {
+    throw transportError(
+      'ClickHouse',
+      `invalid ${kind} '${value}'. Only letters, digits, and underscores are allowed`
+    )
+  }
+  return value
+}
+
+const toRow = (entry: LogEntry): string => {
+  const attributes: Record<string, string> = {}
+  for (const [key, value] of Object.entries(flattenMeta(entry.meta))) {
+    attributes[key] = String(value)
+  }
+  return JSON.stringify({
+    attributes,
+    level: entry.level,
+    message: defaultBody(entry),
+    timestamp: entry.timestamp.toISOString()
+  })
+}
+
+/**
+ * Creates a transport that inserts logs into a ClickHouse table over the HTTP
+ * interface using `JSONEachRow`. Rows carry `timestamp`, `level`, `message`,
+ * and an `attributes` map of the flattened meta (`request.method`,
+ * `context.requestId`, …) with values rendered as strings.
+ *
+ * @throws When the database or table name is not a plain identifier.
+ */
+export const createClickHouseTransport = (
+  options: ClickHouseTransportOptions = {}
+): AdapterTransport => {
+  const baseUrl = stripTrailingSlashes(
+    options.url ?? envString('CLICKHOUSE_URL') ?? DEFAULT_URL
+  )
+  const database = validIdentifier(
+    options.database ?? envString('CLICKHOUSE_DATABASE') ?? DEFAULT_DATABASE,
+    'database'
+  )
+  const table = validIdentifier(
+    options.table ?? envString('CLICKHOUSE_TABLE') ?? DEFAULT_TABLE,
+    'table'
+  )
+  const username = options.username ?? envString('CLICKHOUSE_USERNAME')
+  const password = options.password ?? envString('CLICKHOUSE_PASSWORD')
+
+  const query = new URLSearchParams({
+    date_time_input_format: 'best_effort',
+    query: `INSERT INTO ${database}.${table} FORMAT JSONEachRow`
+  })
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json'
+  }
+  if (username) {
+    headers['X-ClickHouse-User'] = username
+  }
+  if (password) {
+    headers['X-ClickHouse-Key'] = password
+  }
+
+  return createHttpTransport({
+    body: entries => entries.map(toRow).join('\n'),
+    headers,
+    name: 'ClickHouse',
+    options,
+    url: `${baseUrl}/?${query.toString()}`
+  })
+}
+
+export type { AdapterTransport } from './adapters/shared'

--- a/packages/logixlysia/src/datadog.ts
+++ b/packages/logixlysia/src/datadog.ts
@@ -1,0 +1,104 @@
+import {
+  type AdapterTransport,
+  type BatchTransportOptions,
+  createHttpTransport,
+  defaultBody,
+  envString,
+  type LogEntry,
+  transportError
+} from './adapters/shared'
+
+const DEFAULT_SITE = 'datadoghq.com'
+const DEFAULT_SOURCE = 'logixlysia'
+
+export interface DatadogTransportOptions extends BatchTransportOptions {
+  /**
+   * Datadog API key, sent as the `DD-API-KEY` header.
+   * Falls back to the `DD_API_KEY` environment variable.
+   */
+  apiKey?: string
+  /**
+   * Hostname reported with each log.
+   * Falls back to `DD_HOSTNAME`; omitted when unset.
+   */
+  hostname?: string
+  /**
+   * `service` facet on each log.
+   * Falls back to `DD_SERVICE`.
+   * @default 'logixlysia'
+   */
+  service?: string
+  /**
+   * Datadog site: `datadoghq.com` (US1), `datadoghq.eu` (EU),
+   * `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, …
+   * Falls back to `DD_SITE`.
+   * @default 'datadoghq.com'
+   */
+  site?: string
+  /** `ddsource` facet on each log. @default 'logixlysia' */
+  source?: string
+  /** Tags rendered into `ddtags` as `key:value,key2:value2`. */
+  tags?: Record<string, string>
+}
+
+/**
+ * Creates a transport that ships logs to Datadog via the v2 logs intake API.
+ * The log level lands in the `status` attribute (Datadog's default status
+ * remapper), and the full meta object rides along as searchable attributes.
+ *
+ * @throws When no API key is configured.
+ */
+export const createDatadogTransport = (
+  options: DatadogTransportOptions = {}
+): AdapterTransport => {
+  const apiKey = options.apiKey ?? envString('DD_API_KEY')
+  if (!apiKey) {
+    throw transportError(
+      'Datadog',
+      'missing API key. Set DD_API_KEY or pass apiKey to createDatadogTransport()'
+    )
+  }
+  const site = options.site ?? envString('DD_SITE') ?? DEFAULT_SITE
+  const service = options.service ?? envString('DD_SERVICE') ?? DEFAULT_SOURCE
+  const hostname = options.hostname ?? envString('DD_HOSTNAME')
+  const source = options.source ?? DEFAULT_SOURCE
+  const ddtags = Object.entries(options.tags ?? {})
+    .map(([key, value]) => `${key}:${value}`)
+    .join(',')
+
+  const toEvent = (entry: LogEntry): Record<string, unknown> => {
+    // Meta first so the adapter-owned facets below always win — access-log
+    // meta carries an HTTP `status` that must not clobber Datadog's status.
+    const event: Record<string, unknown> = {
+      ...entry.meta,
+      ddsource: source,
+      message: defaultBody(entry),
+      service,
+      status: entry.level.toLowerCase(),
+      timestamp: entry.timestamp.toISOString()
+    }
+    if (ddtags) {
+      event.ddtags = ddtags
+    }
+    if (hostname) {
+      event.hostname = hostname
+    }
+    if (typeof entry.meta.status === 'number') {
+      event.http = { status_code: entry.meta.status }
+    }
+    return event
+  }
+
+  return createHttpTransport({
+    body: entries => JSON.stringify(entries.map(toEvent)),
+    headers: {
+      'Content-Type': 'application/json',
+      'DD-API-KEY': apiKey
+    },
+    name: 'Datadog',
+    options,
+    url: `https://http-intake.logs.${site}/api/v2/logs`
+  })
+}
+
+export type { AdapterTransport } from './adapters/shared'

--- a/packages/logixlysia/src/hyperdx.ts
+++ b/packages/logixlysia/src/hyperdx.ts
@@ -1,0 +1,72 @@
+import { createOtlpCore } from './adapters/otlp-core'
+import {
+  type AdapterTransport,
+  type BatchTransportOptions,
+  envString,
+  stripTrailingSlashes,
+  transportError
+} from './adapters/shared'
+
+const DEFAULT_ENDPOINT = 'https://in-otel.hyperdx.io'
+
+export interface HyperDXTransportOptions extends BatchTransportOptions {
+  /**
+   * HyperDX ingestion API key, sent as the `authorization` header.
+   * Falls back to the `HYPERDX_API_KEY` environment variable.
+   */
+  apiKey?: string
+  /**
+   * OTLP HTTP base URL — the adapter appends `/v1/logs`. For self-hosted
+   * collectors pass the base URL only (port 4318 by default).
+   * Falls back to `HYPERDX_OTLP_ENDPOINT`.
+   * @default 'https://in-otel.hyperdx.io'
+   */
+  endpoint?: string
+  /** Extra OTLP resource attributes merged next to `service.name`. */
+  resourceAttributes?: Record<string, string>
+  /**
+   * Value of the `service.name` resource attribute.
+   * Falls back to `HYPERDX_SERVICE_NAME`, then `OTEL_SERVICE_NAME`.
+   * @default 'logixlysia'
+   */
+  serviceName?: string
+}
+
+/**
+ * Creates a transport that ships logs to HyperDX as OTLP JSON
+ * (`ExportLogsServiceRequest`) over HTTP. Meta fields become dot-notation log
+ * attributes (`request.method`, `context.requestId`, …) so they are searchable
+ * in the HyperDX UI.
+ *
+ * @throws When no API key is configured.
+ */
+export const createHyperDXTransport = (
+  options: HyperDXTransportOptions = {}
+): AdapterTransport => {
+  const apiKey = options.apiKey ?? envString('HYPERDX_API_KEY')
+  if (!apiKey) {
+    throw transportError(
+      'HyperDX',
+      'missing API key. Set HYPERDX_API_KEY or pass apiKey to createHyperDXTransport()'
+    )
+  }
+
+  const endpoint = stripTrailingSlashes(
+    options.endpoint ?? envString('HYPERDX_OTLP_ENDPOINT') ?? DEFAULT_ENDPOINT
+  )
+
+  return createOtlpCore({
+    headers: { authorization: apiKey },
+    name: 'HyperDX',
+    options,
+    resourceAttributes: options.resourceAttributes ?? {},
+    serviceName:
+      options.serviceName ??
+      envString('HYPERDX_SERVICE_NAME') ??
+      envString('OTEL_SERVICE_NAME') ??
+      'logixlysia',
+    url: `${endpoint}/v1/logs`
+  })
+}
+
+export type { AdapterTransport } from './adapters/shared'

--- a/packages/logixlysia/src/loki.ts
+++ b/packages/logixlysia/src/loki.ts
@@ -1,0 +1,122 @@
+import {
+  type AdapterTransport,
+  type BatchTransportOptions,
+  createHttpTransport,
+  defaultBody,
+  envString,
+  type LogEntry,
+  stripTrailingSlashes,
+  toUnixNanos,
+  transportError
+} from './adapters/shared'
+import type { LogLevel } from './interfaces'
+
+export interface LokiTransportOptions extends BatchTransportOptions {
+  /**
+   * Extra static stream labels. Keep these low-cardinality — per-request
+   * values belong in the log line, not in labels.
+   */
+  labels?: Record<string, string>
+  /**
+   * Basic-auth password or API token (Grafana Cloud).
+   * Falls back to `LOKI_PASSWORD`.
+   */
+  password?: string
+  /**
+   * Value of the `service_name` stream label.
+   * Falls back to `LOKI_SERVICE_NAME`, then `OTEL_SERVICE_NAME`.
+   * @default 'logixlysia'
+   */
+  serviceName?: string
+  /**
+   * Tenant ID sent as the `X-Scope-OrgID` header (multi-tenant Loki).
+   * Falls back to `LOKI_TENANT_ID`.
+   */
+  tenantId?: string
+  /**
+   * Loki base URL, e.g. `http://localhost:3100` or a Grafana Cloud push URL
+   * base. The adapter appends `/loki/api/v1/push`.
+   * Falls back to the `LOKI_URL` environment variable.
+   */
+  url?: string
+  /**
+   * Basic-auth username (Grafana Cloud instance ID).
+   * Falls back to `LOKI_USERNAME`.
+   */
+  username?: string
+}
+
+/**
+ * Creates a transport that pushes logs to Grafana Loki. Streams are labeled
+ * with `service_name` and `level` (plus your static labels); the log line is
+ * the message and full meta object as JSON, ready for LogQL's `| json`.
+ *
+ * @throws When no URL is configured.
+ */
+export const createLokiTransport = (
+  options: LokiTransportOptions = {}
+): AdapterTransport => {
+  const rawUrl = options.url ?? envString('LOKI_URL')
+  if (!rawUrl) {
+    throw transportError(
+      'Loki',
+      'missing URL. Set LOKI_URL or pass url to createLokiTransport()'
+    )
+  }
+  const serviceName =
+    options.serviceName ??
+    envString('LOKI_SERVICE_NAME') ??
+    envString('OTEL_SERVICE_NAME') ??
+    'logixlysia'
+  const username = options.username ?? envString('LOKI_USERNAME')
+  const password = options.password ?? envString('LOKI_PASSWORD')
+  const tenantId = options.tenantId ?? envString('LOKI_TENANT_ID')
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json'
+  }
+  if (username && password) {
+    headers.Authorization = `Basic ${Buffer.from(
+      `${username}:${password}`
+    ).toString('base64')}`
+  }
+  if (tenantId) {
+    headers['X-Scope-OrgID'] = tenantId
+  }
+
+  const body = (entries: LogEntry[]): string => {
+    const byLevel = new Map<LogLevel, LogEntry[]>()
+    for (const entry of entries) {
+      const bucket = byLevel.get(entry.level)
+      if (bucket) {
+        bucket.push(entry)
+      } else {
+        byLevel.set(entry.level, [entry])
+      }
+    }
+
+    const streams = [...byLevel.entries()].map(([level, levelEntries]) => ({
+      stream: {
+        ...options.labels,
+        level,
+        service_name: serviceName
+      },
+      values: levelEntries.map(entry => [
+        toUnixNanos(entry.timestamp),
+        JSON.stringify({ ...entry.meta, message: defaultBody(entry) })
+      ])
+    }))
+
+    return JSON.stringify({ streams })
+  }
+
+  return createHttpTransport({
+    body,
+    headers,
+    name: 'Loki',
+    options,
+    url: `${stripTrailingSlashes(rawUrl)}/loki/api/v1/push`
+  })
+}
+
+export type { AdapterTransport } from './adapters/shared'

--- a/packages/logixlysia/src/otlp.ts
+++ b/packages/logixlysia/src/otlp.ts
@@ -1,0 +1,119 @@
+import { createOtlpCore } from './adapters/otlp-core'
+import {
+  type AdapterTransport,
+  type BatchTransportOptions,
+  envString,
+  stripTrailingSlashes,
+  transportError
+} from './adapters/shared'
+
+const LOGS_PATH = '/v1/logs'
+
+/** W3C Baggage values are percent-encoded; keep the raw value if decoding fails. */
+const decodeHeaderValue = (value: string): string => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+/**
+ * Parses the standard `OTEL_EXPORTER_OTLP_HEADERS` format (`k=v,k2=v2`,
+ * W3C Baggage): split on the first `=`, percent-decode values, allow empty
+ * values.
+ */
+const parseHeadersEnv = (raw: string): Record<string, string> => {
+  const headers: Record<string, string> = {}
+  for (const pair of raw.split(',')) {
+    const separator = pair.indexOf('=')
+    if (separator <= 0) {
+      continue
+    }
+    const key = pair.slice(0, separator).trim()
+    if (key) {
+      headers[key] = decodeHeaderValue(pair.slice(separator + 1).trim())
+    }
+  }
+  return headers
+}
+
+export interface OtlpTransportOptions extends BatchTransportOptions {
+  /**
+   * OTLP HTTP base URL — the adapter appends `/v1/logs`. For a local
+   * collector this is typically `http://localhost:4318`.
+   * Falls back to `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` (used as-is, per the
+   * OpenTelemetry spec), then `OTEL_EXPORTER_OTLP_ENDPOINT` (with `/v1/logs`
+   * appended).
+   */
+  endpoint?: string
+  /**
+   * Extra request headers, e.g. vendor auth. Merged over headers parsed from
+   * `OTEL_EXPORTER_OTLP_LOGS_HEADERS`, then `OTEL_EXPORTER_OTLP_HEADERS`
+   * (`k=v,k2=v2`).
+   */
+  headers?: Record<string, string>
+  /** Extra OTLP resource attributes merged next to `service.name`. */
+  resourceAttributes?: Record<string, string>
+  /**
+   * Value of the `service.name` resource attribute.
+   * Falls back to `OTEL_SERVICE_NAME`.
+   * @default 'logixlysia'
+   */
+  serviceName?: string
+}
+
+/**
+ * Resolves the logs URL with the spec's precedence: an explicit option, then
+ * the signal-specific endpoint (used as-is), then the generic endpoint (with
+ * the logs path appended).
+ */
+const resolveLogsUrl = (endpointOption: string | undefined): string => {
+  if (endpointOption) {
+    return `${stripTrailingSlashes(endpointOption)}${LOGS_PATH}`
+  }
+  const logsEndpoint = envString('OTEL_EXPORTER_OTLP_LOGS_ENDPOINT')
+  if (logsEndpoint) {
+    return logsEndpoint
+  }
+  const genericEndpoint = envString('OTEL_EXPORTER_OTLP_ENDPOINT')
+  if (genericEndpoint) {
+    return `${stripTrailingSlashes(genericEndpoint)}${LOGS_PATH}`
+  }
+  throw transportError(
+    'OTLP',
+    'missing endpoint. Set OTEL_EXPORTER_OTLP_ENDPOINT (or OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) or pass endpoint to createOtlpTransport()'
+  )
+}
+
+/**
+ * Creates a transport that ships logs to any OTLP/HTTP logs endpoint as JSON
+ * (`ExportLogsServiceRequest`) — OpenTelemetry Collectors, Grafana Cloud,
+ * New Relic, Honeycomb, SigNoz, and every other OTLP-compatible backend.
+ * Meta fields become dot-notation log attributes (`request.method`,
+ * `context.requestId`, …).
+ *
+ * @throws When no endpoint is configured.
+ */
+export const createOtlpTransport = (
+  options: OtlpTransportOptions = {}
+): AdapterTransport => {
+  const headersEnv =
+    envString('OTEL_EXPORTER_OTLP_LOGS_HEADERS') ??
+    envString('OTEL_EXPORTER_OTLP_HEADERS')
+
+  return createOtlpCore({
+    headers: {
+      ...(headersEnv ? parseHeadersEnv(headersEnv) : {}),
+      ...options.headers
+    },
+    name: 'OTLP',
+    options,
+    resourceAttributes: options.resourceAttributes ?? {},
+    serviceName:
+      options.serviceName ?? envString('OTEL_SERVICE_NAME') ?? 'logixlysia',
+    url: resolveLogsUrl(options.endpoint)
+  })
+}
+
+export type { AdapterTransport } from './adapters/shared'

--- a/packages/logixlysia/src/posthog.ts
+++ b/packages/logixlysia/src/posthog.ts
@@ -1,0 +1,111 @@
+import {
+  type AdapterTransport,
+  type BatchTransportOptions,
+  createHttpTransport,
+  defaultBody,
+  envString,
+  flattenMeta,
+  getPath,
+  type LogEntry,
+  stripTrailingSlashes,
+  transportError
+} from './adapters/shared'
+
+const DEFAULT_HOST = 'https://us.i.posthog.com'
+const DEFAULT_EVENT_NAME = 'logixlysia_log'
+const DEFAULT_DISTINCT_ID = 'logixlysia-server'
+const DEFAULT_DISTINCT_ID_FIELD = 'context.userId'
+
+export interface PostHogTransportOptions extends BatchTransportOptions {
+  /**
+   * PostHog project API key (`phc_…`).
+   * Falls back to the `POSTHOG_API_KEY` environment variable.
+   */
+  apiKey?: string
+  /**
+   * Static `distinct_id` used when {@link distinctIdField} resolves to
+   * nothing — e.g. a service name for a backend acting as one identity.
+   * @default 'logixlysia-server'
+   */
+  distinctId?: string
+  /**
+   * Dot-notation meta path resolved per log to the event's `distinct_id`,
+   * linking logs to PostHog persons. Populate it via
+   * `log.mergeContext({ userId })`.
+   * @default 'context.userId'
+   */
+  distinctIdField?: string
+  /**
+   * Name of the captured event.
+   * @default 'logixlysia_log'
+   */
+  eventName?: string
+  /**
+   * PostHog instance URL: `https://us.i.posthog.com` (US),
+   * `https://eu.i.posthog.com` (EU), or a self-hosted instance.
+   * Falls back to `POSTHOG_HOST`.
+   * @default 'https://us.i.posthog.com'
+   */
+  host?: string
+}
+
+/**
+ * Creates a transport that captures logs as PostHog events via the batch API.
+ * Meta fields become dot-notation event properties (`request.method`,
+ * `context.requestId`, …) usable in filters, insights, and cohorts. Logs
+ * carrying a `userId` in the request context are linked to PostHog persons.
+ *
+ * @throws When no API key is configured.
+ */
+export const createPostHogTransport = (
+  options: PostHogTransportOptions = {}
+): AdapterTransport => {
+  const apiKey = options.apiKey ?? envString('POSTHOG_API_KEY')
+  if (!apiKey) {
+    throw transportError(
+      'PostHog',
+      'missing API key. Set POSTHOG_API_KEY or pass apiKey to createPostHogTransport()'
+    )
+  }
+  const host = stripTrailingSlashes(
+    options.host ?? envString('POSTHOG_HOST') ?? DEFAULT_HOST
+  )
+  const eventName = options.eventName ?? DEFAULT_EVENT_NAME
+  const distinctId = options.distinctId ?? DEFAULT_DISTINCT_ID
+  const distinctIdField = options.distinctIdField ?? DEFAULT_DISTINCT_ID_FIELD
+
+  const distinctIdFor = (entry: LogEntry): string => {
+    const resolved = getPath(entry.meta, distinctIdField)
+    if (typeof resolved === 'string' && resolved.length > 0) {
+      return resolved
+    }
+    if (typeof resolved === 'number') {
+      return String(resolved)
+    }
+    return distinctId
+  }
+
+  return createHttpTransport({
+    body: entries =>
+      JSON.stringify({
+        api_key: apiKey,
+        batch: entries.map(entry => ({
+          distinct_id: distinctIdFor(entry),
+          event: eventName,
+          // Meta first so level/message always win on collision.
+          properties: {
+            ...flattenMeta(entry.meta),
+            level: entry.level,
+            message: defaultBody(entry)
+          },
+          timestamp: entry.timestamp.toISOString()
+        }))
+      }),
+    headers: { 'Content-Type': 'application/json' },
+    name: 'PostHog',
+    options,
+    url: `${host}/batch/`
+  })
+}
+
+export type { AdapterTransport } from './adapters/shared'

--- a/packages/logixlysia/src/sentry.ts
+++ b/packages/logixlysia/src/sentry.ts
@@ -1,0 +1,186 @@
+import {
+  type AdapterTransport,
+  type BatchTransportOptions,
+  createHttpTransport,
+  defaultBody,
+  envString,
+  type FlatValue,
+  flattenMeta,
+  getPath,
+  type LogEntry,
+  transportError
+} from './adapters/shared'
+import type { LogLevel } from './interfaces'
+
+const MILLIS_PER_SECOND = 1000
+const TRACE_ID_BYTES = 16
+const TRACE_ID_PATTERN = /^[0-9a-f]{32}$/i
+
+export interface SentryTransportOptions extends BatchTransportOptions {
+  /**
+   * Sentry DSN (`https://<public-key>@<host>/<project-id>`).
+   * Falls back to the `SENTRY_DSN` environment variable.
+   */
+  dsn?: string
+  /**
+   * Value of the `sentry.environment` attribute.
+   * Falls back to `SENTRY_ENVIRONMENT`.
+   */
+  environment?: string
+  /**
+   * Value of the `sentry.release` attribute.
+   * Falls back to `SENTRY_RELEASE`.
+   */
+  release?: string
+  /** Extra searchable attributes added to every log. */
+  tags?: Record<string, string>
+}
+
+const SENTRY_LEVEL: Record<LogLevel, string> = {
+  DEBUG: 'debug',
+  ERROR: 'error',
+  INFO: 'info',
+  WARNING: 'warn'
+}
+
+interface SentryAttribute {
+  type: 'boolean' | 'double' | 'integer' | 'string'
+  value: boolean | number | string
+}
+
+const toSentryAttribute = (value: FlatValue): SentryAttribute => {
+  if (typeof value === 'boolean') {
+    return { type: 'boolean', value }
+  }
+  if (typeof value === 'number') {
+    return Number.isInteger(value)
+      ? { type: 'integer', value }
+      : { type: 'double', value }
+  }
+  return { type: 'string', value }
+}
+
+const randomTraceId = (): string => {
+  const bytes = new Uint8Array(TRACE_ID_BYTES)
+  crypto.getRandomValues(bytes)
+  let hex = ''
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, '0')
+  }
+  return hex
+}
+
+const traceIdFor = (entry: LogEntry): string => {
+  const fromContext = getPath(entry.meta, 'context.trace_id')
+  if (typeof fromContext === 'string' && TRACE_ID_PATTERN.test(fromContext)) {
+    return fromContext.toLowerCase()
+  }
+  return randomTraceId()
+}
+
+interface ParsedDsn {
+  envelopeUrl: string
+  publicKey: string
+}
+
+// URL.canParse is missing on Node.js < 18.17, which this package still supports.
+const tryParseUrl = (value: string): URL | undefined => {
+  try {
+    return new URL(value)
+  } catch {
+    // Malformed URL: fall through to undefined so parseDsn reports the DSN.
+  }
+}
+
+const parseDsn = (dsn: string): ParsedDsn => {
+  const url = tryParseUrl(dsn)
+  const segments = url?.pathname.split('/').filter(Boolean) ?? []
+  const projectId = segments.at(-1)
+  if (!(url?.username && projectId)) {
+    throw transportError(
+      'Sentry',
+      `invalid DSN. Expected https://<public-key>@<host>/<project-id>, got '${dsn}'`
+    )
+  }
+  const pathPrefix = segments.slice(0, -1).join('/')
+  return {
+    envelopeUrl: `${url.protocol}//${url.host}${
+      pathPrefix ? `/${pathPrefix}` : ''
+    }/api/${projectId}/envelope/`,
+    publicKey: url.username
+  }
+}
+
+/**
+ * Creates a transport that ships logs to Sentry's structured logs
+ * (Explore > Logs) via the envelope endpoint. Every meta field becomes a
+ * typed, searchable attribute; `trace_id` from the request context (as set by
+ * `logixlysia/otel`) links logs to traces.
+ *
+ * @throws When no DSN is configured or the DSN is malformed.
+ */
+export const createSentryTransport = (
+  options: SentryTransportOptions = {}
+): AdapterTransport => {
+  const dsn = options.dsn ?? envString('SENTRY_DSN')
+  if (!dsn) {
+    throw transportError(
+      'Sentry',
+      'missing DSN. Set SENTRY_DSN or pass dsn to createSentryTransport()'
+    )
+  }
+  const { envelopeUrl, publicKey } = parseDsn(dsn)
+  const environment = options.environment ?? envString('SENTRY_ENVIRONMENT')
+  const release = options.release ?? envString('SENTRY_RELEASE')
+
+  const staticAttributes: Record<string, SentryAttribute> = {}
+  if (environment) {
+    staticAttributes['sentry.environment'] = toSentryAttribute(environment)
+  }
+  if (release) {
+    staticAttributes['sentry.release'] = toSentryAttribute(release)
+  }
+  for (const [key, value] of Object.entries(options.tags ?? {})) {
+    staticAttributes[key] = toSentryAttribute(value)
+  }
+
+  const envelope = (entries: LogEntry[]): string => {
+    const items = entries.map(entry => {
+      const attributes: Record<string, SentryAttribute> = {
+        ...staticAttributes
+      }
+      for (const [key, value] of Object.entries(flattenMeta(entry.meta))) {
+        attributes[key] = toSentryAttribute(value)
+      }
+      return {
+        attributes,
+        body: defaultBody(entry),
+        level: SENTRY_LEVEL[entry.level],
+        timestamp: entry.timestamp.getTime() / MILLIS_PER_SECOND,
+        trace_id: traceIdFor(entry)
+      }
+    })
+    return [
+      JSON.stringify({ dsn, sent_at: new Date().toISOString() }),
+      JSON.stringify({
+        content_type: 'application/vnd.sentry.items.log+json',
+        item_count: items.length,
+        type: 'log'
+      }),
+      JSON.stringify({ items })
+    ].join('\n')
+  }
+
+  return createHttpTransport({
+    body: envelope,
+    headers: {
+      'Content-Type': 'application/x-sentry-envelope',
+      'X-Sentry-Auth': `Sentry sentry_version=7, sentry_client=logixlysia, sentry_key=${publicKey}`
+    },
+    name: 'Sentry',
+    options,
+    url: envelopeUrl
+  })
+}
+
+export type { AdapterTransport } from './adapters/shared'


### PR DESCRIPTION
## Description

Adds built-in log adapters as subpath exports, following the existing `logixlysia/otel` / `logixlysia/ai` pattern:

**Cloud platforms**
- `logixlysia/axiom` — Axiom ingest API, nested events (schema-free APL querying)
- `logixlysia/better-stack` — Better Stack Telemetry, incl. dedicated per-source ingesting hosts
- `logixlysia/datadog` — v2 logs intake, level → `status`, HTTP status → `http.status_code`
- `logixlysia/sentry` — structured logs via the envelope endpoint (Explore → Logs), no SDK needed, `trace_id` links logs to traces
- `logixlysia/posthog` — logs as captured events, `distinct_id` resolved from the request context to link persons

**Self-hosted & open standards**
- `logixlysia/otlp` — generic OTLP/HTTP logs exporter honoring the standard `OTEL_EXPORTER_OTLP_*` variables; covers collectors, Grafana Cloud, New Relic, Honeycomb, SigNoz, …
- `logixlysia/hyperdx` — thin wrapper over the shared OTLP core
- `logixlysia/loki` — Loki push API with level-grouped streams, basic auth, and multi-tenant support
- `logixlysia/clickhouse` — direct `JSONEachRow` inserts over the HTTP interface with identifier validation

All adapters share one core: batching (size/interval flush on an unref'ed timer), timeout + linear-backoff retry on network errors/429/5xx, env-var credential resolution with option overrides, a `flush()` method for graceful shutdown, and failures reported through the existing `onError` sink hook.

Docs get a new **Adapters** group (overview + one page per platform) in both blume and Mintlify navigation, and the custom-transports page now points to the built-in adapters.

Each adapter lands as its own atomic commit carrying its source, tests, docs page, build/export wiring, and changeset.

## Related Issues

N/A

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

N/A

## Additional Notes

- 261 tests pass (46 adapter tests mock `fetch` and assert URLs, headers, payload shapes, retry, and batching); typecheck, lint, package build, and docs build are all clean.
- Nine changesets, all `minor` on `logixlysia` — they collapse into a single minor bump with one changelog entry per adapter.
- Skipped intentionally: file-system output (already built in with rotation) and an in-memory adapter (the `Transport` interface is trivially mockable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logging integrations for Axiom, Better Stack, ClickHouse, Datadog, HyperDX, Grafana Loki, OTLP, PostHog, and Sentry.
  * Added batching, retries, timeouts, metadata mapping, authentication, and trace correlation across supported transports.
  * Added production-ready configuration through transport options and environment variables.

* **Documentation**
  * Added setup, configuration, querying, batching, and troubleshooting guides for every adapter.
  * Added a dedicated Adapters section to the documentation navigation.

* **Tests**
  * Added comprehensive coverage for adapter configuration, payloads, authentication, retries, batching, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->