### PR TITLE
feat: sampling, enrichers, structured errors, and typed fields

### DIFF
--- a/.changeset/enrichers.md
+++ b/.changeset/enrichers.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Add `config.enrichers` and the `logixlysia/enrichers` subpath. An enricher contributes fields to the request context once and they reach every sink at once — console tree, file logs, and all transports. Four are built in: `traceparentEnricher()` parses the W3C `traceparent` header directly, with no OpenTelemetry SDK required, so logs link to traces in Sentry, HyperDX, or any OTLP backend; `userAgentEnricher()` adds browser, OS, device, and bot fields; `geoEnricher()` reads the geo headers Vercel, Cloudflare, and Netlify already attach; `sizeEnricher()` records `requestBytes` and `responseBytes`. Custom enrichers are a bare function (request phase) or an object with `request` and `response` phases. A hook that throws is reported via `onError` with the new `sink: 'enricher'` and skipped, never failing the request.

--- a/.changeset/sampling.md
+++ b/.changeset/sampling.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+Add head + tail sampling via `config.sampling`. Head sampling keeps a percentage of records per level (`{ INFO: 10 }`; levels left out keep everything), so log spend stops scaling one-for-one with traffic. Tail sampling buffers what head dropped and replays it when the finished request matches `status`, `durationMs`, or a path glob — failures and slow paths keep their full log trail instead of losing nine lines in ten. Dropped records skip context merging, redaction, formatting, and every sink; replayed ones keep the duration they had when captured.

--- a/.changeset/structured-errors.md
+++ b/.changeset/structured-errors.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+`HttpError` now carries the context that makes a failure actionable: `code` (a stable identifier the client can branch on, unlike the message), `why`, `fix`, `link`, and `internal`. The first four appear in both the log and the response body; `internal` is log-only — it is non-enumerable and excluded from `toJSON()`, so no serializer can put it in a response. Error details also render in the console context tree for 4xx responses now, not just 5xx. Fully backward compatible: `new HttpError(404, 'Not found')` still responds with the bare message, and only an error carrying at least one client-facing field responds as JSON.

--- a/.changeset/typed-fields.md
+++ b/.changeset/typed-fields.md
@@ -1,0 +1,5 @@
+---
+'logixlysia': minor
+---
+
+The request-scoped logger is now generic over your field type: `logixlysia<CheckoutFields>()` types `log.mergeContext()` and the per-call `context` argument as `Partial<CheckoutFields>`, so TypeScript rejects a misspelled `user_id` before it splits your dashboard query in two. `useLogger<CheckoutFields>()` takes the same parameter for code outside the handler. Type-only with no runtime cost, and the default keeps every key allowed, so existing untyped code is unaffected.

--- a/apps/docs/content/api-reference.mdx
+++ b/apps/docs/content/api-reference.mdx
@@ -201,24 +201,68 @@ type LogixlysiaContext = {
 
 ### `HttpError`
 
-Custom HTTP error class.
+An HTTP error carrying the context that makes a failure actionable.
 
 ```ts
 class HttpError extends Error {
+  readonly code?: string
+  readonly fix?: string
+  readonly internal?: unknown
+  readonly link?: string
   readonly status: number
-  constructor(status: number, message: string)
+  readonly why?: string
+
+  constructor(status: number, message: string, init?: HttpErrorInit)
+
+  toJSON(): HttpErrorPayload
+}
+
+interface HttpErrorInit {
+  code?: string
+  fix?: string
+  internal?: unknown
+  link?: string
+  why?: string
 }
 ```
 
 **Properties:**
 
-- `status`: HTTP status code
+- `status` — HTTP status code
+- `code` — stable machine-readable identifier the client can branch on, e.g. `PAYMENT_DECLINED`. Unlike `message`, it is safe to depend on: rewording the message does not break a caller
+- `why` — why the request failed, in plain language
+- `fix` — what the caller should do about it
+- `link` — documentation URL for this failure
+- `internal` — **log-only** diagnostics. Non-enumerable and excluded from `toJSON()`, so no serializer can put it in a response body
 
 **Example:**
 
 ```ts
-throw new HttpError(404, 'User not found')
+throw new HttpError(402, 'Card declined', {
+  code: 'PAYMENT_DECLINED',
+  why: 'The issuing bank rejected the charge.',
+  fix: 'Try a different card, or contact your bank.',
+  link: 'https://docs.example.com/errors/payment-declined',
+  internal: { gatewayCode: 'do_not_honor', chargeId }
+})
 ```
+
+Response body:
+
+```json
+{
+  "code": "PAYMENT_DECLINED",
+  "fix": "Try a different card, or contact your bank.",
+  "link": "https://docs.example.com/errors/payment-declined",
+  "message": "Card declined",
+  "status": 402,
+  "why": "The issuing bank rejected the charge."
+}
+```
+
+The log line carries the same fields **plus** `internal`, rendered in the context tree as `error.code`, `error.why`, `error.fix`, `error.link`, and `error.internal`.
+
+An error with no client-facing fields keeps its previous behaviour exactly — `throw new HttpError(404, 'User not found')` still responds with the bare message, not JSON. Only an error carrying at least one of `code`, `why`, `fix`, or `link` responds as JSON.
 
 ## Usage Examples
 

--- a/apps/docs/content/configuration.mdx
+++ b/apps/docs/content/configuration.mdx
@@ -280,15 +280,32 @@ disableFileLogging: true
 
 ### `onError`
 
-Called when a sink (transport, file, or rotation) fails. Errors thrown by the hook itself are swallowed. When absent, failures go to stderr (rate-limited for transports).
+Called when a sink (transport, file, or rotation) or an [enricher](/docs/features/enrichers) fails. Errors thrown by the hook itself are swallowed. When absent, failures go to stderr (rate-limited for transports and enrichers).
 
-- **Type:** `(context: { sink: 'transport' | 'file' | 'rotation'; error: unknown }) => void`
+- **Type:** `(context: { sink: 'transport' | 'file' | 'rotation' | 'enricher'; error: unknown }) => void`
 - **Default:** `undefined`
 
 ```ts
 onError: ({ sink, error }) => {
   metrics.increment(`logixlysia.sink_error.${sink}`)
 }
+```
+
+### `enrichers`
+
+Context contributors run on every request. Whatever they return is merged into the request context, so the fields reach the console tree, file logs, and every transport at once. See [Enrichers](/docs/features/enrichers).
+
+- **Type:** `EnricherLike[]`
+- **Default:** `undefined`
+
+```ts
+import { geoEnricher, traceparentEnricher } from 'logixlysia/enrichers'
+
+enrichers: [
+  traceparentEnricher(),
+  geoEnricher(),
+  request => ({ tenant: request.headers.get('x-tenant') })
+]
 ```
 
 ## Sampling Options

--- a/apps/docs/content/configuration.mdx
+++ b/apps/docs/content/configuration.mdx
@@ -291,6 +291,29 @@ onError: ({ sink, error }) => {
 }
 ```
 
+## Sampling Options
+
+### `sampling`
+
+Head + tail sampling. Head sampling keeps a percentage of records per level; tail sampling replays what head dropped once the finished request matches a rule. See [Sampling](/docs/features/sampling) for the full guide.
+
+- **Type:** `{ head?: Partial<Record<LogLevel, number>>; tail?: { status?: number; durationMs?: number; paths?: string[] }; maxBufferedPerRequest?: number }`
+- **Default:** `undefined` (no sampling)
+
+```ts
+sampling: {
+  head: { DEBUG: 1, INFO: 10 }, // levels left out keep 100%
+  tail: {
+    status: 400, // rescue any response at or above 400
+    durationMs: 1000, // rescue anything that took a second or longer
+    paths: ['/checkout/**'] // rescue these routes whatever happened
+  },
+  maxBufferedPerRequest: 100
+}
+```
+
+Sampling is off unless at least one head rate is below `100` — `tail` alone rescues nothing, because only head-dropped records are buffered. Invalid values throw at plugin construction.
+
 ## File Logging Options
 
 ### `logFilePath`

--- a/apps/docs/content/docs.json
+++ b/apps/docs/content/docs.json
@@ -45,6 +45,7 @@
           "features/startup",
           "features/presets",
           "features/request-context",
+          "features/enrichers",
           "features/request-id",
           "features/websocket",
           "features/formatting",

--- a/apps/docs/content/docs.json
+++ b/apps/docs/content/docs.json
@@ -49,6 +49,7 @@
           "features/websocket",
           "features/formatting",
           "features/filtering",
+          "features/sampling",
           "features/log-levels",
           "features/file-logging",
           "features/transports",

--- a/apps/docs/content/features/enrichers.mdx
+++ b/apps/docs/content/features/enrichers.mdx
@@ -1,0 +1,130 @@
+---
+title: Enrichers
+description: Add context to every request once, and have it reach every sink
+---
+
+An enricher is a small function that contributes fields to the request context. Set it up once and the fields show up in the console tree, in file logs, and in every transport — Datadog, PostHog, Sentry, OTLP — without touching a single route.
+
+```ts
+import logixlysia from 'logixlysia'
+import { geoEnricher, traceparentEnricher } from 'logixlysia/enrichers'
+
+new Elysia().use(
+  logixlysia({
+    config: {
+      enrichers: [traceparentEnricher(), geoEnricher()]
+    }
+  })
+)
+```
+
+## Built-in Enrichers
+
+### `traceparentEnricher()`
+
+Parses the W3C `traceparent` header directly, with **no OpenTelemetry SDK required**. That is the difference from [`logixlysia/otel`](/docs/integrations/otel), which reads the ids of the currently active span and therefore needs the SDK installed and instrumenting your app.
+
+```ts
+traceparentEnricher()
+// → trace_id, span_id, trace_flags, trace_sampled
+```
+
+The `trace_id` / `span_id` naming matches what Sentry, HyperDX, and OTLP backends expect, so logs link to traces as soon as an upstream service propagates the header.
+
+| Option       | Type      | Default         | Description                                    |
+| ------------ | --------- | --------------- | ---------------------------------------------- |
+| `header`     | `string`  | `'traceparent'` | Header to read the trace context from          |
+| `tracestate` | `boolean` | `false`         | Also record `tracestate`, capped at 512 chars  |
+
+Malformed headers are ignored rather than partially parsed: the reserved `ff` version, all-zero trace or span ids, and a version `00` header carrying extra fields all add nothing.
+
+### `userAgentEnricher()`
+
+Turns `user-agent` into fields you can group by.
+
+```ts
+userAgentEnricher()
+// → ua.browser, ua.browserVersion, ua.os, ua.device, ua.bot
+```
+
+`ua.device` is one of `desktop`, `mobile`, `tablet`, or `bot`. This is a heuristic — user agents are not a parseable grammar — so treat it as a dashboard dimension, not as an access-control input.
+
+### `geoEnricher()`
+
+Reads the geo headers your platform already attaches. Vercel, Cloudflare, and Netlify are recognized.
+
+```ts
+geoEnricher()
+// → geo.city, geo.country, geo.region, geo.timezone, geo.latitude, geo.longitude
+```
+
+Nothing is derived from the IP address itself, and no lookup is performed. On a platform that does not set these headers, the enricher adds nothing. Vercel percent-encodes city names, which the enricher decodes for you.
+
+### `sizeEnricher()`
+
+Records payload sizes.
+
+```ts
+sizeEnricher()
+// → requestBytes, responseBytes
+```
+
+Both come from `content-length`, the only size available without buffering a body. A chunked or streamed response has no `content-length`, so `responseBytes` is omitted rather than guessed.
+
+## Writing Your Own
+
+An enricher is either a bare function — treated as the request phase — or an object with `request` and `response` phases.
+
+```ts
+// Request phase only.
+const tenantEnricher = (request: Request) => ({
+  tenant: request.headers.get('x-tenant-id') ?? 'unknown'
+})
+
+// Both phases.
+const cacheEnricher = {
+  request: (request: Request) => ({
+    cacheKey: new URL(request.url).pathname
+  }),
+  response: ({ headers, status }) => ({
+    cacheHit: headers['x-cache'] === 'HIT',
+    served: status
+  })
+}
+
+logixlysia({ config: { enrichers: [tenantEnricher, cacheEnricher] } })
+```
+
+Return `undefined` to add nothing.
+
+### Phases
+
+| Phase      | Runs                            | Receives                                   |
+| ---------- | ------------------------------- | ------------------------------------------ |
+| `request`  | At request start                | The `Request`                              |
+| `response` | Once the outcome is known       | `{ request, status, durationMs, headers }` |
+
+The response phase runs before the request's final log line on both the success and the error path, so its fields are on the access log and on the error log alike. Request-phase fields, being merged at the start, also reach any `log.info()` you make inside the handler.
+
+## Failure Handling
+
+Enrichment is decoration and must never take a request down. A hook that throws is caught, reported, and skipped — the remaining enrichers still run and the request completes normally.
+
+Failures go to [`onError`](/docs/configuration#onerror) with `sink: 'enricher'`, or to stderr (rate-limited) when no hook is configured.
+
+```ts
+logixlysia({
+  config: {
+    enrichers: [myEnricher],
+    onError: ({ sink, error }) => {
+      if (sink === 'enricher') {
+        metrics.increment('logixlysia.enricher_error')
+      }
+    }
+  }
+})
+```
+
+## Enrichers and Sampling
+
+Enricher fields live in the request context, which is merged at emit time. A record rescued by [tail sampling](/docs/features/sampling) is replayed after the response phase has run, so replayed records carry the response-phase fields too.

--- a/apps/docs/content/features/meta.ts
+++ b/apps/docs/content/features/meta.ts
@@ -6,6 +6,7 @@ export default defineMeta({
     'startup',
     'presets',
     'request-context',
+    'enrichers',
     'request-id',
     'websocket',
     'formatting',

--- a/apps/docs/content/features/meta.ts
+++ b/apps/docs/content/features/meta.ts
@@ -10,6 +10,7 @@ export default defineMeta({
     'websocket',
     'formatting',
     'filtering',
+    'sampling',
     'log-levels',
     'file-logging',
     'transports',

--- a/apps/docs/content/features/request-context.mdx
+++ b/apps/docs/content/features/request-context.mdx
@@ -74,3 +74,44 @@ async function findUser(id: string) {
   return { id, name: 'John Doe' }
 }
 ```
+
+## Typed Fields
+
+`userId` on one route and `user_id` on the next is the kind of drift that makes a dashboard query quietly incomplete. Pass a field type to the plugin and TypeScript catches it at compile time:
+
+```ts
+import { Elysia } from 'elysia'
+import logixlysia from 'logixlysia'
+
+interface CheckoutFields {
+  cartId: string
+  itemCount: number
+  userId: string
+}
+
+const app = new Elysia()
+  .use(logixlysia<CheckoutFields>())
+  .post('/pay', ({ log }) => {
+    log.mergeContext({ userId: 'usr_123' }) // ✓
+    log.info('charged', { itemCount: 3 }) // ✓
+
+    log.mergeContext({ user_id: 'usr_123' }) // ✗ not in CheckoutFields
+    log.mergeContext({ itemCount: 'three' }) // ✗ wrong type
+    return { ok: true }
+  })
+```
+
+Every field stays optional — you declare the vocabulary, not a requirement to fill it in on every route.
+
+`useLogger()` takes the same parameter, so context stays typed outside the handler too:
+
+```ts
+import { useLogger } from 'logixlysia'
+
+const chargeCard = async (amount: number) => {
+  const log = useLogger<CheckoutFields>()
+  log.mergeContext({ cartId: 'cart_9' })
+}
+```
+
+This is type-only: there is no runtime cost, and leaving the parameter off keeps every key allowed, exactly as before.

--- a/apps/docs/content/features/sampling.mdx
+++ b/apps/docs/content/features/sampling.mdx
@@ -1,0 +1,119 @@
+---
+title: Sampling
+description: Keep a percentage of high-volume logs, and rescue the ones that turn out to matter
+---
+
+Sampling keeps your log bill flat as traffic grows. Head sampling thins noisy levels by percentage. Tail sampling puts the dropped records back when the request turns out to be interesting — an error, a slow response, a route you are watching.
+
+Unlike [log filtering](/docs/features/filtering), which is all-or-nothing per level, sampling is per-record and reversible.
+
+## Head Sampling
+
+Head sampling decides as each record is emitted: keep `n%` of a level, drop the rest.
+
+```ts
+logixlysia({
+  config: {
+    sampling: {
+      head: { DEBUG: 1, INFO: 10 }
+    }
+  }
+})
+```
+
+Levels you leave out keep everything, so `ERROR` and `WARNING` above are untouched. Set a level explicitly if you really do want to thin it — `{ ERROR: 50 }` is honored.
+
+Sampling is off unless at least one level is below `100`. A `tail` block on its own does nothing, because only head-dropped records are ever buffered.
+
+## Tail Sampling
+
+A 10% `INFO` rate is fine until a request fails and nine out of ten of its logs are gone. Tail sampling fixes that: head-dropped records are held for the duration of the request, then replayed if the finished request matches any tail rule.
+
+```ts
+logixlysia({
+  config: {
+    sampling: {
+      head: { INFO: 10 },
+      tail: {
+        status: 400, // any response at or above 400
+        durationMs: 1000, // anything that took a second or longer
+        paths: ['/checkout/**', '/api/v?/payments'] // routes worth every line
+      }
+    }
+  }
+})
+```
+
+Rules are OR-ed — a single match replays the whole request, including the access log line that would otherwise have been sampled away.
+
+### Path globs
+
+| Pattern | Matches                                          |
+| ------- | ------------------------------------------------ |
+| `**`    | Any characters, including `/`                    |
+| `*`     | Any characters except `/` — one path segment     |
+| `?`     | A single character except `/`                    |
+
+Everything else is literal, and patterns are anchored, so `/v1/users` matches only `/v1/users`.
+
+### Buffer cap
+
+Records are buffered per request, capped so a pathological handler cannot grow memory without bound. Anything past the cap is dropped and cannot be rescued.
+
+```ts
+sampling: {
+  head: { INFO: 10 },
+  tail: { status: 400 },
+  maxBufferedPerRequest: 250 // default: 100
+}
+```
+
+## What It Costs
+
+A head-dropped record skips context merging, redaction, formatting, and every sink — only its raw `data` and the duration at capture are retained. A request that is never rescued therefore pays close to nothing; a rescued one pays the full pipeline at replay time, with each record keeping the duration it had when it was captured rather than the duration at replay.
+
+## Scope
+
+Tail buffering applies to HTTP requests the plugin opens and closes. WebSocket lifecycle logs are head-sampled but never buffered — a long-lived socket has no request end to rescue against — and the same is true for a `createLogger` instance used outside the plugin.
+
+## Recipes
+
+Cost control — keep the shape of traffic, keep all the failures:
+
+```ts
+sampling: {
+  head: { DEBUG: 0, INFO: 5 },
+  tail: { status: 500 }
+}
+```
+
+Latency hunting — full logs for anything that crosses the SLO:
+
+```ts
+sampling: {
+  head: { INFO: 20 },
+  tail: { durationMs: 750 }
+}
+```
+
+Critical paths — thin everything except the routes that pay the bills:
+
+```ts
+sampling: {
+  head: { INFO: 2 },
+  tail: { paths: ['/checkout/**', '/webhooks/**'], status: 400 }
+}
+```
+
+## Sampling and Adapters
+
+Sampling runs before every sink, so a dropped record never reaches [transports](/docs/features/transports), file logging, or the console. That is the point: it is the cheapest place to cut what Datadog, Better Stack, or PostHog will charge you for.
+
+## Validation
+
+Bad sampling config throws at plugin construction rather than failing quietly at runtime:
+
+- `head.<LEVEL>` must be a number between `0` and `100`
+- `tail.status` and `tail.durationMs` must be non-negative numbers
+- `tail.paths` must contain non-empty strings
+- `maxBufferedPerRequest` must be a non-negative integer

--- a/packages/logixlysia/__tests__/config/resolve-options.test.ts
+++ b/packages/logixlysia/__tests__/config/resolve-options.test.ts
@@ -93,4 +93,48 @@ describe('resolveOptions', () => {
       'logixlysia: invalid preset'
     )
   })
+
+  test('rejects unsupported head sampling levels', () => {
+    expect(() =>
+      resolveOptions({
+        config: { sampling: { head: { TRACE: 50 } as never } }
+      })
+    ).toThrow('head.TRACE is not a valid level')
+  })
+
+  test('accepts valid head sampling levels', () => {
+    const resolved = resolveOptions({
+      config: {
+        sampling: {
+          head: { DEBUG: 10, ERROR: 100, INFO: 50, WARNING: 75 }
+        }
+      }
+    })
+
+    expect(resolved.config?.sampling?.head).toEqual({
+      DEBUG: 10,
+      ERROR: 100,
+      INFO: 50,
+      WARNING: 75
+    })
+  })
+
+  test('validates tail.paths is an array', () => {
+    expect(() =>
+      resolveOptions({
+        config: { sampling: { tail: { paths: 'not-an-array' as never } } }
+      })
+    ).toThrow('tail.paths must be an array')
+  })
+
+  test('validates tail.paths array contains non-empty strings', () => {
+    const resolved = resolveOptions({
+      config: { sampling: { tail: { paths: ['/api/*', '/checkout/**'] } } }
+    })
+
+    expect(resolved.config?.sampling?.tail?.paths).toEqual([
+      '/api/*',
+      '/checkout/**'
+    ])
+  })
 })

--- a/packages/logixlysia/__tests__/enrichers/built-ins.test.ts
+++ b/packages/logixlysia/__tests__/enrichers/built-ins.test.ts
@@ -143,6 +143,19 @@ describe('userAgentEnricher', () => {
     ).toMatchObject({ browser: 'Edge', os: 'Windows' })
   })
 
+  test('identifies Edge on iOS', () => {
+    expect(
+      parse(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 EdgiOS/131.0.2903.48 Mobile/15E148 Safari/605.1.15'
+      )
+    ).toMatchObject({
+      browser: 'Edge',
+      browserVersion: '131.0.2903.48',
+      device: 'mobile',
+      os: 'iOS'
+    })
+  })
+
   test('identifies mobile Safari on iOS', () => {
     expect(
       parse(
@@ -242,6 +255,21 @@ describe('geoEnricher', () => {
   test('ignores an unparseable Netlify blob', () => {
     expect(
       enricher.request?.(requestWith({ 'x-nf-geo': 'not-base64-json' }))
+    ).toBeUndefined()
+  })
+
+  test('ignores a Netlify blob containing null', () => {
+    expect(
+      enricher.request?.(requestWith({ 'x-nf-geo': btoa('null') }))
+    ).toBeUndefined()
+  })
+
+  test('ignores a Netlify blob containing a non-object primitive', () => {
+    expect(
+      enricher.request?.(requestWith({ 'x-nf-geo': btoa('"string"') }))
+    ).toBeUndefined()
+    expect(
+      enricher.request?.(requestWith({ 'x-nf-geo': btoa('123') }))
     ).toBeUndefined()
   })
 

--- a/packages/logixlysia/__tests__/enrichers/built-ins.test.ts
+++ b/packages/logixlysia/__tests__/enrichers/built-ins.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  geoEnricher,
+  sizeEnricher,
+  traceparentEnricher,
+  userAgentEnricher
+} from '../../src/enrichers'
+
+const requestWith = (headers: Record<string, string>): Request =>
+  new Request('http://localhost/', { headers })
+
+const TRACE_ID = '4bf92f3577b34da6a3ce929d0e0e4736'
+const SPAN_ID = '00f067aa0ba902b7'
+
+describe('traceparentEnricher', () => {
+  const enricher = traceparentEnricher()
+
+  test('parses a valid version 00 header', () => {
+    const fields = enricher.request?.(
+      requestWith({ traceparent: `00-${TRACE_ID}-${SPAN_ID}-01` })
+    )
+
+    expect(fields).toEqual({
+      span_id: SPAN_ID,
+      trace_flags: '01',
+      trace_id: TRACE_ID,
+      trace_sampled: true
+    })
+  })
+
+  test('reports an unsampled trace', () => {
+    const fields = enricher.request?.(
+      requestWith({ traceparent: `00-${TRACE_ID}-${SPAN_ID}-00` })
+    )
+
+    expect(fields?.trace_sampled).toBe(false)
+  })
+
+  test('accepts a future version with extra fields', () => {
+    const fields = enricher.request?.(
+      requestWith({ traceparent: `01-${TRACE_ID}-${SPAN_ID}-01-extra` })
+    )
+
+    expect(fields?.trace_id).toBe(TRACE_ID)
+  })
+
+  test('rejects version 00 with a trailing field', () => {
+    expect(
+      enricher.request?.(
+        requestWith({ traceparent: `00-${TRACE_ID}-${SPAN_ID}-01-extra` })
+      )
+    ).toBeUndefined()
+  })
+
+  test.each([
+    ['no header', {}],
+    ['garbage', { traceparent: 'not-a-traceparent' }],
+    ['reserved version ff', { traceparent: `ff-${TRACE_ID}-${SPAN_ID}-01` }],
+    [
+      'all-zero trace id',
+      { traceparent: `00-${'0'.repeat(32)}-${SPAN_ID}-01` }
+    ],
+    [
+      'all-zero span id',
+      { traceparent: `00-${TRACE_ID}-${'0'.repeat(16)}-01` }
+    ],
+    [
+      'uppercase hex',
+      { traceparent: `00-${TRACE_ID.toUpperCase()}-${SPAN_ID}-01` }
+    ],
+    ['short trace id', { traceparent: `00-abc-${SPAN_ID}-01` }]
+  ])('ignores %s', (_label, headers) => {
+    expect(enricher.request?.(requestWith(headers))).toBeUndefined()
+  })
+
+  test('records tracestate only when asked', () => {
+    const headers = {
+      traceparent: `00-${TRACE_ID}-${SPAN_ID}-01`,
+      tracestate: 'vendor=value'
+    }
+
+    expect(
+      traceparentEnricher().request?.(requestWith(headers))?.tracestate
+    ).toBeUndefined()
+    expect(
+      traceparentEnricher({ tracestate: true }).request?.(requestWith(headers))
+        ?.tracestate
+    ).toBe('vendor=value')
+  })
+
+  test('truncates an oversized tracestate', () => {
+    const fields = traceparentEnricher({ tracestate: true }).request?.(
+      requestWith({
+        traceparent: `00-${TRACE_ID}-${SPAN_ID}-01`,
+        tracestate: `vendor=${'x'.repeat(1000)}`
+      })
+    )
+
+    expect(String(fields?.tracestate).length).toBe(512)
+  })
+
+  test('reads a custom header', () => {
+    const fields = traceparentEnricher({ header: 'x-trace' }).request?.(
+      requestWith({ 'x-trace': `00-${TRACE_ID}-${SPAN_ID}-01` })
+    )
+
+    expect(fields?.trace_id).toBe(TRACE_ID)
+  })
+})
+
+describe('userAgentEnricher', () => {
+  const enricher = userAgentEnricher()
+
+  const parse = (userAgent: string) =>
+    enricher.request?.(requestWith({ 'user-agent': userAgent }))?.ua as
+      | Record<string, unknown>
+      | undefined
+
+  test('adds nothing without a user-agent header', () => {
+    expect(enricher.request?.(requestWith({}))).toBeUndefined()
+  })
+
+  test('identifies desktop Chrome', () => {
+    expect(
+      parse(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+      )
+    ).toEqual({
+      bot: false,
+      browser: 'Chrome',
+      browserVersion: '131.0.0.0',
+      device: 'desktop',
+      os: 'macOS'
+    })
+  })
+
+  test('prefers Edge over the Chrome token it also carries', () => {
+    expect(
+      parse(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0'
+      )
+    ).toMatchObject({ browser: 'Edge', os: 'Windows' })
+  })
+
+  test('identifies mobile Safari on iOS', () => {
+    expect(
+      parse(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+      )
+    ).toMatchObject({ browser: 'Safari', device: 'mobile', os: 'iOS' })
+  })
+
+  test('treats an iPad as a tablet', () => {
+    expect(
+      parse('Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) Safari/604.1')
+    ).toMatchObject({ device: 'tablet', os: 'iOS' })
+  })
+
+  test('flags a crawler', () => {
+    expect(
+      parse(
+        'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+      )
+    ).toMatchObject({ bot: true, device: 'bot' })
+  })
+
+  test('falls back to desktop for an unknown agent', () => {
+    expect(parse('curl/8.5.0')).toEqual({ bot: false, device: 'desktop' })
+  })
+})
+
+describe('geoEnricher', () => {
+  const enricher = geoEnricher()
+
+  test('adds nothing without platform headers', () => {
+    expect(enricher.request?.(requestWith({}))).toBeUndefined()
+  })
+
+  test('reads Vercel headers and decodes the city', () => {
+    const fields = enricher.request?.(
+      requestWith({
+        'x-vercel-ip-city': 'S%C3%A3o%20Paulo',
+        'x-vercel-ip-country': 'BR',
+        'x-vercel-ip-country-region': 'SP',
+        'x-vercel-ip-latitude': '-23.5505',
+        'x-vercel-ip-longitude': '-46.6333',
+        'x-vercel-ip-timezone': 'America/Sao_Paulo'
+      })
+    )
+
+    expect(fields?.geo).toEqual({
+      city: 'São Paulo',
+      country: 'BR',
+      latitude: -23.5505,
+      longitude: -46.6333,
+      region: 'SP',
+      timezone: 'America/Sao_Paulo'
+    })
+  })
+
+  test('reads Cloudflare headers', () => {
+    const fields = enricher.request?.(
+      requestWith({
+        'cf-ipcity': 'Bangkok',
+        'cf-ipcountry': 'TH',
+        'cf-iplatitude': '13.7563',
+        'cf-region-code': '10'
+      })
+    )
+
+    expect(fields?.geo).toEqual({
+      city: 'Bangkok',
+      country: 'TH',
+      latitude: 13.7563,
+      region: '10'
+    })
+  })
+
+  test('decodes the Netlify geo blob', () => {
+    const payload = btoa(
+      JSON.stringify({
+        city: 'Berlin',
+        country: { code: 'DE' },
+        latitude: 52.52,
+        subdivision: { code: 'BE' },
+        timezone: 'Europe/Berlin'
+      })
+    )
+
+    expect(
+      enricher.request?.(requestWith({ 'x-nf-geo': payload }))?.geo
+    ).toEqual({
+      city: 'Berlin',
+      country: 'DE',
+      latitude: 52.52,
+      region: 'BE',
+      timezone: 'Europe/Berlin'
+    })
+  })
+
+  test('ignores an unparseable Netlify blob', () => {
+    expect(
+      enricher.request?.(requestWith({ 'x-nf-geo': 'not-base64-json' }))
+    ).toBeUndefined()
+  })
+
+  test('drops a non-numeric coordinate', () => {
+    expect(
+      enricher.request?.(
+        requestWith({
+          'x-vercel-ip-country': 'TH',
+          'x-vercel-ip-latitude': 'unknown'
+        })
+      )?.geo
+    ).toEqual({ country: 'TH' })
+  })
+})
+
+describe('sizeEnricher', () => {
+  const enricher = sizeEnricher()
+
+  test('reads the request content-length', () => {
+    expect(
+      enricher.request?.(requestWith({ 'content-length': '1024' }))
+    ).toEqual({ requestBytes: 1024 })
+  })
+
+  test('adds nothing without a request content-length', () => {
+    expect(enricher.request?.(requestWith({}))).toBeUndefined()
+  })
+
+  test('reads the response content-length whatever its casing', () => {
+    expect(
+      enricher.response?.({
+        durationMs: 1,
+        headers: { 'Content-Length': '2048' },
+        request: requestWith({}),
+        status: 200
+      })
+    ).toEqual({ responseBytes: 2048 })
+  })
+
+  test('omits the response size when the header is absent', () => {
+    expect(
+      enricher.response?.({
+        durationMs: 1,
+        headers: {},
+        request: requestWith({}),
+        status: 200
+      })
+    ).toBeUndefined()
+  })
+
+  test('rejects a negative or non-numeric length', () => {
+    expect(
+      enricher.request?.(requestWith({ 'content-length': '-5' }))
+    ).toBeUndefined()
+    expect(
+      enricher.request?.(requestWith({ 'content-length': 'many' }))
+    ).toBeUndefined()
+  })
+})

--- a/packages/logixlysia/__tests__/enrichers/plugin.test.ts
+++ b/packages/logixlysia/__tests__/enrichers/plugin.test.ts
@@ -182,4 +182,57 @@ describe('enrichers through the plugin', () => {
 
     expect(contextOf(events[0])).toBeUndefined()
   })
+
+  test('sizeEnricher receives headers from a Response object', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = new Elysia()
+      .use(
+        logixlysia({
+          config: {
+            disableFileLogging: true,
+            disableInternalLogger: true,
+            enrichers: [sizeEnricher()],
+            transports: [{ log: transport }]
+          }
+        })
+      )
+      .get(
+        '/with-response',
+        () =>
+          new Response('body', {
+            headers: { 'content-length': '4' }
+          })
+      )
+
+    await app.handle(new Request('http://localhost/with-response'))
+
+    expect(contextOf(events[0])).toMatchObject({ responseBytes: 4 })
+  })
+
+  test('set.headers takes precedence over Response headers', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = new Elysia()
+      .use(
+        logixlysia({
+          config: {
+            disableFileLogging: true,
+            disableInternalLogger: true,
+            enrichers: [sizeEnricher()],
+            requestId: true,
+            transports: [{ log: transport }]
+          }
+        })
+      )
+      .get('/precedence', ({ set }) => {
+        set.headers['x-request-id'] = 'from-set-headers'
+        return new Response('body', {
+          headers: { 'x-request-id': 'from-response' }
+        })
+      })
+
+    await app.handle(new Request('http://localhost/precedence'))
+
+    // The request ID from set.headers should be preserved
+    expect(contextOf(events[0])?.requestId).toBe('from-set-headers')
+  })
 })

--- a/packages/logixlysia/__tests__/enrichers/plugin.test.ts
+++ b/packages/logixlysia/__tests__/enrichers/plugin.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { Elysia } from 'elysia'
+
+import logixlysia from '../../src'
+import {
+  sizeEnricher,
+  traceparentEnricher,
+  userAgentEnricher
+} from '../../src/enrichers'
+import { HttpError, type Options } from '../../src/interfaces'
+
+const TRACE_ID = '4bf92f3577b34da6a3ce929d0e0e4736'
+const SPAN_ID = '00f067aa0ba902b7'
+
+interface CapturedEvent {
+  level: string
+  meta: Record<string, unknown>
+}
+
+const createCaptureTransport = () => {
+  const events: CapturedEvent[] = []
+  const transport = mock(
+    (level: string, _message: string, meta?: Record<string, unknown>) => {
+      events.push({ level, meta: meta ?? {} })
+    }
+  )
+  return { events, transport }
+}
+
+const buildApp = (
+  config: NonNullable<Options['config']>,
+  transport: ReturnType<typeof createCaptureTransport>['transport']
+) =>
+  new Elysia()
+    .use(
+      logixlysia({
+        config: {
+          ...config,
+          disableFileLogging: true,
+          disableInternalLogger: true,
+          transports: [{ log: transport }]
+        }
+      })
+    )
+    .get('/ok', () => 'ok')
+    .get('/custom', ({ log }) => {
+      log.info('handled')
+      return 'ok'
+    })
+    .get('/boom', () => {
+      throw new HttpError(503, 'downstream')
+    })
+
+const contextOf = (event: CapturedEvent | undefined) =>
+  event?.meta.context as Record<string, unknown> | undefined
+
+describe('enrichers through the plugin', () => {
+  test('request-phase fields reach the access log context', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildApp(
+      { enrichers: [traceparentEnricher(), userAgentEnricher()] },
+      transport
+    )
+
+    await app.handle(
+      new Request('http://localhost/ok', {
+        headers: {
+          traceparent: `00-${TRACE_ID}-${SPAN_ID}-01`,
+          'user-agent': 'curl/8.5.0'
+        }
+      })
+    )
+
+    expect(contextOf(events[0])).toMatchObject({
+      trace_id: TRACE_ID,
+      ua: { bot: false, device: 'desktop' }
+    })
+  })
+
+  test('a bare function is treated as the request phase', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildApp(
+      { enrichers: [request => ({ tenant: new URL(request.url).host })] },
+      transport
+    )
+
+    await app.handle(new Request('http://localhost/ok'))
+
+    expect(contextOf(events[0])).toMatchObject({ tenant: 'localhost' })
+  })
+
+  test('response-phase fields land on the access log', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildApp(
+      {
+        enrichers: [
+          sizeEnricher(),
+          {
+            response: ({ durationMs, status }) => ({
+              ok: status < 400,
+              slow: durationMs > 10_000
+            })
+          }
+        ]
+      },
+      transport
+    )
+
+    await app.handle(new Request('http://localhost/ok'))
+
+    expect(contextOf(events[0])).toMatchObject({ ok: true, slow: false })
+  })
+
+  test('enriched fields also reach custom logs made later in the request', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildApp({ enrichers: [traceparentEnricher()] }, transport)
+
+    await app.handle(
+      new Request('http://localhost/custom', {
+        headers: { traceparent: `00-${TRACE_ID}-${SPAN_ID}-01` }
+      })
+    )
+
+    expect(contextOf(events[0])).toMatchObject({ trace_id: TRACE_ID })
+  })
+
+  test('enrichment runs on the error path too', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildApp(
+      {
+        enrichers: [
+          traceparentEnricher(),
+          { response: ({ status }) => ({ finalStatus: status }) }
+        ]
+      },
+      transport
+    )
+
+    await app.handle(
+      new Request('http://localhost/boom', {
+        headers: { traceparent: `00-${TRACE_ID}-${SPAN_ID}-01` }
+      })
+    )
+
+    expect(contextOf(events[0])).toMatchObject({
+      finalStatus: 503,
+      trace_id: TRACE_ID
+    })
+  })
+
+  test('a throwing enricher is reported and does not break the request', async () => {
+    const { events, transport } = createCaptureTransport()
+    const onError = mock((_context: { error: unknown; sink: string }) => {
+      /* noop */
+    })
+    const app = buildApp(
+      {
+        enrichers: [
+          () => {
+            throw new Error('enricher exploded')
+          },
+          () => ({ survivor: true })
+        ],
+        onError
+      },
+      transport
+    )
+
+    const response = await app.handle(new Request('http://localhost/ok'))
+
+    expect(response.status).toBe(200)
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls[0]?.[0].sink).toBe('enricher')
+    expect(contextOf(events[0])).toMatchObject({ survivor: true })
+  })
+
+  test('an enricher returning nothing adds no context', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildApp({ enrichers: [() => undefined] }, transport)
+
+    await app.handle(new Request('http://localhost/ok'))
+
+    expect(contextOf(events[0])).toBeUndefined()
+  })
+})

--- a/packages/logixlysia/__tests__/enrichers/plugin.test.ts
+++ b/packages/logixlysia/__tests__/enrichers/plugin.test.ts
@@ -209,8 +209,32 @@ describe('enrichers through the plugin', () => {
     expect(contextOf(events[0])).toMatchObject({ responseBytes: 4 })
   })
 
-  test('set.headers takes precedence over Response headers', async () => {
+  test('set.headers wins over a header of the same name on the Response', async () => {
     const { events, transport } = createCaptureTransport()
+    const app = new Elysia()
+      .use(
+        logixlysia({
+          config: {
+            disableFileLogging: true,
+            disableInternalLogger: true,
+            enrichers: [sizeEnricher()],
+            transports: [{ log: transport }]
+          }
+        })
+      )
+      .get('/precedence', ({ set }) => {
+        set.headers['content-length'] = '99'
+        return new Response('body', { headers: { 'content-length': '4' } })
+      })
+
+    await app.handle(new Request('http://localhost/precedence'))
+
+    // Elysia applies set.headers last, so the log must agree with the wire.
+    expect(contextOf(events[0])).toMatchObject({ responseBytes: 99 })
+  })
+
+  test('the request id still reaches the response when a Response is returned', async () => {
+    const { transport } = createCaptureTransport()
     const app = new Elysia()
       .use(
         logixlysia({
@@ -223,16 +247,14 @@ describe('enrichers through the plugin', () => {
           }
         })
       )
-      .get('/precedence', ({ set }) => {
-        set.headers['x-request-id'] = 'from-set-headers'
-        return new Response('body', {
-          headers: { 'x-request-id': 'from-response' }
-        })
+      .get('/with-response', () => new Response('body'))
+
+    const response = await app.handle(
+      new Request('http://localhost/with-response', {
+        headers: { 'X-Request-Id': 'req-from-gateway' }
       })
+    )
 
-    await app.handle(new Request('http://localhost/precedence'))
-
-    // The request ID from set.headers should be preserved
-    expect(contextOf(events[0])?.requestId).toBe('from-set-headers')
+    expect(response.headers.get('X-Request-Id')).toBe('req-from-gateway')
   })
 })

--- a/packages/logixlysia/__tests__/errors/http-error.test.ts
+++ b/packages/logixlysia/__tests__/errors/http-error.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { Elysia } from 'elysia'
+
+import logixlysia from '../../src'
+import { HttpError } from '../../src/interfaces'
+import { normalizeLoggedError } from '../../src/utils/error'
+
+const INTERNAL_SECRET = 'sk_live_do_not_leak'
+
+const richError = () =>
+  new HttpError(402, 'Card declined', {
+    code: 'PAYMENT_DECLINED',
+    fix: 'Try a different card, or contact your bank.',
+    internal: { gatewayCode: 'do_not_honor', token: INTERNAL_SECRET },
+    link: 'https://docs.example.com/errors/payment-declined',
+    why: 'The issuing bank rejected the charge.'
+  })
+
+describe('HttpError', () => {
+  test('keeps the existing two-argument shape working', () => {
+    const error = new HttpError(404, 'Not found')
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.status).toBe(404)
+    expect(error.message).toBe('Not found')
+    expect(error.name).toBe('HttpError')
+    expect(error.code).toBeUndefined()
+  })
+
+  test('exposes the structured fields', () => {
+    const error = richError()
+
+    expect(error.code).toBe('PAYMENT_DECLINED')
+    expect(error.why).toBe('The issuing bank rejected the charge.')
+    expect(error.fix).toBe('Try a different card, or contact your bank.')
+    expect(error.link).toBe('https://docs.example.com/errors/payment-declined')
+    expect(error.internal).toEqual({
+      gatewayCode: 'do_not_honor',
+      token: INTERNAL_SECRET
+    })
+  })
+
+  test('toJSON omits internal', () => {
+    expect(richError().toJSON()).toEqual({
+      code: 'PAYMENT_DECLINED',
+      fix: 'Try a different card, or contact your bank.',
+      link: 'https://docs.example.com/errors/payment-declined',
+      message: 'Card declined',
+      status: 402,
+      why: 'The issuing bank rejected the charge.'
+    })
+  })
+
+  test('internal survives no serialization path', () => {
+    const error = richError()
+
+    expect(JSON.stringify(error)).not.toContain(INTERNAL_SECRET)
+    expect(JSON.stringify({ ...error })).not.toContain(INTERNAL_SECRET)
+    expect(Object.keys(error)).not.toContain('internal')
+  })
+
+  test('name is non-enumerable, as on a native Error', () => {
+    expect(Object.keys(new HttpError(404, 'Not found'))).not.toContain('name')
+  })
+})
+
+describe('HttpError responses', () => {
+  const app = new Elysia()
+    .use(
+      logixlysia({
+        config: { disableFileLogging: true, disableInternalLogger: true }
+      })
+    )
+    .get('/plain', () => {
+      throw new HttpError(404, 'Not found')
+    })
+    .get('/rich', () => {
+      throw richError()
+    })
+
+  test('a plain error still responds with the bare message', async () => {
+    const response = await app.handle(new Request('http://localhost/plain'))
+
+    expect(response.status).toBe(404)
+    expect(await response.text()).toBe('Not found')
+  })
+
+  test('a structured error responds as JSON with the client-safe payload', async () => {
+    const response = await app.handle(new Request('http://localhost/rich'))
+
+    expect(response.status).toBe(402)
+    expect(await response.json()).toEqual({
+      code: 'PAYMENT_DECLINED',
+      fix: 'Try a different card, or contact your bank.',
+      link: 'https://docs.example.com/errors/payment-declined',
+      message: 'Card declined',
+      status: 402,
+      why: 'The issuing bank rejected the charge.'
+    })
+  })
+
+  test('the response never carries internal', async () => {
+    const response = await app.handle(new Request('http://localhost/rich'))
+
+    expect(await response.text()).not.toContain(INTERNAL_SECRET)
+  })
+})
+
+describe('HttpError logging', () => {
+  test('normalizeLoggedError keeps every structured field, internal included', () => {
+    const { error, message } = normalizeLoggedError(richError(), false)
+
+    expect(message).toBe('Card declined')
+    expect(error).toMatchObject({
+      code: 'PAYMENT_DECLINED',
+      fix: 'Try a different card, or contact your bank.',
+      internal: { gatewayCode: 'do_not_honor', token: INTERNAL_SECRET },
+      link: 'https://docs.example.com/errors/payment-declined',
+      message: 'Card declined',
+      name: 'HttpError',
+      status: 402,
+      why: 'The issuing bank rejected the charge.'
+    })
+  })
+
+  test('the transport sees the full error, including internal', async () => {
+    const events: Record<string, unknown>[] = []
+    const transport = mock(
+      (_level: string, _message: string, meta?: Record<string, unknown>) => {
+        events.push(meta ?? {})
+      }
+    )
+
+    const app = new Elysia()
+      .use(
+        logixlysia({
+          config: {
+            disableFileLogging: true,
+            disableInternalLogger: true,
+            transports: [{ log: transport }]
+          }
+        })
+      )
+      .get('/rich', () => {
+        throw richError()
+      })
+
+    await app.handle(new Request('http://localhost/rich'))
+
+    expect(events[0]?.error).toMatchObject({
+      code: 'PAYMENT_DECLINED',
+      internal: { token: INTERNAL_SECRET }
+    })
+  })
+
+  test('the console context tree lists code, why, fix, link, and internal', async () => {
+    const lines: string[] = []
+    const original = console.warn
+    console.warn = ((message: string) => {
+      lines.push(String(message))
+    }) as typeof console.warn
+
+    try {
+      const app = new Elysia()
+        .use(
+          logixlysia({
+            config: {
+              disableFileLogging: true,
+              showContextTree: true,
+              useColors: false
+            }
+          })
+        )
+        .get('/rich', () => {
+          throw richError()
+        })
+
+      await app.handle(new Request('http://localhost/rich'))
+    } finally {
+      console.warn = original
+    }
+
+    const output = lines.join('\n')
+    expect(output).toContain('error.code')
+    expect(output).toContain('error.why')
+    expect(output).toContain('error.fix')
+    expect(output).toContain('error.link')
+    expect(output).toContain('error.internal')
+  })
+})

--- a/packages/logixlysia/__tests__/errors/http-error.test.ts
+++ b/packages/logixlysia/__tests__/errors/http-error.test.ts
@@ -104,6 +104,41 @@ describe('HttpError responses', () => {
 
     expect(await response.text()).not.toContain(INTERNAL_SECRET)
   })
+
+  test('toResponse uses status 500 when the original status is invalid', () => {
+    const error = new HttpError(0, 'Bad status', { code: 'BAD_STATUS' })
+    const response = error.toResponse?.()
+
+    expect(response?.status).toBe(500)
+  })
+
+  test('toResponse uses status 500 when the original status is 600+', () => {
+    const error = new HttpError(600, 'Out of range', { code: 'OUT_OF_RANGE' })
+    const response = error.toResponse?.()
+
+    expect(response?.status).toBe(500)
+  })
+
+  test('toResponse uses status 500 for body-disallowed status like 204', () => {
+    const error = new HttpError(204, 'No Content', { code: 'NO_CONTENT' })
+    const response = error.toResponse?.()
+
+    expect(response?.status).toBe(500)
+  })
+
+  test('toResponse uses status 500 for body-disallowed status like 304', () => {
+    const error = new HttpError(304, 'Not Modified', { code: 'NOT_MODIFIED' })
+    const response = error.toResponse?.()
+
+    expect(response?.status).toBe(500)
+  })
+
+  test('toResponse uses the original valid status when appropriate', () => {
+    const error = new HttpError(400, 'Bad Request', { code: 'BAD_REQUEST' })
+    const response = error.toResponse?.()
+
+    expect(response?.status).toBe(400)
+  })
 })
 
 describe('HttpError logging', () => {

--- a/packages/logixlysia/__tests__/sampling/glob.test.ts
+++ b/packages/logixlysia/__tests__/sampling/glob.test.ts
@@ -42,4 +42,24 @@ describe('globToRegExp', () => {
     expect(pattern.test('')).toBe(true)
     expect(pattern.test('/')).toBe(false)
   })
+
+  test('rejects adjacent recursive wildcards to prevent ReDoS', () => {
+    expect(() => globToRegExp('**/**')).toThrow('repeated recursive wildcards')
+  })
+
+  test('rejects nearly-adjacent recursive wildcards', () => {
+    expect(() => globToRegExp('**//**')).toThrow('repeated recursive wildcards')
+  })
+
+  test('allows recursive wildcards separated by meaningful paths', () => {
+    const pattern = globToRegExp('**/foo/**/bar')
+    expect(pattern.test('a/b/foo/c/d/bar')).toBe(true)
+    expect(pattern.test('foo/bar')).toBe(true)
+  })
+
+  test('allows a single recursive wildcard', () => {
+    const pattern = globToRegExp('/api/**')
+    expect(pattern.test('/api/users')).toBe(true)
+    expect(pattern.test('/api/v1/users')).toBe(true)
+  })
 })

--- a/packages/logixlysia/__tests__/sampling/glob.test.ts
+++ b/packages/logixlysia/__tests__/sampling/glob.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+
+import { globToRegExp } from '../../src/sampling/glob'
+
+describe('globToRegExp', () => {
+  test('matches a literal path exactly', () => {
+    const pattern = globToRegExp('/v1/users')
+    expect(pattern.test('/v1/users')).toBe(true)
+    expect(pattern.test('/v1/users/1')).toBe(false)
+    expect(pattern.test('/api/v1/users')).toBe(false)
+  })
+
+  test('single star stays inside one segment', () => {
+    const pattern = globToRegExp('/v1/*')
+    expect(pattern.test('/v1/users')).toBe(true)
+    expect(pattern.test('/v1/')).toBe(true)
+    expect(pattern.test('/v1/users/1')).toBe(false)
+  })
+
+  test('double star crosses segments', () => {
+    const pattern = globToRegExp('/checkout/**')
+    expect(pattern.test('/checkout/')).toBe(true)
+    expect(pattern.test('/checkout/cart/items')).toBe(true)
+    expect(pattern.test('/checkouts')).toBe(false)
+  })
+
+  test('question mark matches one non-slash character', () => {
+    const pattern = globToRegExp('/v?/users')
+    expect(pattern.test('/v1/users')).toBe(true)
+    expect(pattern.test('/v12/users')).toBe(false)
+    expect(pattern.test('//users')).toBe(false)
+  })
+
+  test('regex metacharacters in the pattern are literal', () => {
+    const pattern = globToRegExp('/files/report.pdf')
+    expect(pattern.test('/files/report.pdf')).toBe(true)
+    expect(pattern.test('/files/reportXpdf')).toBe(false)
+  })
+
+  test('an empty pattern matches only the empty string', () => {
+    const pattern = globToRegExp('')
+    expect(pattern.test('')).toBe(true)
+    expect(pattern.test('/')).toBe(false)
+  })
+})

--- a/packages/logixlysia/__tests__/sampling/glob.test.ts
+++ b/packages/logixlysia/__tests__/sampling/glob.test.ts
@@ -54,7 +54,9 @@ describe('globToRegExp', () => {
   test('allows recursive wildcards separated by meaningful paths', () => {
     const pattern = globToRegExp('**/foo/**/bar')
     expect(pattern.test('a/b/foo/c/d/bar')).toBe(true)
-    expect(pattern.test('foo/bar')).toBe(true)
+    expect(pattern.test('/foo/x/bar')).toBe(true)
+    // The literal `/foo/` and `/bar` segments are still required.
+    expect(pattern.test('foo/bar')).toBe(false)
   })
 
   test('allows a single recursive wildcard', () => {

--- a/packages/logixlysia/__tests__/sampling/plugin.test.ts
+++ b/packages/logixlysia/__tests__/sampling/plugin.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { Elysia } from 'elysia'
+
+import logixlysia from '../../src'
+import { HttpError, type Options } from '../../src/interfaces'
+
+interface CapturedEvent {
+  level: string
+  message: string
+  meta: Record<string, unknown>
+}
+
+const createCaptureTransport = () => {
+  const events: CapturedEvent[] = []
+  const transport = mock(
+    (level: string, message: string, meta?: Record<string, unknown>) => {
+      events.push({ level, message, meta: meta ?? {} })
+    }
+  )
+  return { events, transport }
+}
+
+const buildApp = (
+  config: NonNullable<Options['config']>,
+  transport: ReturnType<typeof createCaptureTransport>['transport']
+) =>
+  new Elysia()
+    .use(
+      logixlysia({
+        config: {
+          ...config,
+          disableFileLogging: true,
+          disableInternalLogger: true,
+          transports: [{ log: transport }]
+        }
+      })
+    )
+    .get('/fast', ({ log }) => {
+      log.info('step one')
+      log.info('step two')
+      return 'ok'
+    })
+    .get('/boom', () => {
+      throw new HttpError(503, 'downstream')
+    })
+    .get('/boom-logged', ({ log }) => {
+      log.info('loaded the order')
+      throw new HttpError(503, 'downstream')
+    })
+    .get('/checkout/cart', ({ log }) => {
+      log.info('cart read')
+      return 'ok'
+    })
+
+const get = (app: ReturnType<typeof buildApp>, path: string) =>
+  app.handle(new Request(`http://localhost${path}`))
+
+describe('sampling through the plugin', () => {
+  test('head sampling at 0% silences INFO but keeps ERROR', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildApp({ sampling: { head: { INFO: 0 } } }, transport)
+
+    await get(app, '/fast')
+    expect(events).toHaveLength(0)
+
+    await get(app, '/boom')
+    expect(events.map(event => event.level)).toEqual(['ERROR'])
+  })
+
+  test('head sampling at 100% is a no-op', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildApp({ sampling: { head: { INFO: 100 } } }, transport)
+
+    await get(app, '/fast')
+    expect(events).toHaveLength(2)
+  })
+
+  test('tail sampling replays head-dropped records on an error status', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildApp(
+      { sampling: { head: { INFO: 0 }, tail: { status: 400 } } },
+      transport
+    )
+
+    await get(app, '/fast')
+    expect(events).toHaveLength(0)
+
+    await get(app, '/boom-logged')
+    expect(events.map(event => [event.level, event.message])).toEqual([
+      ['INFO', 'loaded the order'],
+      ['ERROR', 'downstream']
+    ])
+  })
+
+  test('tail sampling rescues the custom logs of a matching path', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildApp(
+      { sampling: { head: { INFO: 0 }, tail: { paths: ['/checkout/**'] } } },
+      transport
+    )
+
+    await get(app, '/fast')
+    expect(events).toHaveLength(0)
+
+    await get(app, '/checkout/cart')
+    expect(events.map(event => event.message)).toEqual(['cart read'])
+  })
+
+  test('a replayed record keeps the duration it had when captured', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildApp(
+      { sampling: { head: { INFO: 0 }, tail: { paths: ['/checkout/**'] } } },
+      transport
+    )
+
+    await get(app, '/checkout/cart')
+
+    const [replayed] = events
+    expect(typeof replayed?.meta.durationMs).toBe('number')
+  })
+
+  test('sampling is off entirely when unconfigured', async () => {
+    const { events, transport } = createCaptureTransport()
+    const app = buildApp({}, transport)
+
+    await get(app, '/fast')
+    expect(events).toHaveLength(2)
+  })
+
+  test('WebSocket pseudo-requests drop rather than buffer', () => {
+    const { events, transport } = createCaptureTransport()
+    const plugin = logixlysia({
+      config: {
+        disableFileLogging: true,
+        disableInternalLogger: true,
+        sampling: { head: { INFO: 0 }, tail: { status: 400 } },
+        transports: [{ log: transport }]
+      }
+    })
+    const hooks = plugin.wrapWs('/ws', {
+      close(_ws) {
+        /* noop */
+      },
+      message(_ws, _message) {
+        /* noop */
+      },
+      open(_ws) {
+        /* noop */
+      }
+    })
+    const ws = { id: 'ws-1' }
+
+    hooks.open(ws)
+    hooks.message(ws, 'hello')
+    hooks.close(ws)
+
+    expect(events).toHaveLength(0)
+  })
+})
+
+const HEAD_RATE_ERROR = /head\.INFO must be a number between 0 and 100/
+const TAIL_STATUS_ERROR = /tail\.status must be a non-negative number/
+const TAIL_DURATION_ERROR = /tail\.durationMs must be a non-negative number/
+const TAIL_PATHS_ERROR = /tail\.paths must contain non-empty glob strings/
+const MAX_BUFFERED_ERROR =
+  /maxBufferedPerRequest must be a non-negative integer/
+
+describe('sampling config validation', () => {
+  const build = (config: NonNullable<Options['config']>) => () =>
+    logixlysia({ config })
+
+  test('rejects a rate outside 0-100', () => {
+    expect(build({ sampling: { head: { INFO: 150 } } })).toThrow(
+      HEAD_RATE_ERROR
+    )
+  })
+
+  test('rejects a negative tail status', () => {
+    expect(build({ sampling: { tail: { status: -1 } } })).toThrow(
+      TAIL_STATUS_ERROR
+    )
+  })
+
+  test('rejects a negative tail duration', () => {
+    expect(build({ sampling: { tail: { durationMs: -5 } } })).toThrow(
+      TAIL_DURATION_ERROR
+    )
+  })
+
+  test('rejects an empty glob', () => {
+    expect(build({ sampling: { tail: { paths: [''] } } })).toThrow(
+      TAIL_PATHS_ERROR
+    )
+  })
+
+  test('rejects a fractional buffer cap', () => {
+    expect(build({ sampling: { maxBufferedPerRequest: 1.5 } })).toThrow(
+      MAX_BUFFERED_ERROR
+    )
+  })
+})

--- a/packages/logixlysia/__tests__/sampling/runtime.test.ts
+++ b/packages/logixlysia/__tests__/sampling/runtime.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { RequestOutcome } from '../../src/sampling'
+import { resolveSampling } from '../../src/sampling'
+
+/** Returns each value in turn, then repeats the last one. */
+const sequence = (values: number[]): (() => number) => {
+  let index = 0
+  return () => {
+    const value = values[Math.min(index, values.length - 1)] as number
+    index += 1
+    return value
+  }
+}
+
+const outcome = (partial: Partial<RequestOutcome> = {}): RequestOutcome => ({
+  durationMs: 0,
+  pathname: '/',
+  status: 200,
+  ...partial
+})
+
+describe('resolveSampling', () => {
+  test('is off when no head rate drops anything', () => {
+    expect(resolveSampling(undefined)).toBeUndefined()
+    expect(resolveSampling({})).toBeUndefined()
+    expect(resolveSampling({ head: {} })).toBeUndefined()
+    expect(resolveSampling({ head: { INFO: 100 } })).toBeUndefined()
+  })
+
+  test('is off when only tail rules are configured', () => {
+    expect(resolveSampling({ tail: { status: 400 } })).toBeUndefined()
+  })
+
+  test('is on as soon as one level is thinned', () => {
+    expect(resolveSampling({ head: { INFO: 10 } })).toBeDefined()
+  })
+})
+
+describe('head sampling', () => {
+  test('keeps levels that are not listed', () => {
+    const sampling = resolveSampling({ head: { INFO: 0 } }, () => 0.99)
+    const key = {}
+    expect(sampling?.decide('ERROR', key)).toBe('keep')
+    expect(sampling?.decide('WARNING', key)).toBe('keep')
+    expect(sampling?.decide('DEBUG', key)).toBe('keep')
+  })
+
+  test('keeps the configured share of a thinned level', () => {
+    // 0.05 -> 5 < 10 (kept); 0.5 -> 50 >= 10 (dropped)
+    const sampling = resolveSampling(
+      { head: { INFO: 10 } },
+      sequence([0.05, 0.5])
+    )
+    const key = {}
+    expect(sampling?.decide('INFO', key)).toBe('keep')
+    expect(sampling?.decide('INFO', key)).toBe('drop')
+  })
+
+  test('a rate of 0 never keeps, whatever the draw', () => {
+    const sampling = resolveSampling({ head: { INFO: 0 } }, () => 0)
+    expect(sampling?.decide('INFO', {})).toBe('drop')
+  })
+
+  test('an explicit ERROR rate is honored over the keep-everything default', () => {
+    const sampling = resolveSampling({ head: { ERROR: 0 } }, () => 0)
+    expect(sampling?.decide('ERROR', {})).toBe('drop')
+  })
+})
+
+describe('tail sampling', () => {
+  const config = {
+    head: { INFO: 0 },
+    tail: { durationMs: 1000, paths: ['/checkout/**'], status: 400 }
+  }
+
+  test('buffers dropped records only for requests that were begun', () => {
+    const sampling = resolveSampling(config, () => 0.99)
+    const begun = {}
+    sampling?.begin(begun)
+
+    expect(sampling?.decide('INFO', begun)).toBe('buffer')
+    expect(sampling?.decide('INFO', {})).toBe('drop')
+  })
+
+  test('replays buffered records when the status matches', () => {
+    const sampling = resolveSampling(config, () => 0.99)
+    const key = {}
+    sampling?.begin(key)
+    sampling?.buffer(key, {
+      data: { message: 'step 1' },
+      durationMs: 2,
+      level: 'INFO'
+    })
+    sampling?.buffer(key, {
+      data: { message: 'step 2' },
+      durationMs: 4,
+      level: 'INFO'
+    })
+
+    const records = sampling?.finalize(key, outcome({ status: 500 })) ?? []
+    expect(records.map(record => record.data.message)).toEqual([
+      'step 1',
+      'step 2'
+    ])
+    expect(records.map(record => record.durationMs)).toEqual([2, 4])
+  })
+
+  test('replays when the request was slow', () => {
+    const sampling = resolveSampling(config, () => 0.99)
+    const key = {}
+    sampling?.begin(key)
+    sampling?.buffer(key, { data: {}, durationMs: 1, level: 'INFO' })
+
+    expect(sampling?.finalize(key, outcome({ durationMs: 1500 }))).toHaveLength(
+      1
+    )
+  })
+
+  test('replays when the pathname matches a glob', () => {
+    const sampling = resolveSampling(config, () => 0.99)
+    const key = {}
+    sampling?.begin(key)
+    sampling?.buffer(key, { data: {}, durationMs: 1, level: 'INFO' })
+
+    expect(
+      sampling?.finalize(key, outcome({ pathname: '/checkout/cart' }))
+    ).toHaveLength(1)
+  })
+
+  test('discards buffered records when nothing matches', () => {
+    const sampling = resolveSampling(config, () => 0.99)
+    const key = {}
+    sampling?.begin(key)
+    sampling?.buffer(key, { data: {}, durationMs: 1, level: 'INFO' })
+
+    expect(sampling?.finalize(key, outcome())).toHaveLength(0)
+  })
+
+  test('a rescued request keeps every later record', () => {
+    const sampling = resolveSampling(config, () => 0.99)
+    const key = {}
+    sampling?.begin(key)
+    sampling?.finalize(key, outcome({ status: 500 }))
+
+    expect(sampling?.decide('INFO', key)).toBe('keep')
+  })
+
+  test('an unrescued request drops its final record', () => {
+    const sampling = resolveSampling(config, () => 0.99)
+    const key = {}
+    sampling?.begin(key)
+    sampling?.finalize(key, outcome())
+
+    expect(sampling?.decide('INFO', key)).toBe('drop')
+  })
+
+  test('buffering stops at maxBufferedPerRequest', () => {
+    const sampling = resolveSampling(
+      { ...config, maxBufferedPerRequest: 2 },
+      () => 0.99
+    )
+    const key = {}
+    sampling?.begin(key)
+    for (let index = 0; index < 5; index += 1) {
+      sampling?.buffer(key, { data: { index }, durationMs: 0, level: 'INFO' })
+    }
+
+    const records = sampling?.finalize(key, outcome({ status: 500 })) ?? []
+    expect(records.map(record => record.data.index)).toEqual([0, 1])
+  })
+
+  test('finalize clears the buffer so a second call replays nothing', () => {
+    const sampling = resolveSampling(config, () => 0.99)
+    const key = {}
+    sampling?.begin(key)
+    sampling?.buffer(key, { data: {}, durationMs: 1, level: 'INFO' })
+
+    expect(sampling?.finalize(key, outcome({ status: 500 }))).toHaveLength(1)
+    expect(sampling?.finalize(key, outcome({ status: 500 }))).toHaveLength(0)
+  })
+
+  test('drops instead of buffering when no tail rule is configured', () => {
+    const sampling = resolveSampling({ head: { INFO: 0 } }, () => 0.99)
+    const key = {}
+    sampling?.begin(key)
+    expect(sampling?.decide('INFO', key)).toBe('drop')
+  })
+
+  test('an empty tail object is treated as no tail rules', () => {
+    const sampling = resolveSampling(
+      { head: { INFO: 0 }, tail: { paths: [] } },
+      () => 0.99
+    )
+    const key = {}
+    sampling?.begin(key)
+    expect(sampling?.decide('INFO', key)).toBe('drop')
+  })
+})

--- a/packages/logixlysia/__tests__/types/typed-fields.test.ts
+++ b/packages/logixlysia/__tests__/types/typed-fields.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { Elysia } from 'elysia'
+import logixlysia, { useLogger } from '../../src'
+
+/**
+ * These assertions are checked by `tsc --noEmit` as much as by the runtime:
+ * every `@ts-expect-error` below fails the typecheck if the field typing stops
+ * rejecting what it should.
+ */
+interface CheckoutFields {
+  cartId: string
+  itemCount: number
+  userId: string
+}
+
+const captureTransport = () => {
+  const contexts: Record<string, unknown>[] = []
+  const transport = mock(
+    (_level: string, _message: string, meta?: Record<string, unknown>) => {
+      const context = meta?.context
+      if (context && typeof context === 'object') {
+        contexts.push(context as Record<string, unknown>)
+      }
+    }
+  )
+  return { contexts, transport }
+}
+
+describe('typed request fields', () => {
+  test('accepts declared fields and records them', async () => {
+    const { contexts, transport } = captureTransport()
+
+    const app = new Elysia()
+      .use(
+        logixlysia<CheckoutFields>({
+          config: {
+            disableFileLogging: true,
+            disableInternalLogger: true,
+            transports: [{ log: transport }]
+          }
+        })
+      )
+      .post('/pay', ({ log }) => {
+        log.mergeContext({ cartId: 'cart_1', userId: 'user_1' })
+        log.info('charged', { itemCount: 3 })
+        return 'ok'
+      })
+
+    await app.handle(new Request('http://localhost/pay', { method: 'POST' }))
+
+    expect(contexts[0]).toMatchObject({
+      cartId: 'cart_1',
+      itemCount: 3,
+      userId: 'user_1'
+    })
+  })
+
+  test('rejects misspelled and undeclared fields at compile time', () => {
+    const app = new Elysia()
+      .use(
+        logixlysia<CheckoutFields>({
+          config: { disableFileLogging: true, disableInternalLogger: true }
+        })
+      )
+      .get('/typos', ({ log }) => {
+        // @ts-expect-error — snake_case variant of a camelCase field
+        log.mergeContext({ user_id: 'user_1' })
+        // @ts-expect-error — field is not part of CheckoutFields
+        log.mergeContext({ unrelated: true })
+        // @ts-expect-error — itemCount is a number
+        log.mergeContext({ itemCount: 'three' })
+        // @ts-expect-error — the same check applies to per-call context
+        log.info('charged', { userid: 'user_1' })
+        return 'ok'
+      })
+
+    expect(app).toBeDefined()
+  })
+
+  test('useLogger carries the same field type', () => {
+    const log = useLogger<CheckoutFields>()
+
+    log.mergeContext({ userId: 'user_1' })
+    // @ts-expect-error — not part of CheckoutFields
+    log.mergeContext({ userId2: 'user_1' })
+
+    expect(typeof log.info).toBe('function')
+  })
+
+  test('untyped usage still accepts any field', async () => {
+    const { contexts, transport } = captureTransport()
+
+    const app = new Elysia()
+      .use(
+        logixlysia({
+          config: {
+            disableFileLogging: true,
+            disableInternalLogger: true,
+            transports: [{ log: transport }]
+          }
+        })
+      )
+      .get('/anything', ({ log }) => {
+        log.mergeContext({ whatever: 1 })
+        log.info('done', { alsoFine: true })
+        return 'ok'
+      })
+
+    await app.handle(new Request('http://localhost/anything'))
+
+    expect(contexts[0]).toMatchObject({ alsoFine: true, whatever: 1 })
+  })
+})

--- a/packages/logixlysia/bunup.config.ts
+++ b/packages/logixlysia/bunup.config.ts
@@ -5,6 +5,7 @@ const config = defineConfig({
   entry: [
     'src/index.ts',
     'src/otel.ts',
+    'src/enrichers.ts',
     'src/ai.ts',
     'src/axiom.ts',
     'src/hyperdx.ts',

--- a/packages/logixlysia/package.json
+++ b/packages/logixlysia/package.json
@@ -29,6 +29,11 @@
       "import": "./dist/otel.js",
       "default": "./dist/otel.js"
     },
+    "./enrichers": {
+      "types": "./dist/enrichers.d.ts",
+      "import": "./dist/enrichers.js",
+      "default": "./dist/enrichers.js"
+    },
     "./ai": {
       "types": "./dist/ai.d.ts",
       "import": "./dist/ai.js",

--- a/packages/logixlysia/src/config/resolve-options.ts
+++ b/packages/logixlysia/src/config/resolve-options.ts
@@ -46,6 +46,8 @@ const isPercentage = (value: unknown): boolean =>
 const isNonNegativeNumber = (value: unknown): boolean =>
   typeof value === 'number' && Number.isFinite(value) && value >= 0
 
+const VALID_SAMPLING_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR'] as const
+
 const validateSampling = (config: Options['config']): void => {
   const sampling = config?.sampling
   if (!sampling) {
@@ -57,6 +59,11 @@ const validateSampling = (config: Options['config']): void => {
   }
 
   for (const [level, rate] of Object.entries(sampling.head ?? {})) {
+    if (!VALID_SAMPLING_LEVELS.includes(level as never)) {
+      invalid(
+        `head.${level} is not a valid level (must be DEBUG, INFO, WARNING, or ERROR)`
+      )
+    }
     if (!isPercentage(rate)) {
       invalid(`head.${level} must be a number between 0 and 100`)
     }
@@ -69,10 +76,15 @@ const validateSampling = (config: Options['config']): void => {
   if (tail?.durationMs !== undefined && !isNonNegativeNumber(tail.durationMs)) {
     invalid('tail.durationMs must be a non-negative number')
   }
-  if (
-    tail?.paths?.some(path => typeof path !== 'string' || path.length === 0)
-  ) {
-    invalid('tail.paths must contain non-empty glob strings')
+  if (tail?.paths !== undefined) {
+    if (!Array.isArray(tail.paths)) {
+      invalid('tail.paths must be an array')
+    }
+    if (
+      tail.paths.some(path => typeof path !== 'string' || path.length === 0)
+    ) {
+      invalid('tail.paths must contain non-empty glob strings')
+    }
   }
 
   const { maxBufferedPerRequest } = sampling

--- a/packages/logixlysia/src/config/resolve-options.ts
+++ b/packages/logixlysia/src/config/resolve-options.ts
@@ -35,6 +35,55 @@ const validateLogRotation = (config: Options['config']): void => {
   }
 }
 
+const MAX_SAMPLING_RATE = 100
+
+const isPercentage = (value: unknown): boolean =>
+  typeof value === 'number' &&
+  Number.isFinite(value) &&
+  value >= 0 &&
+  value <= MAX_SAMPLING_RATE
+
+const isNonNegativeNumber = (value: unknown): boolean =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0
+
+const validateSampling = (config: Options['config']): void => {
+  const sampling = config?.sampling
+  if (!sampling) {
+    return
+  }
+
+  const invalid = (detail: string): never => {
+    throw new Error(`logixlysia: invalid sampling config — ${detail}`)
+  }
+
+  for (const [level, rate] of Object.entries(sampling.head ?? {})) {
+    if (!isPercentage(rate)) {
+      invalid(`head.${level} must be a number between 0 and 100`)
+    }
+  }
+
+  const { tail } = sampling
+  if (tail?.status !== undefined && !isNonNegativeNumber(tail.status)) {
+    invalid('tail.status must be a non-negative number')
+  }
+  if (tail?.durationMs !== undefined && !isNonNegativeNumber(tail.durationMs)) {
+    invalid('tail.durationMs must be a non-negative number')
+  }
+  if (
+    tail?.paths?.some(path => typeof path !== 'string' || path.length === 0)
+  ) {
+    invalid('tail.paths must contain non-empty glob strings')
+  }
+
+  const { maxBufferedPerRequest } = sampling
+  if (
+    maxBufferedPerRequest !== undefined &&
+    !(Number.isInteger(maxBufferedPerRequest) && maxBufferedPerRequest >= 0)
+  ) {
+    invalid('maxBufferedPerRequest must be a non-negative integer')
+  }
+}
+
 const PRESET_DEFAULTS: Record<LogPreset, NonNullable<Options['config']>> = {
   dev: {
     pino: {
@@ -95,6 +144,13 @@ const mergeConfig = (
     }
   }
 
+  if (base.sampling || override.sampling) {
+    merged.sampling = {
+      ...base.sampling,
+      ...override.sampling
+    }
+  }
+
   if (base.logRotation || override.logRotation) {
     merged.logRotation = {
       ...base.logRotation,
@@ -127,5 +183,6 @@ export const resolveOptions = (options: Options = {}): Options => {
     : options
 
   validateLogRotation(resolved.config)
+  validateSampling(resolved.config)
   return resolved
 }

--- a/packages/logixlysia/src/context/enrich.ts
+++ b/packages/logixlysia/src/context/enrich.ts
@@ -1,0 +1,92 @@
+import type {
+  EnricherFields,
+  EnricherLike,
+  EnricherResponseInput,
+  SinkErrorContext
+} from '../interfaces'
+import { createErrorReporter } from '../utils/report'
+import type { RequestContextStore } from './request-context'
+
+const reportEnricherError = createErrorReporter('enricher', 'enricher failed')
+
+type RequestPhase = (request: Request) => EnricherFields
+type ResponsePhase = (input: EnricherResponseInput) => EnricherFields
+
+/** Enricher phases split so each request only walks the hooks that exist. */
+export interface ResolvedEnrichers {
+  request: RequestPhase[]
+  response: ResponsePhase[]
+}
+
+/** Splits configured enrichers by phase, or `undefined` when there are none. */
+export const resolveEnrichers = (
+  enrichers?: EnricherLike[]
+): ResolvedEnrichers | undefined => {
+  if (!enrichers?.length) {
+    return
+  }
+
+  const request: RequestPhase[] = []
+  const response: ResponsePhase[] = []
+
+  for (const enricher of enrichers) {
+    if (typeof enricher === 'function') {
+      request.push(enricher)
+      continue
+    }
+    if (enricher.request) {
+      request.push(enricher.request)
+    }
+    if (enricher.response) {
+      response.push(enricher.response)
+    }
+  }
+
+  return request.length === 0 && response.length === 0
+    ? undefined
+    : { request, response }
+}
+
+/**
+ * Runs one phase and merges what it returns into the request context. A hook
+ * that throws is reported and skipped: enrichment is decoration, and must
+ * never take a request down with it.
+ */
+const runPhase = <TInput>(
+  hooks: ((input: TInput) => EnricherFields)[],
+  input: TInput,
+  contextStore: RequestContextStore,
+  key: Request,
+  onError?: (context: SinkErrorContext) => void
+): void => {
+  for (const hook of hooks) {
+    let fields: EnricherFields
+    try {
+      fields = hook(input)
+    } catch (error) {
+      reportEnricherError(error, onError)
+      continue
+    }
+    if (fields) {
+      contextStore.mergeContext(key, fields)
+    }
+  }
+}
+
+export const applyRequestEnrichers = (
+  enrichers: ResolvedEnrichers,
+  contextStore: RequestContextStore,
+  request: Request,
+  onError?: (context: SinkErrorContext) => void
+): void => {
+  runPhase(enrichers.request, request, contextStore, request, onError)
+}
+
+export const applyResponseEnrichers = (
+  enrichers: ResolvedEnrichers,
+  contextStore: RequestContextStore,
+  input: EnricherResponseInput,
+  onError?: (context: SinkErrorContext) => void
+): void => {
+  runPhase(enrichers.response, input, contextStore, input.request, onError)
+}

--- a/packages/logixlysia/src/context/storage.ts
+++ b/packages/logixlysia/src/context/storage.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import type { RequestScopedLogger } from '../interfaces'
+import type { LogFields, RequestScopedLogger } from '../interfaces'
 
 export const loggerStorage: AsyncLocalStorage<RequestScopedLogger> =
   new AsyncLocalStorage<RequestScopedLogger>()
@@ -12,5 +12,15 @@ const NOOP_LOGGER: RequestScopedLogger = {
   warn: () => undefined
 }
 
-export const useLogger = (): RequestScopedLogger =>
-  loggerStorage.getStore() ?? NOOP_LOGGER
+/**
+ * The current request's logger, or a no-op one outside a request.
+ *
+ * Pass the same field type you gave the plugin to keep context typed away
+ * from the Elysia handler: `useLogger<CheckoutFields>()`.
+ */
+export const useLogger = <
+  TFields extends object = LogFields
+>(): RequestScopedLogger<TFields> =>
+  // The stored logger writes into an untyped context bag; the type parameter
+  // only narrows what callers may hand it.
+  (loggerStorage.getStore() ?? NOOP_LOGGER) as RequestScopedLogger<TFields>

--- a/packages/logixlysia/src/enrichers.ts
+++ b/packages/logixlysia/src/enrichers.ts
@@ -16,11 +16,13 @@ const MAX_TRACESTATE_LENGTH = 512
 
 // version-trace_id-parent_id-flags, with an optional tail for versions > 00.
 const TRACEPARENT =
-  /^([\da-f]{2})-([\da-f]{32})-([\da-f]{16})-([\da-f]{2})(-.+)?$/
+  /^([\da-f]{2})-([\da-f]{32})-([\da-f]{16})-([\da-f]{2})(?:-.+)?$/
 const ZERO_TRACE_ID = '0'.repeat(32)
 const ZERO_SPAN_ID = '0'.repeat(16)
 const INVALID_VERSION = 'ff'
 const CURRENT_VERSION = '00'
+/** `00-` + 32 + `-` + 16 + `-` + 2: version 00 is exactly these four fields. */
+const VERSION_00_LENGTH = 55
 
 export interface TraceparentEnricherOptions {
   /**
@@ -57,27 +59,21 @@ export const traceparentEnricher = (
         return
       }
 
-      const match = TRACEPARENT.exec(raw.trim())
+      const value = raw.trim()
+      const match = TRACEPARENT.exec(value)
       if (!match) {
         return
       }
 
-      const [, version, traceId, spanId, flags, tail] = match as unknown as [
-        string,
-        string,
-        string,
-        string,
-        string,
-        string | undefined
-      ]
+      const [, version, traceId, spanId, flags] = match
 
-      // `ff` is reserved, all-zero ids are invalid, and version 00 is defined
-      // as exactly four fields — a tail means the header is malformed for it.
+      // `ff` is reserved, all-zero ids are invalid, and a version-00 header
+      // carrying extra fields is malformed rather than forward-compatible.
       if (
         version === INVALID_VERSION ||
         traceId === ZERO_TRACE_ID ||
         spanId === ZERO_SPAN_ID ||
-        (version === CURRENT_VERSION && tail !== undefined)
+        (version === CURRENT_VERSION && value.length !== VERSION_00_LENGTH)
       ) {
         return
       }

--- a/packages/logixlysia/src/enrichers.ts
+++ b/packages/logixlysia/src/enrichers.ts
@@ -105,7 +105,7 @@ const ANDROID_MOBILE = /android.*mobile/i
 
 /** First match wins, so more specific engines are listed before their base. */
 const BROWSERS: readonly [name: string, pattern: RegExp][] = [
-  ['Edge', /edga?i?\/([\d.]+)/i],
+  ['Edge', /edg(?:a|ios)?\/([\d.]+)/i],
   ['Opera', /(?:opr|opios|opera)\/([\d.]+)/i],
   ['Samsung Internet', /samsungbrowser\/([\d.]+)/i],
   ['Firefox', /(?:firefox|fxios)\/([\d.]+)/i],
@@ -234,31 +234,36 @@ const readNetlifyGeo = (
     return
   }
 
-  let parsed: NetlifyGeo
+  let parsed: unknown
   try {
-    parsed = JSON.parse(atob(raw)) as NetlifyGeo
+    parsed = JSON.parse(atob(raw))
   } catch {
     return
   }
 
+  if (parsed === null || typeof parsed !== 'object') {
+    return
+  }
+
+  const data = parsed as NetlifyGeo
   const geo: Record<string, unknown> = {}
-  if (parsed.city) {
-    geo.city = parsed.city
+  if (data.city) {
+    geo.city = data.city
   }
-  if (parsed.country?.code) {
-    geo.country = parsed.country.code
+  if (data.country?.code) {
+    geo.country = data.country.code
   }
-  if (parsed.subdivision?.code) {
-    geo.region = parsed.subdivision.code
+  if (data.subdivision?.code) {
+    geo.region = data.subdivision.code
   }
-  if (parsed.timezone) {
-    geo.timezone = parsed.timezone
+  if (data.timezone) {
+    geo.timezone = data.timezone
   }
-  if (typeof parsed.latitude === 'number') {
-    geo.latitude = parsed.latitude
+  if (typeof data.latitude === 'number') {
+    geo.latitude = data.latitude
   }
-  if (typeof parsed.longitude === 'number') {
-    geo.longitude = parsed.longitude
+  if (typeof data.longitude === 'number') {
+    geo.longitude = data.longitude
   }
 
   return Object.keys(geo).length > 0 ? geo : undefined

--- a/packages/logixlysia/src/enrichers.ts
+++ b/packages/logixlysia/src/enrichers.ts
@@ -1,0 +1,345 @@
+import type {
+  Enricher,
+  EnricherFields,
+  EnricherResponseInput
+} from './types/enricher'
+
+export type {
+  Enricher,
+  EnricherFields,
+  EnricherLike,
+  EnricherResponseInput
+} from './types/enricher'
+
+const HEX_RADIX = 16
+const MAX_TRACESTATE_LENGTH = 512
+
+// version-trace_id-parent_id-flags, with an optional tail for versions > 00.
+const TRACEPARENT =
+  /^([\da-f]{2})-([\da-f]{32})-([\da-f]{16})-([\da-f]{2})(-.+)?$/
+const ZERO_TRACE_ID = '0'.repeat(32)
+const ZERO_SPAN_ID = '0'.repeat(16)
+const INVALID_VERSION = 'ff'
+const CURRENT_VERSION = '00'
+
+export interface TraceparentEnricherOptions {
+  /**
+   * Header to read the trace context from.
+   * @default 'traceparent'
+   */
+  header?: string
+  /**
+   * Also record the raw `tracestate` header (truncated to 512 characters).
+   * @default false
+   */
+  tracestate?: boolean
+}
+
+/**
+ * Reads W3C trace context straight off the request headers, so logs link to
+ * traces in Sentry, HyperDX, or any OTLP backend without an OpenTelemetry SDK
+ * in the process.
+ *
+ * Use `logixlysia/otel` instead when you already run the SDK and want the ids
+ * of the *active span* rather than the ids the caller propagated.
+ *
+ * Adds `trace_id`, `span_id`, `trace_flags`, and `trace_sampled`.
+ */
+export const traceparentEnricher = (
+  options: TraceparentEnricherOptions = {}
+): Enricher => {
+  const header = options.header ?? 'traceparent'
+
+  return {
+    request(request) {
+      const raw = request.headers.get(header)
+      if (!raw) {
+        return
+      }
+
+      const match = TRACEPARENT.exec(raw.trim())
+      if (!match) {
+        return
+      }
+
+      const [, version, traceId, spanId, flags, tail] = match as unknown as [
+        string,
+        string,
+        string,
+        string,
+        string,
+        string | undefined
+      ]
+
+      // `ff` is reserved, all-zero ids are invalid, and version 00 is defined
+      // as exactly four fields — a tail means the header is malformed for it.
+      if (
+        version === INVALID_VERSION ||
+        traceId === ZERO_TRACE_ID ||
+        spanId === ZERO_SPAN_ID ||
+        (version === CURRENT_VERSION && tail !== undefined)
+      ) {
+        return
+      }
+
+      const fields: Record<string, unknown> = {
+        span_id: spanId,
+        trace_flags: flags,
+        trace_id: traceId,
+        // `sampled` is the low bit of the flags byte, so an odd value is set.
+        trace_sampled: Number.parseInt(flags, HEX_RADIX) % 2 === 1
+      }
+
+      if (options.tracestate) {
+        const state = request.headers.get('tracestate')
+        if (state) {
+          fields.tracestate = state.slice(0, MAX_TRACESTATE_LENGTH)
+        }
+      }
+
+      return fields
+    }
+  }
+}
+
+const BOT = /bot|crawl|spider|slurp|facebookexternalhit|preview|headless/i
+const TABLET = /ipad|tablet|playbook|silk|kindle/i
+const MOBILE = /mobi|iphone|ipod|windows phone/i
+const ANDROID_MOBILE = /android.*mobile/i
+
+/** First match wins, so more specific engines are listed before their base. */
+const BROWSERS: readonly [name: string, pattern: RegExp][] = [
+  ['Edge', /edga?i?\/([\d.]+)/i],
+  ['Opera', /(?:opr|opios|opera)\/([\d.]+)/i],
+  ['Samsung Internet', /samsungbrowser\/([\d.]+)/i],
+  ['Firefox', /(?:firefox|fxios)\/([\d.]+)/i],
+  ['Chrome', /(?:chrome|crios)\/([\d.]+)/i],
+  ['Safari', /version\/([\d.]+).*safari/i]
+]
+
+const OPERATING_SYSTEMS: readonly [name: string, pattern: RegExp][] = [
+  ['iOS', /iphone|ipad|ipod/i],
+  ['Android', /android/i],
+  ['ChromeOS', /cros/i],
+  ['Windows', /windows nt/i],
+  ['macOS', /mac os x/i],
+  ['Linux', /linux/i]
+]
+
+const matchName = (
+  candidates: readonly [string, RegExp][],
+  value: string
+): { name: string; version?: string } | undefined => {
+  for (const [name, pattern] of candidates) {
+    const match = pattern.exec(value)
+    if (match) {
+      return { name, version: match[1] }
+    }
+  }
+}
+
+const resolveDevice = (value: string, bot: boolean): string => {
+  if (bot) {
+    return 'bot'
+  }
+  if (TABLET.test(value)) {
+    return 'tablet'
+  }
+  if (MOBILE.test(value) || ANDROID_MOBILE.test(value)) {
+    return 'mobile'
+  }
+  return 'desktop'
+}
+
+/**
+ * Turns the `user-agent` header into queryable fields under `ua`: `browser`,
+ * `browserVersion`, `os`, `device` (`desktop` | `mobile` | `tablet` | `bot`),
+ * and `bot`.
+ *
+ * Deliberately a heuristic — user agents are not a parseable grammar. It is
+ * built for grouping traffic in a dashboard, not for making access decisions.
+ */
+export const userAgentEnricher = (): Enricher => ({
+  request(request) {
+    const value = request.headers.get('user-agent')
+    if (!value) {
+      return
+    }
+
+    const bot = BOT.test(value)
+    const browser = matchName(BROWSERS, value)
+    const os = matchName(OPERATING_SYSTEMS, value)
+
+    return {
+      ua: {
+        bot,
+        ...(browser ? { browser: browser.name } : {}),
+        ...(browser?.version ? { browserVersion: browser.version } : {}),
+        device: resolveDevice(value, bot),
+        ...(os ? { os: os.name } : {})
+      }
+    }
+  }
+})
+
+/** Header candidates per geo field, in priority order across platforms. */
+const GEO_HEADERS: readonly [field: string, headers: readonly string[]][] = [
+  ['city', ['x-vercel-ip-city', 'cf-ipcity']],
+  ['country', ['x-vercel-ip-country', 'cf-ipcountry']],
+  ['region', ['x-vercel-ip-country-region', 'cf-region-code', 'cf-region']],
+  ['timezone', ['x-vercel-ip-timezone', 'cf-timezone']]
+]
+
+const GEO_NUMERIC_HEADERS: readonly [
+  field: string,
+  headers: readonly string[]
+][] = [
+  ['latitude', ['x-vercel-ip-latitude', 'cf-iplatitude']],
+  ['longitude', ['x-vercel-ip-longitude', 'cf-iplongitude']]
+]
+
+const NETLIFY_GEO_HEADER = 'x-nf-geo'
+
+const firstHeader = (
+  request: Request,
+  headers: readonly string[]
+): string | undefined => {
+  for (const header of headers) {
+    const value = request.headers.get(header)
+    if (value) {
+      return value
+    }
+  }
+}
+
+/** Vercel percent-encodes city names, so `S%C3%A3o%20Paulo` must be decoded. */
+const decodeHeaderValue = (value: string): string => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+interface NetlifyGeo {
+  city?: string
+  country?: { code?: string }
+  latitude?: number
+  longitude?: number
+  subdivision?: { code?: string }
+  timezone?: string
+}
+
+const readNetlifyGeo = (
+  request: Request
+): Record<string, unknown> | undefined => {
+  const raw = request.headers.get(NETLIFY_GEO_HEADER)
+  if (!raw) {
+    return
+  }
+
+  let parsed: NetlifyGeo
+  try {
+    parsed = JSON.parse(atob(raw)) as NetlifyGeo
+  } catch {
+    return
+  }
+
+  const geo: Record<string, unknown> = {}
+  if (parsed.city) {
+    geo.city = parsed.city
+  }
+  if (parsed.country?.code) {
+    geo.country = parsed.country.code
+  }
+  if (parsed.subdivision?.code) {
+    geo.region = parsed.subdivision.code
+  }
+  if (parsed.timezone) {
+    geo.timezone = parsed.timezone
+  }
+  if (typeof parsed.latitude === 'number') {
+    geo.latitude = parsed.latitude
+  }
+  if (typeof parsed.longitude === 'number') {
+    geo.longitude = parsed.longitude
+  }
+
+  return Object.keys(geo).length > 0 ? geo : undefined
+}
+
+/**
+ * Reads the geo headers the edge already attached — Vercel, Cloudflare, or
+ * Netlify — into `geo.city`, `geo.country`, `geo.region`, `geo.timezone`,
+ * `geo.latitude`, and `geo.longitude`.
+ *
+ * Nothing is derived from the IP address itself, so behind a platform that
+ * does not set these headers the enricher simply adds nothing.
+ */
+export const geoEnricher = (): Enricher => ({
+  request(request) {
+    const geo: Record<string, unknown> = {}
+
+    for (const [field, headers] of GEO_HEADERS) {
+      const value = firstHeader(request, headers)
+      if (value) {
+        geo[field] = decodeHeaderValue(value)
+      }
+    }
+
+    for (const [field, headers] of GEO_NUMERIC_HEADERS) {
+      const value = firstHeader(request, headers)
+      const parsed = value === undefined ? Number.NaN : Number(value)
+      if (Number.isFinite(parsed)) {
+        geo[field] = parsed
+      }
+    }
+
+    if (Object.keys(geo).length > 0) {
+      return { geo }
+    }
+
+    const netlify = readNetlifyGeo(request)
+    return netlify ? { geo: netlify } : undefined
+  }
+})
+
+const readContentLength = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return value
+  }
+  if (typeof value !== 'string' || value.length === 0) {
+    return
+  }
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
+}
+
+const findHeader = (
+  headers: Record<string, unknown>,
+  name: string
+): unknown => {
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === name) {
+      return value
+    }
+  }
+}
+
+/**
+ * Records payload sizes as `requestBytes` and `responseBytes`.
+ *
+ * Both come from `content-length`, which is the only size the plugin can read
+ * without buffering a body. A chunked or streamed response has no
+ * `content-length`, so `responseBytes` is omitted rather than guessed.
+ */
+export const sizeEnricher = (): Enricher => ({
+  request(request): EnricherFields {
+    const bytes = readContentLength(request.headers.get('content-length'))
+    return bytes === undefined ? undefined : { requestBytes: bytes }
+  },
+  response(input: EnricherResponseInput): EnricherFields {
+    const bytes = readContentLength(findHeader(input.headers, 'content-length'))
+    return bytes === undefined ? undefined : { responseBytes: bytes }
+  }
+})

--- a/packages/logixlysia/src/errors.ts
+++ b/packages/logixlysia/src/errors.ts
@@ -49,6 +49,23 @@ export interface HttpErrorInit {
  * response body is the plain message. Only an error that carries at least one
  * client-facing field responds as JSON.
  */
+/**
+ * Statuses the Fetch spec forbids a body on — `Response.json` throws for
+ * these, as it does for anything outside 200-599.
+ */
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304])
+const MIN_RESPONSE_STATUS = 200
+const MAX_RESPONSE_STATUS = 599
+const FALLBACK_RESPONSE_STATUS = 500
+
+/** Falls back to 500 for a status `Response.json` would reject. */
+const responseStatus = (status: number): number =>
+  status >= MIN_RESPONSE_STATUS &&
+  status <= MAX_RESPONSE_STATUS &&
+  !NULL_BODY_STATUSES.has(status)
+    ? status
+    : FALLBACK_RESPONSE_STATUS
+
 export class HttpError extends Error {
   readonly code?: string
   readonly fix?: string
@@ -56,6 +73,12 @@ export class HttpError extends Error {
   declare readonly internal?: unknown
   readonly link?: string
   readonly status: number
+  /**
+   * Present only when the error carries a client-facing field, so a plain
+   * `new HttpError(404, 'Not found')` still renders as the bare message.
+   * Elysia calls it to build the response.
+   */
+  declare readonly toResponse?: () => Response
   readonly why?: string
 
   constructor(status: number, message: string, init: HttpErrorInit = {}) {
@@ -100,18 +123,10 @@ export class HttpError extends Error {
       Object.defineProperty(this, 'toResponse', {
         configurable: true,
         enumerable: false,
-        value: (): Response => {
-          // Use the original status only when it's within 200-599 and permits a body.
-          // Fall back to 500 for invalid statuses (0, 600, etc.) or body-disallowed codes (204, 304, etc.)
-          const safeStatus =
-            this.status >= 200 &&
-            this.status < 600 &&
-            this.status !== 204 &&
-            this.status !== 304
-              ? this.status
-              : 500
-          return Response.json(this.toJSON(), { status: safeStatus })
-        },
+        value: (): Response =>
+          Response.json(this.toJSON(), {
+            status: responseStatus(this.status)
+          }),
         writable: true
       })
     }

--- a/packages/logixlysia/src/errors.ts
+++ b/packages/logixlysia/src/errors.ts
@@ -100,8 +100,18 @@ export class HttpError extends Error {
       Object.defineProperty(this, 'toResponse', {
         configurable: true,
         enumerable: false,
-        value: (): Response =>
-          Response.json(this.toJSON(), { status: this.status }),
+        value: (): Response => {
+          // Use the original status only when it's within 200-599 and permits a body.
+          // Fall back to 500 for invalid statuses (0, 600, etc.) or body-disallowed codes (204, 304, etc.)
+          const safeStatus =
+            this.status >= 200 &&
+            this.status < 600 &&
+            this.status !== 204 &&
+            this.status !== 304
+              ? this.status
+              : 500
+          return Response.json(this.toJSON(), { status: safeStatus })
+        },
         writable: true
       })
     }

--- a/packages/logixlysia/src/errors.ts
+++ b/packages/logixlysia/src/errors.ts
@@ -90,7 +90,13 @@ export class HttpError extends Error {
     // falls back to the plain message otherwise. Defining it only when there
     // is something structured to say keeps plain errors byte-identical to
     // their pre-`HttpErrorInit` behaviour.
-    if (init.code ?? init.why ?? init.fix ?? init.link) {
+    const hasClientFields =
+      init.code !== undefined ||
+      init.why !== undefined ||
+      init.fix !== undefined ||
+      init.link !== undefined
+
+    if (hasClientFields) {
       Object.defineProperty(this, 'toResponse', {
         configurable: true,
         enumerable: false,
@@ -101,15 +107,18 @@ export class HttpError extends Error {
     }
   }
 
-  /** The client-safe payload. `internal` is never part of it. */
+  /**
+   * The client-safe payload. `internal` is never part of it; unset fields are
+   * `undefined` and so are dropped by `JSON.stringify`.
+   */
   toJSON(): HttpErrorPayload {
     return {
-      ...(this.code === undefined ? {} : { code: this.code }),
-      ...(this.fix === undefined ? {} : { fix: this.fix }),
-      ...(this.link === undefined ? {} : { link: this.link }),
+      code: this.code,
+      fix: this.fix,
+      link: this.link,
       message: this.message,
       status: this.status,
-      ...(this.why === undefined ? {} : { why: this.why })
+      why: this.why
     }
   }
 }

--- a/packages/logixlysia/src/errors.ts
+++ b/packages/logixlysia/src/errors.ts
@@ -1,8 +1,115 @@
-export class HttpError extends Error {
-  readonly status: number
+/** The client-safe view of an {@link HttpError} — everything but `internal`. */
+export interface HttpErrorPayload {
+  code?: string
+  fix?: string
+  link?: string
+  message: string
+  status: number
+  why?: string
+}
 
-  constructor(status: number, message: string) {
+export interface HttpErrorInit {
+  /**
+   * Stable, machine-readable identifier the client can branch on, e.g.
+   * `PAYMENT_DECLINED`. Unlike `message`, it is safe to depend on: rewording
+   * the message does not break a caller.
+   */
+  code?: string
+  /** What the caller should do about it, in plain language. */
+  fix?: string
+  /**
+   * Diagnostics for you, not for the caller: a query, an upstream body, an id.
+   * Logged in full, never serialized into the response.
+   */
+  internal?: unknown
+  /** Documentation URL for this failure. */
+  link?: string
+  /** Why the request failed, in plain language. */
+  why?: string
+}
+
+/**
+ * An HTTP error carrying the context that makes a failure actionable.
+ *
+ * `code`, `why`, `fix`, and `link` appear in both the log and the response.
+ * `internal` appears only in the log — it is non-enumerable and excluded from
+ * `toJSON()`, so no serializer can leak it into a response body.
+ *
+ * ```ts
+ * throw new HttpError(402, 'Card declined', {
+ *   code: 'PAYMENT_DECLINED',
+ *   why: 'The issuing bank rejected the charge.',
+ *   fix: 'Try a different card, or contact your bank.',
+ *   link: 'https://docs.example.com/errors/payment-declined',
+ *   internal: { gatewayCode: 'do_not_honor', chargeId }
+ * })
+ * ```
+ *
+ * A bare `new HttpError(404, 'Not found')` behaves exactly as before: the
+ * response body is the plain message. Only an error that carries at least one
+ * client-facing field responds as JSON.
+ */
+export class HttpError extends Error {
+  readonly code?: string
+  readonly fix?: string
+  /** Log-only diagnostics; see the class doc. */
+  declare readonly internal?: unknown
+  readonly link?: string
+  readonly status: number
+  readonly why?: string
+
+  constructor(status: number, message: string, init: HttpErrorInit = {}) {
     super(message)
     this.status = status
+    this.code = init.code
+    this.fix = init.fix
+    this.link = init.link
+    this.why = init.why
+
+    // Set explicitly — a native subclass otherwise reports the generic
+    // "Error", and the constructor-name fallback breaks under minification.
+    // Non-enumerable to match `Error.prototype.name`.
+    Object.defineProperty(this, 'name', {
+      configurable: true,
+      enumerable: false,
+      value: 'HttpError',
+      writable: true
+    })
+
+    // Non-enumerable so `JSON.stringify`, spreads, and framework serializers
+    // that walk own keys cannot pick it up. Property access still works, which
+    // is all the log pipeline needs.
+    Object.defineProperty(this, 'internal', {
+      configurable: true,
+      enumerable: false,
+      value: init.internal,
+      writable: false
+    })
+
+    // Elysia renders a thrown error with `toResponse()` when it has one, and
+    // falls back to the plain message otherwise. Defining it only when there
+    // is something structured to say keeps plain errors byte-identical to
+    // their pre-`HttpErrorInit` behaviour.
+    if (init.code ?? init.why ?? init.fix ?? init.link) {
+      Object.defineProperty(this, 'toResponse', {
+        configurable: true,
+        enumerable: false,
+        value: (): Response =>
+          Response.json(this.toJSON(), { status: this.status }),
+        writable: true
+      })
+    }
+  }
+
+  /** The client-safe payload. `internal` is never part of it. */
+  toJSON(): HttpErrorPayload {
+    return {
+      ...(this.code === undefined ? {} : { code: this.code }),
+      ...(this.fix === undefined ? {} : { fix: this.fix }),
+      ...(this.link === undefined ? {} : { link: this.link }),
+      message: this.message,
+      status: this.status,
+      ...(this.why === undefined ? {} : { why: this.why })
+    }
   }
 }

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -10,6 +10,7 @@ import { loggerStorage } from './context/storage'
 import { startServer } from './extensions'
 import { getStatusCode } from './helpers/status'
 import type {
+  LogFields,
   LogixlysiaStore,
   Options,
   RequestScopedLogger
@@ -34,24 +35,35 @@ export interface EmptyElysiaSlot {
  * Explicit singleton without Elysia's `SingletonBase` `Record<string, unknown>` on decorator/derive/resolve so
  * merged `Context` and WebSocket `ws.data` keep precise keys after `.use(logixlysia())`.
  */
-export interface LogixlysiaSingleton {
+export interface LogixlysiaSingleton<TFields extends object = LogFields> {
   decorator: EmptyElysiaSlot
   derive: {
-    log: RequestScopedLogger
+    log: RequestScopedLogger<TFields>
   }
   resolve: EmptyElysiaSlot
   store: LogixlysiaStore
 }
 
-// Elysia's `SingletonBase.store` is `Record<string, unknown>`; `LogixlysiaStore` is intentionally closed (see #220).
-// @ts-expect-error — closed store is correct at runtime and for merged `ws.data` inference.
-export type Logixlysia = Elysia<'', LogixlysiaSingleton>
+// Elysia's `SingletonBase` slots are `Record<string, unknown>`; ours are intentionally closed (see #220).
+export type Logixlysia<TFields extends object = LogFields> = Elysia<
+  '',
+  // @ts-expect-error — closed slots are correct at runtime and for merged `ws.data` inference.
+  LogixlysiaSingleton<TFields>
+>
 
-export type LogixlysiaPlugin = Logixlysia & {
-  wrapWs: ReturnType<typeof createWsHandlerWrapper>
-}
+export type LogixlysiaPlugin<TFields extends object = LogFields> =
+  Logixlysia<TFields> & {
+    wrapWs: ReturnType<typeof createWsHandlerWrapper>
+  }
 
-const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
+/**
+ * @typeParam TFields - Field bag for the request-scoped `log`. Supply your own
+ * interface to have TypeScript reject misspelled context keys; the default
+ * allows any key, so untyped usage is unchanged.
+ */
+const logixlysia = <TFields extends object = LogFields>(
+  rawOptions: Options = {}
+): LogixlysiaPlugin<TFields> => {
   const options = resolveOptions(rawOptions)
   const didCustomLog = new WeakSet<Request>()
   const requestStartTimes = new WeakMap<Request, bigint>()
@@ -249,9 +261,9 @@ const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
         contextStore.clearContext(request)
       }
     })
-    .as('scoped') as Logixlysia
+    .as('scoped') as Logixlysia<TFields>
 
-  return Object.assign(plugin, { wrapWs }) as LogixlysiaPlugin
+  return Object.assign(plugin, { wrapWs }) as LogixlysiaPlugin<TFields>
 }
 
 // biome-ignore lint/performance/noBarrelFile: public package entry re-exports
@@ -263,6 +275,7 @@ export type {
   EnricherLike,
   EnricherResponseInput,
   HeadSamplingConfig,
+  LogFields,
   Logger,
   LogixlysiaContext,
   LogixlysiaStore,

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -13,7 +13,8 @@ import type {
   LogFields,
   LogixlysiaStore,
   Options,
-  RequestScopedLogger
+  RequestScopedLogger,
+  StoreData
 } from './interfaces'
 import { createPluginLogger } from './logger'
 import { errorStatus } from './logger/handle-http-error'
@@ -21,6 +22,7 @@ import {
   getOrCreateRequestId,
   resolveRequestIdConfig
 } from './middleware/request-id'
+import { elapsedMs } from './utils/duration'
 import { createWsHandlerWrapper } from './websocket/wrap-ws'
 
 /**
@@ -74,10 +76,6 @@ const logixlysia = <TFields extends object = LogFields>(
   const enrichers = resolveEnrichers(options.config?.enrichers)
   const onSinkError = options.config?.onError
 
-  const elapsedMs = (beforeTime: bigint): number =>
-    beforeTime === BigInt(0)
-      ? 0
-      : Number(process.hrtime.bigint() - beforeTime) / 1_000_000
   const logger = {
     ...baseLogger,
     debug: (
@@ -124,6 +122,48 @@ const logixlysia = <TFields extends object = LogFields>(
     warn: (message, context) => logger.warn(request, message, context)
   })
 
+  /**
+   * Everything both exits share once the status is known: echo the request id,
+   * run the response-phase enrichers, and resolve tail sampling — all before
+   * the request's final log line, so it and any replayed records see the same
+   * context. Returns the timing store for that final line.
+   */
+  const closeRequest = (
+    request: Request,
+    setHeaders: Record<string, string | number>,
+    status: number
+  ): StoreData => {
+    if (requestIdConfig) {
+      const id = contextStore.getContext(request).requestId as
+        | string
+        | undefined
+      if (id) {
+        setHeaders[requestIdConfig.header] = id
+      }
+    }
+
+    const store: StoreData = {
+      beforeTime: requestStartTimes.get(request) ?? BigInt(0)
+    }
+
+    if (enrichers) {
+      applyResponseEnrichers(
+        enrichers,
+        contextStore,
+        {
+          durationMs: elapsedMs(store.beforeTime),
+          headers: setHeaders,
+          request,
+          status
+        },
+        onSinkError
+      )
+    }
+
+    logger.finalizeRequest(request, store, status)
+    return store
+  }
+
   const app = new Elysia({
     detail: {
       description:
@@ -166,42 +206,14 @@ const logixlysia = <TFields extends object = LogFields>(
     })
     .onAfterHandle(({ request, set }) => {
       try {
-        if (requestIdConfig) {
-          const ctx = contextStore.getContext(request)
-          const id = ctx.requestId as string | undefined
-          if (id) {
-            set.headers[requestIdConfig.header] = id
-          }
-        }
-
         const status =
           set.status === undefined || set.status === null
             ? 200
             : getStatusCode(set.status)
 
-        const store = {
-          beforeTime: requestStartTimes.get(request) ?? BigInt(0)
-        }
-
-        // Enrich first so replayed records and the access log both see the
-        // response-phase fields.
-        if (enrichers) {
-          applyResponseEnrichers(
-            enrichers,
-            contextStore,
-            {
-              durationMs: elapsedMs(store.beforeTime),
-              headers: set.headers,
-              request,
-              status
-            },
-            onSinkError
-          )
-        }
-
-        // Resolve tail sampling before the early return: a request that only
-        // emitted custom logs still needs its buffered records replayed.
-        logger.finalizeRequest(request, store, status)
+        // Runs before the early return: a request that only emitted custom
+        // logs still needs its buffered records replayed.
+        const store = closeRequest(request, set.headers, status)
 
         if (didCustomLog.has(request)) {
           return
@@ -228,33 +240,7 @@ const logixlysia = <TFields extends object = LogFields>(
     })
     .onError(({ request, error, set }) => {
       try {
-        if (requestIdConfig) {
-          const ctx = contextStore.getContext(request)
-          const id = ctx.requestId as string | undefined
-          if (id) {
-            set.headers[requestIdConfig.header] = id
-          }
-        }
-        const store = {
-          beforeTime: requestStartTimes.get(request) ?? BigInt(0)
-        }
-        const status = errorStatus(error)
-
-        if (enrichers) {
-          applyResponseEnrichers(
-            enrichers,
-            contextStore,
-            {
-              durationMs: elapsedMs(store.beforeTime),
-              headers: set.headers,
-              request,
-              status
-            },
-            onSinkError
-          )
-        }
-
-        logger.finalizeRequest(request, store, status)
+        const store = closeRequest(request, set.headers, errorStatus(error))
         logger.handleHttpError(request, error, store)
       } finally {
         requestStartTimes.delete(request)

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -1,5 +1,10 @@
 import { Elysia } from 'elysia'
 import { resolveOptions } from './config/resolve-options'
+import {
+  applyRequestEnrichers,
+  applyResponseEnrichers,
+  resolveEnrichers
+} from './context/enrich'
 import { createRequestContextStore } from './context/request-context'
 import { loggerStorage } from './context/storage'
 import { startServer } from './extensions'
@@ -54,6 +59,13 @@ const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
   const baseLogger = createPluginLogger(options, contextStore)
   const wrapWs = createWsHandlerWrapper(options, baseLogger, contextStore)
   const requestIdConfig = resolveRequestIdConfig(options.config?.requestId)
+  const enrichers = resolveEnrichers(options.config?.enrichers)
+  const onSinkError = options.config?.onError
+
+  const elapsedMs = (beforeTime: bigint): number =>
+    beforeTime === BigInt(0)
+      ? 0
+      : Number(process.hrtime.bigint() - beforeTime) / 1_000_000
   const logger = {
     ...baseLogger,
     debug: (
@@ -132,6 +144,10 @@ const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
         contextStore.mergeContext(request, { requestId })
       }
 
+      if (enrichers) {
+        applyRequestEnrichers(enrichers, contextStore, request, onSinkError)
+      }
+
       if (options.config?.useAsyncLocalStorage) {
         loggerStorage.enterWith(createRequestScopedLogger(request))
       }
@@ -151,11 +167,28 @@ const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
             ? 200
             : getStatusCode(set.status)
 
-        // Resolve tail sampling before the early return: a request that only
-        // emitted custom logs still needs its buffered records replayed.
         const store = {
           beforeTime: requestStartTimes.get(request) ?? BigInt(0)
         }
+
+        // Enrich first so replayed records and the access log both see the
+        // response-phase fields.
+        if (enrichers) {
+          applyResponseEnrichers(
+            enrichers,
+            contextStore,
+            {
+              durationMs: elapsedMs(store.beforeTime),
+              headers: set.headers,
+              request,
+              status
+            },
+            onSinkError
+          )
+        }
+
+        // Resolve tail sampling before the early return: a request that only
+        // emitted custom logs still needs its buffered records replayed.
         logger.finalizeRequest(request, store, status)
 
         if (didCustomLog.has(request)) {
@@ -193,7 +226,23 @@ const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
         const store = {
           beforeTime: requestStartTimes.get(request) ?? BigInt(0)
         }
-        logger.finalizeRequest(request, store, errorStatus(error))
+        const status = errorStatus(error)
+
+        if (enrichers) {
+          applyResponseEnrichers(
+            enrichers,
+            contextStore,
+            {
+              durationMs: elapsedMs(store.beforeTime),
+              headers: set.headers,
+              request,
+              status
+            },
+            onSinkError
+          )
+        }
+
+        logger.finalizeRequest(request, store, status)
         logger.handleHttpError(request, error, store)
       } finally {
         requestStartTimes.delete(request)
@@ -209,6 +258,10 @@ const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
 export { resolveOptions } from './config/resolve-options'
 export { useLogger } from './context/storage'
 export type {
+  Enricher,
+  EnricherFields,
+  EnricherLike,
+  EnricherResponseInput,
   HeadSamplingConfig,
   Logger,
   LogixlysiaContext,

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -123,15 +123,36 @@ const logixlysia = <TFields extends object = LogFields>(
   })
 
   /**
+   * The response headers an enricher gets to read. `set.headers` alone misses
+   * anything a handler put on a returned `Response` (a `content-length`, say),
+   * so the two are merged — with `set.headers` winning, since Elysia applies
+   * it last. Only built when an enricher will actually read it.
+   */
+  const readableResponseHeaders = (
+    setHeaders: Record<string, string | number>,
+    responseHeaders?: Headers
+  ): Record<string, unknown> => {
+    const merged: Record<string, unknown> = {}
+    responseHeaders?.forEach((value, key) => {
+      merged[key] = value
+    })
+    return Object.assign(merged, setHeaders)
+  }
+
+  /**
    * Everything both exits share once the status is known: echo the request id,
    * run the response-phase enrichers, and resolve tail sampling — all before
    * the request's final log line, so it and any replayed records see the same
    * context. Returns the timing store for that final line.
+   *
+   * `setHeaders` is the live `set.headers` and is written to; the merged view
+   * handed to enrichers is read-only, so it must not stand in for it.
    */
   const closeRequest = (
     request: Request,
     setHeaders: Record<string, string | number>,
-    status: number
+    status: number,
+    responseHeaders?: Headers
   ): StoreData => {
     if (requestIdConfig) {
       const id = contextStore.getContext(request).requestId as
@@ -152,7 +173,7 @@ const logixlysia = <TFields extends object = LogFields>(
         contextStore,
         {
           durationMs: elapsedMs(store.beforeTime),
-          headers: setHeaders,
+          headers: readableResponseHeaders(setHeaders, responseHeaders),
           request,
           status
         },
@@ -211,19 +232,14 @@ const logixlysia = <TFields extends object = LogFields>(
             ? 200
             : getStatusCode(set.status)
 
-        // Merge response headers with set.headers, with set.headers taking precedence.
-        // This ensures enrichers see headers from Response objects and Elysia's set.headers.
-        const mergedHeaders: Record<string, unknown> = {}
-        if (response instanceof Response) {
-          response.headers.forEach((value, key) => {
-            mergedHeaders[key] = value
-          })
-        }
-        Object.assign(mergedHeaders, set.headers)
-
         // Runs before the early return: a request that only emitted custom
         // logs still needs its buffered records replayed.
-        const store = closeRequest(request, mergedHeaders, status)
+        const store = closeRequest(
+          request,
+          set.headers,
+          status,
+          response instanceof Response ? response.headers : undefined
+        )
 
         if (didCustomLog.has(request)) {
           return

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -10,6 +10,7 @@ import type {
   RequestScopedLogger
 } from './interfaces'
 import { createPluginLogger } from './logger'
+import { errorStatus } from './logger/handle-http-error'
 import {
   getOrCreateRequestId,
   resolveRequestIdConfig
@@ -125,6 +126,7 @@ const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
     })
     .onRequest(({ request }) => {
       requestStartTimes.set(request, process.hrtime.bigint())
+      logger.beginRequest(request)
       if (requestIdConfig) {
         const requestId = getOrCreateRequestId(request, requestIdConfig)
         contextStore.mergeContext(request, { requestId })
@@ -144,14 +146,22 @@ const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
           }
         }
 
-        if (didCustomLog.has(request)) {
-          return
-        }
-
         const status =
           set.status === undefined || set.status === null
             ? 200
             : getStatusCode(set.status)
+
+        // Resolve tail sampling before the early return: a request that only
+        // emitted custom logs still needs its buffered records replayed.
+        const store = {
+          beforeTime: requestStartTimes.get(request) ?? BigInt(0)
+        }
+        logger.finalizeRequest(request, store, status)
+
+        if (didCustomLog.has(request)) {
+          return
+        }
+
         let level: 'INFO' | 'WARNING' | 'ERROR' = 'INFO'
         if (status >= 500) {
           level = 'ERROR'
@@ -165,9 +175,7 @@ const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
           data.context = { ...accumulated }
         }
 
-        logger.log(level, request, data, {
-          beforeTime: requestStartTimes.get(request) ?? BigInt(0)
-        })
+        logger.log(level, request, data, store)
       } finally {
         requestStartTimes.delete(request)
         contextStore.clearContext(request)
@@ -182,9 +190,11 @@ const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
             set.headers[requestIdConfig.header] = id
           }
         }
-        logger.handleHttpError(request, error, {
+        const store = {
           beforeTime: requestStartTimes.get(request) ?? BigInt(0)
-        })
+        }
+        logger.finalizeRequest(request, store, errorStatus(error))
+        logger.handleHttpError(request, error, store)
       } finally {
         requestStartTimes.delete(request)
         contextStore.clearContext(request)
@@ -199,6 +209,7 @@ const logixlysia = (rawOptions: Options = {}): LogixlysiaPlugin => {
 export { resolveOptions } from './config/resolve-options'
 export { useLogger } from './context/storage'
 export type {
+  HeadSamplingConfig,
   Logger,
   LogixlysiaContext,
   LogixlysiaStore,
@@ -208,7 +219,9 @@ export type {
   Pino,
   RequestIdConfig,
   RequestScopedLogger,
+  SamplingConfig,
   StoreData,
+  TailSamplingConfig,
   Transport
 } from './interfaces'
 export { createLogger, createPluginLogger } from './logger'
@@ -217,6 +230,12 @@ export {
   getOrCreateRequestId,
   resolveRequestIdConfig
 } from './middleware/request-id'
+export type {
+  RequestOutcome,
+  SamplingDecision,
+  SamplingRuntime
+} from './sampling'
+export { resolveSampling } from './sampling'
 export type { WsHandlerHooks } from './websocket/wrap-ws'
 export { createWsHandlerWrapper } from './websocket/wrap-ws'
 

--- a/packages/logixlysia/src/index.ts
+++ b/packages/logixlysia/src/index.ts
@@ -204,16 +204,26 @@ const logixlysia = <TFields extends object = LogFields>(
         loggerStorage.enterWith(createRequestScopedLogger(request))
       }
     })
-    .onAfterHandle(({ request, set }) => {
+    .onAfterHandle(({ request, set, response }) => {
       try {
         const status =
           set.status === undefined || set.status === null
             ? 200
             : getStatusCode(set.status)
 
+        // Merge response headers with set.headers, with set.headers taking precedence.
+        // This ensures enrichers see headers from Response objects and Elysia's set.headers.
+        const mergedHeaders: Record<string, unknown> = {}
+        if (response instanceof Response) {
+          response.headers.forEach((value, key) => {
+            mergedHeaders[key] = value
+          })
+        }
+        Object.assign(mergedHeaders, set.headers)
+
         // Runs before the early return: a request that only emitted custom
         // logs still needs its buffered records replayed.
-        const store = closeRequest(request, set.headers, status)
+        const store = closeRequest(request, mergedHeaders, status)
 
         if (didCustomLog.has(request)) {
           return

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -2,6 +2,7 @@
 export { HttpError } from './errors'
 export type {
   FormattingConfig,
+  HeadSamplingConfig,
   LogFilter,
   LogixlysiaConfig,
   LogPreset,
@@ -13,7 +14,9 @@ export type {
   RedactionConfig,
   RequestIdConfig,
   RequestTrackingConfig,
+  SamplingConfig,
   SinkErrorContext,
+  TailSamplingConfig,
   Transport
 } from './types/config'
 export type {

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -27,4 +27,10 @@ export type {
   RequestInfo,
   StoreData
 } from './types/core'
+export type {
+  Enricher,
+  EnricherFields,
+  EnricherLike,
+  EnricherResponseInput
+} from './types/enricher'
 export type { Logger, RequestScopedLogger } from './types/logger'

--- a/packages/logixlysia/src/interfaces.ts
+++ b/packages/logixlysia/src/interfaces.ts
@@ -33,4 +33,4 @@ export type {
   EnricherLike,
   EnricherResponseInput
 } from './types/enricher'
-export type { Logger, RequestScopedLogger } from './types/logger'
+export type { LogFields, Logger, RequestScopedLogger } from './types/logger'

--- a/packages/logixlysia/src/logger/create-logger.ts
+++ b/packages/logixlysia/src/logger/create-logger.ts
@@ -2,6 +2,7 @@ import { STATUS_CODES } from 'node:http'
 import chalk from 'chalk'
 import { getStatusCode } from '../helpers/status'
 import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
+import { elapsedMs } from '../utils/duration'
 import { isStructuredError, parseError } from '../utils/error'
 import { sanitizeLogText } from '../utils/sanitize'
 
@@ -576,11 +577,7 @@ const getDurationTokens = (
   if (!(needsDuration || needsSpeed)) {
     return { coloredDuration: '', speedToken: '' }
   }
-  const durationMs =
-    precomputed?.durationMs ??
-    (store.beforeTime === BigInt(0)
-      ? 0
-      : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000)
+  const durationMs = precomputed?.durationMs ?? elapsedMs(store.beforeTime)
   const { text, isVerySlow } = colorDurationText(
     durationMs,
     useColors,

--- a/packages/logixlysia/src/logger/create-logger.ts
+++ b/packages/logixlysia/src/logger/create-logger.ts
@@ -373,6 +373,9 @@ const collectStructuredErrorEntries = (error: unknown): [string, string][] => {
     entries.push(['error', msg])
   }
   if (isStructuredError(error)) {
+    if (error.code !== undefined) {
+      entries.push(['error.code', String(error.code)])
+    }
     if (error.why !== undefined) {
       entries.push(['error.why', String(error.why)])
     }
@@ -416,7 +419,9 @@ export const buildContextTreeLines = (
     )
   }
 
-  if (level === 'ERROR' && 'error' in data && data.error !== undefined) {
+  // WARNING as well as ERROR: a 4xx is logged at WARNING, and its
+  // `why`/`fix`/`link` are exactly as worth showing as a 5xx's.
+  if ((level === 'ERROR' || level === 'WARNING') && data.error !== undefined) {
     entries.push(...collectStructuredErrorEntries(data.error))
   }
 

--- a/packages/logixlysia/src/logger/emit.ts
+++ b/packages/logixlysia/src/logger/emit.ts
@@ -12,6 +12,7 @@ import type {
 import { logToTransports } from '../output'
 import { logToFile } from '../output/file'
 import type { SamplingRuntime } from '../sampling'
+import { elapsedMs } from '../utils/duration'
 import { redact, redactRequest } from '../utils/redact'
 import {
   type FormatContext,
@@ -66,11 +67,6 @@ export const shouldLog = (level: LogLevel, logFilter?: LogFilter): boolean => {
   return logFilter.level.includes(level)
 }
 
-const computeDurationMs = (store: StoreData): number =>
-  store.beforeTime === BigInt(0)
-    ? 0
-    : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000
-
 /** Parses the URL once; only called when at least one active sink reads pathname/search. */
 export const parseRequestUrlOnce = (
   request: RequestInfo
@@ -95,7 +91,7 @@ export const computePrecomputedLogParts = (
   needsUrlParts: boolean,
   durationOverride?: number
 ): PrecomputedLogParts => {
-  const durationMs = durationOverride ?? computeDurationMs(store)
+  const durationMs = durationOverride ?? elapsedMs(store.beforeTime)
   const { pathname, search } = needsUrlParts
     ? parseRequestUrlOnce(request)
     : { pathname: '', search: '' }
@@ -177,7 +173,7 @@ export const emit = ({
       // replay, so a request that never gets rescued pays almost nothing.
       sampling.buffer(request, {
         data,
-        durationMs: computeDurationMs(store),
+        durationMs: elapsedMs(store.beforeTime),
         level
       })
       return

--- a/packages/logixlysia/src/logger/emit.ts
+++ b/packages/logixlysia/src/logger/emit.ts
@@ -11,6 +11,7 @@ import type {
 } from '../interfaces'
 import { logToTransports } from '../output'
 import { logToFile } from '../output/file'
+import type { SamplingRuntime } from '../sampling'
 import { redact, redactRequest } from '../utils/redact'
 import {
   type FormatContext,
@@ -71,7 +72,7 @@ const computeDurationMs = (store: StoreData): number =>
     : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000
 
 /** Parses the URL once; only called when at least one active sink reads pathname/search. */
-const parseRequestUrlOnce = (
+export const parseRequestUrlOnce = (
   request: RequestInfo
 ): { pathname: string; search: string } => {
   try {
@@ -91,9 +92,10 @@ const parseRequestUrlOnce = (
 export const computePrecomputedLogParts = (
   store: StoreData,
   request: RequestInfo,
-  needsUrlParts: boolean
+  needsUrlParts: boolean,
+  durationOverride?: number
 ): PrecomputedLogParts => {
-  const durationMs = computeDurationMs(store)
+  const durationMs = durationOverride ?? computeDurationMs(store)
   const { pathname, search } = needsUrlParts
     ? parseRequestUrlOnce(request)
     : { pathname: '', search: '' }
@@ -122,14 +124,20 @@ const consoleForLevel = (level: LogLevel): typeof console.log => {
 }
 
 export interface EmitInput {
+  /** Skips the sampling gate; set when replaying a tail-rescued record. */
+  bypassSampling?: boolean
   /** Shared per-request context bag (peeked, never cloned/retained). */
   contextStore: RequestContextStore
   data: Record<string, unknown>
+  /** Duration captured when a record was buffered, replacing the live sample. */
+  durationOverride?: number
   /** Hoisted per-logger constants for `formatLogOutput`; only read when the internal console logger is active. */
   formatContext: FormatContext
   level: LogLevel
   options: Options
   request: RequestInfo
+  /** Hoisted per-logger sampling runtime; undefined when sampling is off. */
+  sampling?: SamplingRuntime
   /** Hoisted per-logger sink gates from {@link resolveSinks}. */
   sinks: Sinks
   store: StoreData
@@ -141,12 +149,15 @@ export interface EmitInput {
  * redact -> transports -> file -> console, all gated by the same `sinks`.
  */
 export const emit = ({
+  bypassSampling,
   contextStore,
   data,
+  durationOverride,
   formatContext,
   level,
   options,
   request,
+  sampling,
   sinks,
   store
 }: EmitInput): void => {
@@ -154,6 +165,23 @@ export const emit = ({
 
   if (sinks.isEffectivelyDisabled || !shouldLog(level, config?.logFilter)) {
     return
+  }
+
+  if (sampling && !bypassSampling) {
+    const decision = sampling.decide(level, request)
+    if (decision === 'drop') {
+      return
+    }
+    if (decision === 'buffer') {
+      // Buffered raw: context merge, redaction and formatting are deferred to
+      // replay, so a request that never gets rescued pays almost nothing.
+      sampling.buffer(request, {
+        data,
+        durationMs: computeDurationMs(store),
+        level
+      })
+      return
+    }
   }
 
   const dataWithContext = mergeLogDataContext(
@@ -174,7 +202,8 @@ export const emit = ({
   const precomputed = computePrecomputedLogParts(
     store,
     logRequest,
-    sinks.needsUrlParts
+    sinks.needsUrlParts,
+    durationOverride
   )
 
   if (sinks.hasTransports) {

--- a/packages/logixlysia/src/logger/handle-http-error.ts
+++ b/packages/logixlysia/src/logger/handle-http-error.ts
@@ -1,5 +1,6 @@
 import type { RequestContextStore } from '../context/request-context'
 import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
+import type { SamplingRuntime } from '../sampling'
 import { normalizeLoggedError } from '../utils/error'
 import type { FormatContext } from './create-logger'
 import { emit, type Sinks, shouldLog } from './emit'
@@ -12,6 +13,10 @@ const isErrorWithStatus = (
   'status' in value &&
   typeof (value as { status?: unknown }).status === 'number'
 
+/** The status a thrown value maps to; anything without one is a 500. */
+export const errorStatus = (error: unknown): number =>
+  isErrorWithStatus(error) ? error.status : 500
+
 export const handleHttpError = (
   request: RequestInfo,
   error: unknown,
@@ -19,11 +24,12 @@ export const handleHttpError = (
   options: Options,
   contextStore: RequestContextStore,
   sinks: Sinks,
-  formatContext: FormatContext
+  formatContext: FormatContext,
+  sampling?: SamplingRuntime
 ): void => {
   const { config } = options
 
-  const status = isErrorWithStatus(error) ? error.status : 500
+  const status = errorStatus(error)
   const level: LogLevel = status >= 400 && status < 500 ? 'WARNING' : 'ERROR'
 
   // Mirrors emit()'s own gate check, but performed *before* normalizing the
@@ -48,6 +54,7 @@ export const handleHttpError = (
     level,
     options,
     request,
+    sampling,
     sinks,
     store
   })

--- a/packages/logixlysia/src/logger/index.ts
+++ b/packages/logixlysia/src/logger/index.ts
@@ -12,10 +12,13 @@ import type {
   RequestInfo,
   StoreData
 } from '../interfaces'
+import { type BufferedRecord, resolveSampling } from '../sampling'
 import { buildPinoRedactPaths } from '../utils/redact'
 import { createFormatContext } from './create-logger'
-import { emit, resolveSinks, shouldLog } from './emit'
+import { emit, parseRequestUrlOnce, resolveSinks, shouldLog } from './emit'
 import { handleHttpError } from './handle-http-error'
+
+const ZERO_STORE: StoreData = { beforeTime: BigInt(0) }
 
 export const createLogger = (
   options: Options = {},
@@ -112,6 +115,7 @@ export const createLogger = (
 
   // Resolved once per logger instance: none of these depend on per-request state.
   const sinks = resolveSinks(config)
+  const sampling = resolveSampling(config?.sampling)
 
   const log = (
     level: LogLevel,
@@ -126,9 +130,51 @@ export const createLogger = (
       level,
       options,
       request,
+      sampling,
       sinks,
       store
     })
+  }
+
+  /** Re-emits tail-rescued records with the duration each had when captured. */
+  const replay = (
+    request: RequestInfo,
+    records: readonly BufferedRecord[]
+  ): void => {
+    for (const record of records) {
+      emit({
+        bypassSampling: true,
+        contextStore,
+        data: record.data,
+        durationOverride: record.durationMs,
+        formatContext,
+        level: record.level,
+        options,
+        request,
+        sampling,
+        sinks,
+        store: ZERO_STORE
+      })
+    }
+  }
+
+  const finalizeRequest = (
+    request: RequestInfo,
+    store: StoreData,
+    status: number
+  ): void => {
+    if (!sampling) {
+      return
+    }
+    const durationMs =
+      store.beforeTime === BigInt(0)
+        ? 0
+        : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000
+    const { pathname } = parseRequestUrlOnce(request)
+    const records = sampling.finalize(request, { durationMs, pathname, status })
+    if (records.length > 0) {
+      replay(request, records)
+    }
   }
 
   const logWithContext = (
@@ -145,12 +191,16 @@ export const createLogger = (
   }
 
   return {
+    beginRequest: request => {
+      sampling?.begin(request)
+    },
     debug: (request, message, context) => {
       logWithContext('DEBUG', request, message, context)
     },
     error: (request, message, context) => {
       logWithContext('ERROR', request, message, context)
     },
+    finalizeRequest,
     getContext: request => contextStore.getContext(request),
     handleHttpError: (request, error, store) => {
       handleHttpError(
@@ -160,7 +210,8 @@ export const createLogger = (
         options,
         contextStore,
         sinks,
-        formatContext
+        formatContext,
+        sampling
       )
     },
     info: (request, message, context) => {

--- a/packages/logixlysia/src/logger/index.ts
+++ b/packages/logixlysia/src/logger/index.ts
@@ -12,7 +12,8 @@ import type {
   RequestInfo,
   StoreData
 } from '../interfaces'
-import { type BufferedRecord, resolveSampling } from '../sampling'
+import { resolveSampling } from '../sampling'
+import { elapsedMs } from '../utils/duration'
 import { buildPinoRedactPaths } from '../utils/redact'
 import { createFormatContext } from './create-logger'
 import { emit, parseRequestUrlOnce, resolveSinks, shouldLog } from './emit'
@@ -136,12 +137,23 @@ export const createLogger = (
     })
   }
 
-  /** Re-emits tail-rescued records with the duration each had when captured. */
-  const replay = (
+  /** Resolves the tail verdict and re-emits whatever it rescued. */
+  const finalizeRequest = (
     request: RequestInfo,
-    records: readonly BufferedRecord[]
+    store: StoreData,
+    status: number
   ): void => {
-    for (const record of records) {
+    if (!sampling) {
+      return
+    }
+
+    const outcome = {
+      durationMs: elapsedMs(store.beforeTime),
+      pathname: parseRequestUrlOnce(request).pathname,
+      status
+    }
+
+    for (const record of sampling.finalize(request, outcome)) {
       emit({
         bypassSampling: true,
         contextStore,
@@ -153,27 +165,10 @@ export const createLogger = (
         request,
         sampling,
         sinks,
+        // Unread on this path: `durationOverride` supplies the duration each
+        // record had when it was captured.
         store: ZERO_STORE
       })
-    }
-  }
-
-  const finalizeRequest = (
-    request: RequestInfo,
-    store: StoreData,
-    status: number
-  ): void => {
-    if (!sampling) {
-      return
-    }
-    const durationMs =
-      store.beforeTime === BigInt(0)
-        ? 0
-        : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000
-    const { pathname } = parseRequestUrlOnce(request)
-    const records = sampling.finalize(request, { durationMs, pathname, status })
-    if (records.length > 0) {
-      replay(request, records)
     }
   }
 

--- a/packages/logixlysia/src/output/file.ts
+++ b/packages/logixlysia/src/output/file.ts
@@ -5,6 +5,7 @@ import type {
   SinkErrorContext,
   StoreData
 } from '../interfaces'
+import { elapsedMs } from '../utils/duration'
 import { sanitizeLogText } from '../utils/sanitize'
 import { getFileSink } from './file-sink'
 
@@ -68,11 +69,7 @@ export const logToFile = async (input: LogToFileInput): Promise<void> => {
   }
 
   const message = typeof data.message === 'string' ? data.message : ''
-  const durationMs =
-    precomputed?.durationMs ??
-    (store.beforeTime === BigInt(0)
-      ? 0
-      : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000)
+  const durationMs = precomputed?.durationMs ?? elapsedMs(store.beforeTime)
 
   const pathname = resolvePathname(request, config?.logQueryParams, precomputed)
   const line = `${level} ${durationMs.toFixed(2)}ms ${request.method} ${sanitizeLogText(pathname, 1024)} ${sanitizeLogText(message)}\n`

--- a/packages/logixlysia/src/output/index.ts
+++ b/packages/logixlysia/src/output/index.ts
@@ -1,4 +1,5 @@
 import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
+import { elapsedMs } from '../utils/duration'
 import { createErrorReporter } from '../utils/report'
 
 const reportTransportError = createErrorReporter(
@@ -31,11 +32,7 @@ export const logToTransports = (input: LogToTransportsInput): void => {
       url: request.url
     },
     ...data,
-    durationMs:
-      precomputed?.durationMs ??
-      (store.beforeTime === BigInt(0)
-        ? 0
-        : Number(process.hrtime.bigint() - store.beforeTime) / 1_000_000)
+    durationMs: precomputed?.durationMs ?? elapsedMs(store.beforeTime)
   }
 
   for (const transport of transports) {

--- a/packages/logixlysia/src/output/index.ts
+++ b/packages/logixlysia/src/output/index.ts
@@ -1,33 +1,10 @@
-import type {
-  LogLevel,
-  Options,
-  RequestInfo,
-  SinkErrorContext,
-  StoreData
-} from '../interfaces'
+import type { LogLevel, Options, RequestInfo, StoreData } from '../interfaces'
+import { createErrorReporter } from '../utils/report'
 
-let lastTransportErrorAt = 0
-const TRANSPORT_ERROR_INTERVAL_MS = 5000
-
-const reportTransportError = (
-  error: unknown,
-  onError?: (context: SinkErrorContext) => void
-): void => {
-  if (onError) {
-    try {
-      onError({ error, sink: 'transport' })
-    } catch {
-      // Swallow errors thrown by the hook itself.
-    }
-    return
-  }
-  const now = Date.now()
-  if (now - lastTransportErrorAt < TRANSPORT_ERROR_INTERVAL_MS) {
-    return
-  }
-  lastTransportErrorAt = now
-  console.error('[logixlysia] transport failed:', error)
-}
+const reportTransportError = createErrorReporter(
+  'transport',
+  'transport failed'
+)
 
 interface LogToTransportsInput {
   data: Record<string, unknown>

--- a/packages/logixlysia/src/sampling/glob.ts
+++ b/packages/logixlysia/src/sampling/glob.ts
@@ -1,7 +1,35 @@
 const REGEXP_SPECIALS = /[.*+?^${}()|[\]\\]/g
+const REPEATED_RECURSIVE_PATTERN = /\*\*.*\*\*/
+const RECURSIVE_WILDCARD_SPLIT = /\*\*/
+const ALPHANUMERIC_PATTERN = /[a-zA-Z0-9]/
 
 const escapeRegExp = (value: string): string =>
   value.replace(REGEXP_SPECIALS, '\\$&')
+
+/**
+ * Detects if a pattern contains repeated recursive wildcards that could cause ReDoS.
+ * Patterns with adjacent or nearly-adjacent `**` wildcards can lead to catastrophic backtracking.
+ */
+const hasRepeatedRecursiveWildcards = (pattern: string): boolean => {
+  if (!REPEATED_RECURSIVE_PATTERN.test(pattern)) {
+    return false
+  }
+
+  const segments = pattern.split(RECURSIVE_WILDCARD_SPLIT)
+  // If we have multiple ** with only short literal separators between them, reject it
+  for (let i = 1; i < segments.length; i += 1) {
+    const separator = segments[i]
+    // Allow ** followed by reasonable literal paths, but reject adjacent or nearly-adjacent **
+    if (
+      separator === '' ||
+      (separator.length < 2 && !ALPHANUMERIC_PATTERN.test(separator))
+    ) {
+      return true
+    }
+  }
+
+  return false
+}
 
 /**
  * Compiles a path glob into an anchored `RegExp`.
@@ -13,6 +41,13 @@ const escapeRegExp = (value: string): string =>
  * Everything else is matched literally, so `/v1/users` only matches itself.
  */
 export const globToRegExp = (pattern: string): RegExp => {
+  // Detect repeated recursive wildcards that could cause catastrophic backtracking.
+  if (hasRepeatedRecursiveWildcards(pattern)) {
+    throw new Error(
+      'Invalid glob pattern: repeated recursive wildcards (**) can cause performance issues'
+    )
+  }
+
   let source = ''
   let index = 0
 

--- a/packages/logixlysia/src/sampling/glob.ts
+++ b/packages/logixlysia/src/sampling/glob.ts
@@ -1,0 +1,40 @@
+const REGEXP_SPECIALS = /[.*+?^${}()|[\]\\]/g
+
+const escapeRegExp = (value: string): string =>
+  value.replace(REGEXP_SPECIALS, '\\$&')
+
+/**
+ * Compiles a path glob into an anchored `RegExp`.
+ *
+ * - `**` matches any characters, including `/`
+ * - `*` matches any characters except `/`
+ * - `?` matches a single character except `/`
+ *
+ * Everything else is matched literally, so `/v1/users` only matches itself.
+ */
+export const globToRegExp = (pattern: string): RegExp => {
+  let source = ''
+  let index = 0
+
+  while (index < pattern.length) {
+    const char = pattern[index]
+
+    if (char === '*') {
+      const crossesSegments = pattern[index + 1] === '*'
+      source += crossesSegments ? '.*' : '[^/]*'
+      index += crossesSegments ? 2 : 1
+      continue
+    }
+
+    if (char === '?') {
+      source += '[^/]'
+      index += 1
+      continue
+    }
+
+    source += escapeRegExp(char)
+    index += 1
+  }
+
+  return new RegExp(`^${source}$`)
+}

--- a/packages/logixlysia/src/sampling/index.ts
+++ b/packages/logixlysia/src/sampling/index.ts
@@ -1,0 +1,186 @@
+import type {
+  LogLevel,
+  SamplingConfig,
+  TailSamplingConfig
+} from '../interfaces'
+import { globToRegExp } from './glob'
+
+const FULL_RATE = 100
+const DEFAULT_MAX_BUFFERED_PER_REQUEST = 100
+
+const NO_RECORDS: readonly BufferedRecord[] = Object.freeze([])
+
+/**
+ * What head sampling decided for a single record:
+ *
+ * - `keep` — emit now
+ * - `buffer` — hold it until the request's tail verdict is known
+ * - `drop` — discard it; no tail rule can bring it back
+ */
+export type SamplingDecision = 'buffer' | 'drop' | 'keep'
+
+/** A head-dropped record held until its request's tail verdict is known. */
+export interface BufferedRecord {
+  data: Record<string, unknown>
+  /** Elapsed time at capture, so a replayed record keeps its original duration. */
+  durationMs: number
+  level: LogLevel
+}
+
+/** How a request finished, matched against {@link TailSamplingConfig}. */
+export interface RequestOutcome {
+  durationMs: number
+  pathname: string
+  status: number
+}
+
+export interface SamplingRuntime {
+  /** Marks a request as one that will reach {@link SamplingRuntime.finalize}. */
+  begin: (key: object) => void
+  /** Holds a head-dropped record, up to `maxBufferedPerRequest`. */
+  buffer: (key: object, record: BufferedRecord) => void
+  decide: (level: LogLevel, key: object) => SamplingDecision
+  /**
+   * Resolves the tail verdict for a finished request. Returns the records to
+   * replay — empty when the outcome matched no tail rule — and marks a rescued
+   * request so the caller's own final log bypasses head sampling too.
+   */
+  finalize: (key: object, outcome: RequestOutcome) => readonly BufferedRecord[]
+}
+
+interface ResolvedTail {
+  durationMs?: number
+  paths?: RegExp[]
+  status?: number
+}
+
+const resolveTail = (
+  tail: TailSamplingConfig | undefined
+): ResolvedTail | undefined => {
+  if (!tail) {
+    return
+  }
+
+  const paths = tail.paths?.length ? tail.paths.map(globToRegExp) : undefined
+  if (
+    tail.durationMs === undefined &&
+    tail.status === undefined &&
+    paths === undefined
+  ) {
+    return
+  }
+
+  return { durationMs: tail.durationMs, paths, status: tail.status }
+}
+
+/** Tail rules are OR-ed: any single match rescues the whole request. */
+const matchesTail = (tail: ResolvedTail, outcome: RequestOutcome): boolean => {
+  if (tail.status !== undefined && outcome.status >= tail.status) {
+    return true
+  }
+  if (tail.durationMs !== undefined && outcome.durationMs >= tail.durationMs) {
+    return true
+  }
+  if (tail.paths) {
+    for (const path of tail.paths) {
+      if (path.test(outcome.pathname)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+/** Keeps only the rates that actually drop something. */
+const resolveRates = (
+  head: SamplingConfig['head']
+): Partial<Record<LogLevel, number>> | undefined => {
+  if (!head) {
+    return
+  }
+
+  const rates: Partial<Record<LogLevel, number>> = {}
+  let hasRate = false
+  for (const [level, rate] of Object.entries(head)) {
+    if (typeof rate === 'number' && rate < FULL_RATE) {
+      rates[level as LogLevel] = rate
+      hasRate = true
+    }
+  }
+
+  return hasRate ? rates : undefined
+}
+
+/**
+ * Builds the sampling runtime, or `undefined` when the config drops nothing —
+ * tail rules alone are a no-op, since only head-dropped records are ever
+ * buffered.
+ *
+ * @param random Injectable for deterministic tests; defaults to `Math.random`.
+ */
+export const resolveSampling = (
+  config: SamplingConfig | undefined,
+  random: () => number = Math.random
+): SamplingRuntime | undefined => {
+  const rates = resolveRates(config?.head)
+  if (!rates) {
+    return
+  }
+
+  const tail = resolveTail(config?.tail)
+  const maxBuffered =
+    config?.maxBufferedPerRequest ?? DEFAULT_MAX_BUFFERED_PER_REQUEST
+
+  const buffers = new WeakMap<object, BufferedRecord[]>()
+  // Only requests the plugin opened (and will close) may buffer: WebSocket
+  // pseudo-requests and hand-rolled `createLogger` callers never finalize, so
+  // buffering for them would grow without bound.
+  const inFlight = new WeakSet<object>()
+  const rescued = new WeakSet<object>()
+
+  return {
+    begin(key) {
+      if (tail) {
+        inFlight.add(key)
+      }
+    },
+
+    buffer(key, record) {
+      let bucket = buffers.get(key)
+      if (!bucket) {
+        bucket = []
+        buffers.set(key, bucket)
+      }
+      if (bucket.length >= maxBuffered) {
+        return
+      }
+      bucket.push(record)
+    },
+
+    decide(level, key) {
+      if (rescued.has(key)) {
+        return 'keep'
+      }
+
+      const rate = rates[level] ?? FULL_RATE
+      if (rate >= FULL_RATE || (rate > 0 && random() * FULL_RATE < rate)) {
+        return 'keep'
+      }
+
+      return tail && inFlight.has(key) ? 'buffer' : 'drop'
+    },
+
+    finalize(key, outcome) {
+      inFlight.delete(key)
+      const bucket = buffers.get(key)
+      buffers.delete(key)
+
+      if (!(tail && matchesTail(tail, outcome))) {
+        return NO_RECORDS
+      }
+
+      rescued.add(key)
+      return bucket ?? NO_RECORDS
+    }
+  }
+}

--- a/packages/logixlysia/src/types/config.ts
+++ b/packages/logixlysia/src/types/config.ts
@@ -1,5 +1,6 @@
 import type { LoggerOptions as PinoLoggerOptions } from 'pino'
 import type { LogLevel } from './core'
+import type { Enricher, EnricherLike } from './enricher'
 
 export interface Transport {
   log: (
@@ -95,7 +96,7 @@ export type LogPreset = 'dev' | 'prod' | 'json'
 /** Context passed to {@link Options.config.onError} when a sink fails. */
 export interface SinkErrorContext {
   error: unknown
-  sink: 'file' | 'rotation' | 'transport'
+  sink: 'enricher' | 'file' | 'rotation' | 'transport'
 }
 
 export interface RequestIdConfig {
@@ -149,9 +150,9 @@ export interface OutputConfig {
   logFilePath?: string
   logRotation?: LogRotationConfig
   /**
-   * Called when a sink (transport, file, rotation) fails. Errors thrown by
-   * the hook itself are swallowed. When absent, failures go to stderr
-   * (rate-limited for transports).
+   * Called when a sink (transport, file, rotation) or an enricher fails.
+   * Errors thrown by the hook itself are swallowed. When absent, failures go
+   * to stderr (rate-limited for transports and enrichers).
    */
   onError?: (context: SinkErrorContext) => void
   transports?: Transport[]
@@ -184,6 +185,18 @@ export interface RedactionConfig {
 export interface RequestTrackingConfig {
   /** Skip automatic WebSocket lifecycle logs from `wrapWs`; default false. */
   disableWebSocketLogging?: boolean
+
+  /**
+   * Context contributors run on every request. Whatever they return is merged
+   * into the request context, so the fields reach the console tree, file logs,
+   * and every transport at once.
+   *
+   * Each entry is either an {@link Enricher} (a `request` phase, a `response`
+   * phase, or both) or a bare function, which is treated as the request phase.
+   * Ready-made ones — traceparent, user agent, geo, sizes — live in
+   * `logixlysia/enrichers`.
+   */
+  enrichers?: EnricherLike[]
 
   /**
    * Enable automatic request ID generation and propagation.

--- a/packages/logixlysia/src/types/config.ts
+++ b/packages/logixlysia/src/types/config.ts
@@ -37,6 +37,49 @@ export interface LogFilter {
 }
 
 /**
+ * Percentage of records to keep per level, `0`–`100`. Levels left out keep
+ * everything, so `{ INFO: 10 }` thins access logs while every `ERROR` still
+ * reaches the sinks.
+ */
+export type HeadSamplingConfig = Partial<Record<LogLevel, number>>
+
+/**
+ * Conditions that rescue a request's head-dropped records once its outcome is
+ * known. Rules are OR-ed: any single match replays the whole request.
+ */
+export interface TailSamplingConfig {
+  /** Rescue when the request took at least this many milliseconds. */
+  durationMs?: number
+  /**
+   * Rescue when the request pathname matches one of these globs.
+   * `**` crosses `/`, `*` and `?` do not — e.g. `/checkout/**`.
+   */
+  paths?: string[]
+  /** Rescue when the response status is at or above this code, e.g. `400`. */
+  status?: number
+}
+
+export interface SamplingConfig {
+  /**
+   * Head sampling: the share of records kept per level, decided as each record
+   * is emitted. Without this, sampling is off — `tail` alone rescues nothing,
+   * because only head-dropped records are buffered.
+   */
+  head?: HeadSamplingConfig
+  /**
+   * Cap on records buffered per request while awaiting a tail verdict.
+   * Records past the cap are dropped.
+   * @default 100
+   */
+  maxBufferedPerRequest?: number
+  /**
+   * Tail sampling: replays a request's head-dropped records when the finished
+   * request matches, so failures and slow paths keep their full log trail.
+   */
+  tail?: TailSamplingConfig
+}
+
+/**
  * Configuration for pino-pretty transport output.
  *
  * - `true`: Enable pretty printing with default options
@@ -176,6 +219,12 @@ export interface LogixlysiaConfig
     RequestTrackingConfig,
     PinoConfig {
   logFilter?: LogFilter
+  /**
+   * Head + tail sampling. Head sampling thins high-volume levels by
+   * percentage; tail sampling replays what head dropped once the request turns
+   * out to be interesting (an error, a slow path, a watched route).
+   */
+  sampling?: SamplingConfig
 }
 
 export interface Options {

--- a/packages/logixlysia/src/types/enricher.ts
+++ b/packages/logixlysia/src/types/enricher.ts
@@ -1,0 +1,27 @@
+/** Fields an enricher contributes, or nothing when it has nothing to add. */
+export type EnricherFields = Record<string, unknown> | undefined
+
+/** What the response phase of an enricher gets to look at. */
+export interface EnricherResponseInput {
+  /** Elapsed time for the request in milliseconds. */
+  durationMs: number
+  /** Response headers set so far (Elysia's `set.headers`). */
+  headers: Record<string, unknown>
+  request: Request
+  status: number
+}
+
+/**
+ * A two-phase context contributor. Whatever it returns is merged into the
+ * request context, so the fields reach every sink at once — the console tree,
+ * file logs, and every configured transport.
+ */
+export interface Enricher {
+  /** Runs at request start, before the handler. */
+  request?: (request: Request) => EnricherFields
+  /** Runs once the outcome is known, before the request's final log line. */
+  response?: (input: EnricherResponseInput) => EnricherFields
+}
+
+/** An {@link Enricher}, or just its request phase as a bare function. */
+export type EnricherLike = Enricher | ((request: Request) => EnricherFields)

--- a/packages/logixlysia/src/types/logger.ts
+++ b/packages/logixlysia/src/types/logger.ts
@@ -57,10 +57,35 @@ export interface Logger {
   ) => void
 }
 
-export interface RequestScopedLogger {
-  debug: (message: string, context?: Record<string, unknown>) => void
-  error: (message: string, context?: Record<string, unknown>) => void
-  info: (message: string, context?: Record<string, unknown>) => void
-  mergeContext: (partial: Record<string, unknown>) => void
-  warn: (message: string, context?: Record<string, unknown>) => void
+/** The shape of a request's context bag. Widen it per app to type your fields. */
+export type LogFields = Record<string, unknown>
+
+/**
+ * The per-request logger derived onto the Elysia context as `log`.
+ *
+ * Parameterise the plugin with your own field type to have TypeScript reject
+ * misspelled or unexpected keys at compile time, which keeps a field from
+ * arriving as `userId` on one route and `user_id` on the next:
+ *
+ * ```ts
+ * interface CheckoutFields {
+ *   cartId: string
+ *   userId: string
+ * }
+ *
+ * new Elysia().use(logixlysia<CheckoutFields>()).post('/pay', ({ log }) => {
+ *   log.mergeContext({ userId: user.id })
+ *   log.mergeContext({ user_id: user.id }) // ✗ not in CheckoutFields
+ * })
+ * ```
+ *
+ * The default keeps every key allowed, so untyped code is unaffected. This is
+ * type-only: nothing changes at runtime.
+ */
+export interface RequestScopedLogger<TFields extends object = LogFields> {
+  debug: (message: string, context?: Partial<TFields>) => void
+  error: (message: string, context?: Partial<TFields>) => void
+  info: (message: string, context?: Partial<TFields>) => void
+  mergeContext: (partial: Partial<TFields>) => void
+  warn: (message: string, context?: Partial<TFields>) => void
 }

--- a/packages/logixlysia/src/types/logger.ts
+++ b/packages/logixlysia/src/types/logger.ts
@@ -1,6 +1,12 @@
 import type { LogLevel, Pino, RequestInfo, StoreData } from './core'
 
 export interface Logger {
+  /**
+   * Opens a request for tail sampling. Without it, records this request drops
+   * to head sampling are discarded rather than buffered. No-op when sampling
+   * is off.
+   */
+  beginRequest: (request: RequestInfo) => void
   debug: (
     request: RequestInfo,
     message: string,
@@ -10,6 +16,17 @@ export interface Logger {
     request: RequestInfo,
     message: string,
     context?: Record<string, unknown>
+  ) => void
+  /**
+   * Closes a request opened by {@link Logger.beginRequest} and resolves its
+   * tail-sampling verdict, replaying buffered records when the outcome
+   * matches. Call it before the request's final log line. No-op when sampling
+   * is off.
+   */
+  finalizeRequest: (
+    request: RequestInfo,
+    store: StoreData,
+    status: number
   ) => void
   getContext: (key: RequestInfo | object) => Readonly<Record<string, unknown>>
   handleHttpError: (

--- a/packages/logixlysia/src/utils/duration.ts
+++ b/packages/logixlysia/src/utils/duration.ts
@@ -1,0 +1,10 @@
+const NANOS_PER_MILLI = 1_000_000
+
+/**
+ * Milliseconds elapsed since `beforeTime`, or `0` when no start was recorded
+ * (`BigInt(0)` is the plugin's "never started" sentinel).
+ */
+export const elapsedMs = (beforeTime: bigint): number =>
+  beforeTime === BigInt(0)
+    ? 0
+    : Number(process.hrtime.bigint() - beforeTime) / NANOS_PER_MILLI

--- a/packages/logixlysia/src/utils/error.ts
+++ b/packages/logixlysia/src/utils/error.ts
@@ -9,6 +9,7 @@ export const parseError = (error: unknown): string => {
 }
 
 export interface StructuredError {
+  code?: string
   fix?: string
   internal?: unknown
   link?: string
@@ -20,7 +21,11 @@ export const isStructuredError = (
 ): value is StructuredError & Record<string, unknown> =>
   typeof value === 'object' &&
   value !== null &&
-  ('why' in value || 'fix' in value || 'link' in value || 'internal' in value)
+  ('why' in value ||
+    'fix' in value ||
+    'link' in value ||
+    'code' in value ||
+    'internal' in value)
 
 export interface NormalizedLoggedError {
   /** Safe structured representation for data/transport meta. */
@@ -42,6 +47,7 @@ const isValidationErrorLike = (
     value.constructor?.name === 'ValidationError')
 
 const STRUCTURED_ERROR_KEYS = [
+  'code',
   'fix',
   'internal',
   'link',

--- a/packages/logixlysia/src/utils/report.ts
+++ b/packages/logixlysia/src/utils/report.ts
@@ -1,0 +1,38 @@
+import type { SinkErrorContext } from '../interfaces'
+
+const REPORT_INTERVAL_MS = 5000
+
+export type ErrorReporter = (
+  error: unknown,
+  onError?: (context: SinkErrorContext) => void
+) => void
+
+/**
+ * Routes a failure to `config.onError`, or — when no hook is configured — to
+ * stderr at most once per interval, so a component that fails on every request
+ * cannot flood the very log it is meant to be feeding.
+ */
+export const createErrorReporter = (
+  sink: SinkErrorContext['sink'],
+  label: string
+): ErrorReporter => {
+  let lastReportedAt = 0
+
+  return (error, onError) => {
+    if (onError) {
+      try {
+        onError({ error, sink })
+      } catch {
+        // Swallow errors thrown by the hook itself.
+      }
+      return
+    }
+
+    const now = Date.now()
+    if (now - lastReportedAt < REPORT_INTERVAL_MS) {
+      return
+    }
+    lastReportedAt = now
+    console.error(`[logixlysia] ${label}:`, error)
+  }
+}


### PR DESCRIPTION
## Description

Four additions that round out request-level observability:

- **Sampling** (`config.sampling`): head sampling drops a percentage of records per level; tail sampling buffers what head dropped and replays it when the finished request matches a `status`, `durationMs`, or path glob rule, so failures and slow paths never lose their log trail.
- **Enrichers** (`config.enrichers`, `logixlysia/enrichers`): request/response context contributors that merge fields into the request context once, reaching the console tree, file logs, and every transport together. Ships with `traceparentEnricher()`, `userAgentEnricher()`, `geoEnricher()`, and `sizeEnricher()`. A throwing enricher is caught, reported via `onError` with `sink: 'enricher'`, and skipped — never fails the request.
- **Structured `HttpError`**: adds `code`, `why`, `fix`, `link`, and log-only `internal` (non-enumerable, excluded from `toJSON()`). Fully backward compatible — `new HttpError(status, message)` still responds with the bare message; only an error carrying a client-facing field responds as JSON. 4xx errors now also render in the console context tree.
- **Typed context fields**: the request-scoped logger is generic over a field type, e.g. `logixlysia<CheckoutFields>()`, so `log.mergeContext()` and `useLogger<CheckoutFields>()` reject misspelled or mistyped keys at compile time. Type-only, no runtime cost, and untyped usage is unaffected.

Includes a follow-up refactor collapsing duplication introduced across the four features.

## Related Issues

N/A

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

## Additional Notes

Each feature ships its own changeset (`enrichers`, `sampling`, `structured-errors`, `typed-fields`) and docs page (`features/enrichers.mdx`, `features/sampling.mdx`, plus updates to `api-reference.mdx`, `configuration.mdx`, and `features/request-context.mdx`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request and response enrichers for trace, user-agent, geographic, payload-size, and custom context data.
  * Added head and tail log sampling to reduce volume while preserving complete trails for errors, slow requests, and matching paths.
  * Added structured HTTP error metadata with client-safe JSON responses and log-only diagnostics.
  * Added optional compile-time typing for request-scoped logger fields.
* **Documentation**
  * Added configuration guidance, feature pages, examples, and API references for enrichers, sampling, structured errors, and typed fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->