### PR TITLE
chore(deps): bump codeql-action to v4.37.9 and changesets/action to v2.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,13 +47,11 @@ jobs:
         run: bun run build --filter logixlysia
       - name: 🎟️ Create Release PR or Publish to NPM
         id: changesets
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          version: bun run changeset version
-          publish: bun run changeset publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: "" # Workaround for https://github.com/changesets/action/pull/545
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version-script: bun run changeset version
+          publish-script: bun run changeset publish
       - name: ▲ Deploy to Vercel
         if: steps.changesets.outputs.published == 'true'
         run: bunx vercel --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,12 +18,12 @@ jobs:
       - name: 🛫 Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 🔬 Setting up CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: javascript-typescript
       - name: 🩻 Auto Build
-        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       - name: 🧪 Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: '/languages/javascript-typescript'


### PR DESCRIPTION
## Description

Rolls up four github-actions bumps from Dependabot into one commit.

- `github/codeql-action/{init,autobuild,analyze}` 4.37.4 → 4.37.9 (#409, #407, #406) — all three sub-actions share a single pin, so they belong in one change
- `changesets/action` 1.9.0 → 2.1.1 (#408)

**changesets/action v2 is not a drop-in bump.** The bare version bump would have silently broken releases:

- inputs were renamed: `version` → `version-script`, `publish` → `publish-script`. Unknown inputs are ignored, so the action would have stopped running the publish script entirely
- a custom token now has to go through the `github-token` input; the `GITHUB_TOKEN` env var is no longer a substitute
- v2 dropped the `.npmrc` handling that the `NPM_TOKEN: ""` workaround existed to defeat, so that line is gone. npm auth stays on trusted publishing via `setup-node`’s `registry-url` plus `id-token: write`

The `steps.changesets.outputs.published` reference at `release.yml:56` is unchanged — `published` kept its name in v2.

## Related Issues

Supersedes #406, #407, #408, #409

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Additional Notes

The release job only runs on push to `main`, so green CI on the original Dependabot PR said nothing about whether the action still worked.