### PR TITLE
fix(deps): revert simple-icons to ^13.0.0 to unbreak the docs build

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "@types/node": "^26.4.0",
-    "simple-icons": "^16.29.0",
+    "simple-icons": "^13.0.0",
     "typescript": "^7.0.2"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
         "@types/node": "^26.4.0",
-        "simple-icons": "^16.29.0",
+        "simple-icons": "^13.0.0",
         "typescript": "^7.0.2",
       },
     },
@@ -2295,7 +2295,7 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "simple-icons": ["simple-icons@16.29.0", "", {}, "sha512-4H94f5ZgcCcgJroc902TFlFdgPu2IU2eD7+WebN2Z14xKYrKHeJ4UQcZwzgSuH4Rgzw+jp7sbHl40NefuIEYsg=="],
+    "simple-icons": ["simple-icons@13.21.0", "", {}, "sha512-LI5pVJPBv6oc79OMsffwb6kEqnmB8P1Cjg1crNUlhsxPETQ5UzbCKQdxU+7MW6+DD1qfPkla/vSKlLD4IfyXpQ=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
@@ -2734,8 +2734,6 @@
     "astro/magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
 
     "astro/tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
-
-    "blume/simple-icons": ["simple-icons@13.21.0", "", {}, "sha512-LI5pVJPBv6oc79OMsffwb6kEqnmB8P1Cjg1crNUlhsxPETQ5UzbCKQdxU+7MW6+DD1qfPkla/vSKlLD4IfyXpQ=="],
 
     "blume/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 


### PR DESCRIPTION
## Description

Reverts 0d2892a (#398). `main` currently fails to deploy — the docs build dies during static route generation:

```
[error] The requested module 'simple-icons' does not provide an export named 'siCss3'
  import { siAstro, siC, siCplusplus, siCss3, ... } from "simple-icons";
```

`blume` pins `simple-icons: ^13.0.0` and its own source (`blume/src/markdown/language-icon.ts`) imports `siCss3`, which v16 removed. blume's source is processed as part of the app rather than pre-bundled, so Vite resolves that bare import against the workspace root — where v16 was hoisted — instead of the nested v13 copy. The nested `blume/node_modules/simple-icons@13.21.0` never gets used.

Nothing in our own code needed v16: `apps/docs/components/home/adapters.astro` uses seven icons (`siBetterstack`, `siClickhouse`, `siDatadog`, `siGrafana`, `siOpentelemetry`, `siPosthog`, `siSentry`) and all seven exist in v13 and v16 alike. The upgrade bought nothing and cost the deploy.

Verified locally: `bun install --frozen-lockfile` is a no-op against the reverted lockfile, and `bun run build --filter docs --force` (cache bypassed) completes.

This bump was deliberately excluded from the #412/#413/#414 stack for exactly this reason — see the note in #414.

## Related Issues

Reverts #398

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Additional Notes

Dependabot will re-propose this bump on its next monthly run. If that is unwanted until blume widens its range, add an `ignore` entry for `simple-icons` major versions in `.github/dependabot.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation site’s Simple Icons development dependency to an earlier compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->